### PR TITLE
fix(tests): EmptyModelURL test misaligned with new name-fallback

### DIFF
--- a/ArboreUi/ArboreUiTests/ModelCacheManagerTests.swift
+++ b/ArboreUi/ArboreUiTests/ModelCacheManagerTests.swift
@@ -444,12 +444,16 @@ class PlantModelTests: XCTestCase {
     }
 
     func testPlant_GetModelURL_WithEmptyModelURL_ShouldThrowError() async {
-        // Test avec modelURL vide
+        // Both `modelURL` and `name` empty — no candidate filename can be
+        // reconstructed, so getModelURL should throw `.invalidModelURL`
+        // immediately. (When `name` is non-empty, getModelURL tries
+        // <name>.usdz / <name>_with_underscores.usdz as fallbacks before
+        // giving up — covered by other tests.)
 
         let plantJSON = """
         {
             "id": "test123",
-            "name": "Test Plant",
+            "name": "",
             "type": "Indoor",
             "imageURLs": ["https://example.com/image.jpg"],
             "description": "Test description",


### PR DESCRIPTION
## Context

The 🌱 Arbore CI/CD run on \`f9c4f85\` failed with a single test:
\`PlantModelTests.testPlant_GetModelURL_WithEmptyModelURL_ShouldThrowError\`.
Backend integration tests in the same run passed (so the rotated
\`ARBORE_API_KEY\` is healthy — the failure is unrelated to the secret).

## Root cause

\`Plant.getModelURL()\` got a name-based fallback in commit \`6dc4394\`:
when \`modelURL\` is empty/missing, it derives candidate filenames from
\`name\` (\"Test Plant\" → tries \`Test_Plant.usdz\`, \`Test-Plant.usdz\`,
\`Test Plant.usdz\`).

The fixture in this test sets \`modelURL=\"\"\` but keeps \`name=\"Test Plant\"\`,
so the fallback kicks in, hits the backend with one of the derived names,
404s, and surfaces the resulting network error — not
\`ModelCacheError.invalidModelURL\` as the test expects.

## Fix

Drop \`name\` from the fixture (set to \`\"\"\`). With no resolvable info at
all, the candidate list is empty and the early
\`guard !uniqueCandidates.isEmpty\` throws \`.invalidModelURL\` —
exactly what the test asserts.

The fallback behavior itself is intentional and useful (lets a plant
load its USDZ from a name even when \`modelURL\` is missing in the
backend response). It is exercised by the other PlantModelTests
already.

## Verification

- Build green.
- Pre-commit hook (gitleaks + bundle-id check) passes.
- The CI on this branch should turn 🌱 Arbore CI/CD green again.

## Out of scope

- The 🔒 CodeQL Security Analysis failure on this repo is a separate
  unrelated issue: \"Advanced Security must be enabled for this
  repository to use code scanning\". Tracked separately.