### PR TITLE
📚 [Docs Phase 1] Index + C4 Context & Container + Glossaire

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+# Documentation Arbore
+
+Cette section regroupe la documentation technique de l'application Arbore, rédigée en **Markdown + Mermaid** afin de vivre à côté du code source et d'être rendue nativement par GitHub.
+
+> 🗂️ **Tracker** : [Issue #141](https://github.com/ArboreTeam/Arbore/issues/141) suit l'avancement des phases de documentation.
+
+## Guide de lecture
+
+La documentation est découpée en cinq vues complémentaires. Selon l'information recherchée :
+
+| Information recherchée | Emplacement |
+|---|---|
+| Vue d'ensemble (acteurs et systèmes externes) | [`architecture/01-context.md`](architecture/01-context.md) |
+| Briques techniques déployées | [`architecture/02-containers.md`](architecture/02-containers.md) |
+| Détail des modules internes d'un container | `architecture/03-components-*.md` *(Phase 2)* |
+| Schéma de données MongoDB | `architecture/04-data-model.md` *(Phase 2)* |
+| Enchaînement des écrans côté utilisateur | `flows/*.md` *(Phase 3)* |
+| États discrets d'une fonctionnalité | `state-machines/*.md` *(Phase 3)* |
+| Détail d'un écran principal (hero screen) | `screens/*.md` *(Phase 4)* |
+| Justification d'un choix d'architecture | `decisions/*.md` *(Phase 5)* |
+| Définition d'un terme métier ou technique | [`glossary.md`](glossary.md) |
+
+## Structure
+
+```
+docs/
+├── README.md                  # ce document
+├── architecture/              # vue STATIQUE (modèle C4)
+├── flows/                     # vue DYNAMIQUE (séquences, flowcharts)
+├── state-machines/            # vue COMPORTEMENTALE
+├── screens/                   # per-screen specs (hero screens uniquement)
+├── decisions/                 # Architecture Decision Records (format MADR)
+└── glossary.md                # vocabulaire du domaine
+```
+
+Les fichiers numérotés (`01-`, `02-`) suivent l'ordre de lecture recommandé. Les ADRs (`0001-`, `0002-`) sont datés et **immuables** une fois acceptés : toute évolution donne lieu à un nouvel ADR qui supersede le précédent.
+
+## Règles de rédaction
+
+1. **Toute PR de code touchant à un domaine documenté doit mettre à jour la documentation correspondante dans la même PR.** Les PR purement documentaires ne sont autorisées que pendant les phases initiales d'écriture.
+2. **Un sujet par fichier.** Trois niveaux de titres maximum.
+3. **Contexte autour de chaque diagramme.** Précéder chaque diagramme de deux à trois lignes de contexte, le suivre de deux à trois lignes synthétisant les points clés. Un diagramme isolé n'est lisible que par son auteur.
+4. **Modèle C4 limité aux niveaux Context, Container et Component.** Le niveau Code (UML de classes) est volontairement omis : le code source en tient lieu.
+5. **Les per-screen specs sont réservés aux hero screens** (trois à cinq écrans maximum). Les écrans simples sont décrits en une ligne dans `flows/`.
+6. **Les ADRs sont courts** (une page maximum), nommés `NNNN-kebab-case.md` et jamais modifiés après acceptation : créer un nouvel ADR pour superseder.
+7. **En cas de problème de layout sur un diagramme Mermaid C4**, réordonner les déclarations d'éléments dans la source. La directive `Lay_U/D/L/R` n'est pas supportée à ce jour.
+
+## Types de diagrammes Mermaid utilisés
+
+| Besoin | Type Mermaid |
+|---|---|
+| Acteurs et systèmes externes (niveau C4 Context) | `flowchart TB` avec labels `[Person]` / `[System Ext]` |
+| Applications et services déployés (niveau C4 Container) | `flowchart TB` avec labels `[Container]` |
+| Modules internes d'un service (niveau C4 Component) | `flowchart TB` avec labels `[Component]` |
+| Schéma de données relationnel | `erDiagram` |
+| Enchaînement linéaire d'écrans | `flowchart TD` |
+| Interaction entre acteurs dans le temps | `sequenceDiagram` |
+| États discrets et transitions | `stateDiagram-v2` |
+
+## Outils et statut
+
+- **Markdown + Mermaid** — rendu natif GitHub, diff-able, aucun outillage externe.
+- **Sémantique C4 portée par `flowchart`.** La syntaxe `C4Context` / `C4Container` native de Mermaid est officiellement marquée comme [`experimental`](https://mermaid.js.org/syntax/c4.html) et produit des **chevauchements d'arêtes** dès que le graphe dépasse une dizaine d'éléments. La convention adoptée dans cette documentation utilise `flowchart` avec des labels préfixés `[Person]`, `[Container]`, `[System Ext]`, etc. Cette approche préserve la sémantique C4 tout en bénéficiant du moteur de layout mature de Mermaid. La décision est tracée dans l'ADR `0001-mermaid-for-docs.md` (Phase 5).
+- **MADR** — voir [adr.github.io/madr](https://adr.github.io/madr/) pour le format complet.
+
+## Documents legacy
+
+Les fichiers suivants précèdent la mise en place de cette structure et sont conservés à titre de référence. Ils seront migrés ou supprimés au fil des sprints :
+
+- `AR_CAMERA_BLACK_SCREEN_FIX.md`
+- `CI-CD.md`
+- `DEBUG_MODE_VISUAL_SUMMARY.md`, `DEBUG_THUMBNAIL_MODE.md`
+- `TROUBLESHOOTING.md`
+- `BETA_TEST_PLAN_Arbore_simple_v2_2026-05-02.{pdf,docx}`

--- a/docs/architecture/01-context.md
+++ b/docs/architecture/01-context.md
@@ -1,0 +1,65 @@
+# C4 — Niveau 1 : Context
+
+Cette vue décrit, au plus haut niveau d'abstraction, les **acteurs utilisant Arbore et les systèmes externes avec lesquels l'application interagit**. La structure interne d'Arbore n'est pas représentée à ce niveau : seules les frontières du système et ses interfaces sont visibles.
+
+## Diagramme
+
+> **Note de rendu** : la sémantique C4 (Person, System, External) est préservée dans les labels. La syntaxe utilisée est `flowchart` plutôt que `C4Context` natif, car la layout du C4 Mermaid est encore expérimentale et produit des chevauchements d'arêtes sur les graphes denses. Voir [README §Outils](../README.md#outils-et-statut).
+
+```mermaid
+flowchart TB
+    %% Acteurs
+    user["👤 [Person] Utilisateur<br/>Jardinier amateur"]
+    reviewer["👤 [Person] Apple Reviewer<br/>apple-review@arbore.app"]
+    team["👤 [Person] Équipe Arbore<br/>Devs + ops"]
+
+    %% Système central
+    arbore(("🌱 [System] Arbore<br/>App de jardinage AR"))
+
+    %% Systèmes externes runtime
+    subgraph runtime["Systèmes externes — runtime"]
+        firebase["[System Ext] Firebase<br/>Auth + Admin SDK"]
+        mongo[("[System Ext] MongoDB Atlas<br/>Users / plants / gardens")]
+        openai["[System Ext] OpenAI / Mistral<br/>LLM fiches plantes"]
+        unsplash["[System Ext] Unsplash<br/>Photos catalogue"]
+    end
+
+    %% Systèmes externes operate-time
+    subgraph operate["Systèmes externes — operate-time"]
+        meshy["[System Ext] Meshy<br/>Modèles 3D USDZ batch"]
+        github["[System Ext] GitHub<br/>CI/CD + Dependabot"]
+        apple["[System Ext] Apple Connect<br/>TestFlight + App Store"]
+    end
+
+    user      -- "Conçoit et place des plantes"        --> arbore
+    reviewer  -- "Valide builds TestFlight"            --> arbore
+    team      -- "Développe et opère"                  --> arbore
+
+    arbore    -- "Auth + tokens (HTTPS)"               --> firebase
+    arbore    -- "Persistance via backend"             --> mongo
+    arbore    -- "Génération fiches (via AI Gen)"      --> openai
+    arbore    -- "Photos plantes"                      --> unsplash
+
+    team      -- "Génération batch USDZ"               --> meshy
+    team      -- "Push + monitoring CI"                --> github
+    team      -- "Upload builds + review"              --> apple
+
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef system fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef ext    fill:#999,stroke:#666,color:#fff
+    class user,reviewer,team person
+    class arbore system
+    class firebase,mongo,openai,unsplash,meshy,github,apple ext
+```
+
+## Points clés
+
+- **Arbore vu de l'extérieur** constitue une boîte unique qui communique avec cinq systèmes externes en runtime (Firebase, MongoDB Atlas, OpenAI/Mistral, Unsplash) et deux systèmes utilisés exclusivement en operate-time (Meshy, GitHub Actions, Apple Connect).
+- **Trois catégories d'acteurs humains** sont distinguées : utilisateurs finaux (jardiniers), reviewer Apple (compte dédié `apple-review@arbore.app`) et équipe interne. La review Apple est représentée comme un acteur distinct car son parcours d'usage fait l'objet d'une documentation spécifique (notes TestFlight).
+- **Meshy n'intervient pas en runtime.** Ce service est utilisé en amont par l'équipe pour pré-générer le catalogue de modèles 3D ; il n'est jamais appelé depuis l'application. Ce choix est volontaire : le coût et la latence de Meshy sont incompatibles avec un usage AR temps réel.
+- **Aucun système de paiement externe** n'est intégré à ce jour : Arbore est gratuit et ne propose pas d'achats in-app. Toute évolution dans ce sens devra mettre à jour ce diagramme (Apple In-App Purchase et éventuellement Stripe).
+- **iCloud Private Relay n'est pas représenté** car il ne constitue pas une intégration mais un proxy transparent susceptible de perturber les appels HTTP sortants (cf. issue #90 résolue et choix HTTPS détaillé dans l'ADR à venir).
+
+## Vue suivante
+
+Le [niveau 2 — Container](02-containers.md) ouvre la boîte « Arbore » et expose les applications et services qui la composent : application iOS, backend Go, AI Generator Python.

--- a/docs/architecture/02-containers.md
+++ b/docs/architecture/02-containers.md
@@ -1,0 +1,77 @@
+# C4 — Niveau 2 : Containers
+
+Cette vue ouvre la boîte « Arbore » et représente les **applications et services déployables**. Un container correspond à une unité runtime indépendamment déployable : un process iOS, un container Docker ou un service Apple managé.
+
+Pour le niveau de granularité supérieur (acteurs et systèmes externes), consulter [`01-context.md`](01-context.md).
+
+## Diagramme
+
+> **Note de rendu** : la sémantique C4 (Person, Container, System Ext) est préservée dans les labels. La syntaxe utilisée est `flowchart` plutôt que `C4Container` natif, car la layout du C4 Mermaid est encore expérimentale et produit des chevauchements d'arêtes sur les graphes denses.
+
+```mermaid
+flowchart TB
+    user["👤 [Person] Utilisateur<br/>Jardinier amateur"]
+
+    subgraph arbore["🌱 Arbore"]
+        direction TB
+        ios["📱 [Container] App iOS Arbore<br/>Swift · SwiftUI · ARKit · RoomPlan"]
+        web["🌐 [Container] Web Arbore<br/>Next.js (planifié — #98-#109)"]
+
+        subgraph backend_vps["Backend — VPS Fedora (Docker Compose)"]
+            direction TB
+            backend["⚙️ [Container] Backend API<br/>Go 1.21 · Gin"]
+            ai["🤖 [Container] AI Generator<br/>Python 3.11 · FastAPI"]
+        end
+    end
+
+    subgraph ext["Systèmes externes"]
+        firebase_auth["[System Ext] Firebase Auth<br/>Email/password · Google Sign-In"]
+        firebase_admin["[System Ext] Firebase Admin SDK<br/>Vérification tokens"]
+        mongo[("[System Ext] MongoDB Atlas<br/>users · plants · gardens · consents")]
+        openai["[System Ext] OpenAI / Mistral<br/>LLM fiches plantes"]
+        unsplash["[System Ext] Unsplash API<br/>Photos catalogue"]
+    end
+
+    user -- "Native UI"  --> ios
+    user -- "HTTPS"      --> web
+
+    ios     -- "Login / signup (HTTPS)"                        --> firebase_auth
+    ios     -- "API REST (HTTPS + X-API-Key + Bearer token)"   --> backend
+    web     -- "Mêmes endpoints (CORS)"                        --> backend
+
+    backend -- "Vérifie chaque requête (service account)"      --> firebase_admin
+    backend -- "MongoDB driver Go"                             --> mongo
+    backend -- "HTTP interne Docker"                           --> ai
+    backend -- "HTTPS"                                         --> unsplash
+    ai      -- "Prompt LLM (HTTPS)"                            --> openai
+
+    classDef person   fill:#08427B,stroke:#073B6F,color:#fff
+    classDef cont     fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef ext_node fill:#999,stroke:#666,color:#fff
+    class user person
+    class ios,web,backend,ai cont
+    class firebase_auth,firebase_admin,mongo,openai,unsplash ext_node
+```
+
+## Points clés
+
+- **Trois containers Arbore sont actuellement en production** : l'application iOS, le backend Go et l'AI Generator Python. Les deux derniers tournent en containers Docker sur un VPS Fedora unique. Le **front web Next.js** est planifié mais n'est pas encore déployé (cf. issues #98 à #109).
+- **Deux barrières de sécurité protègent l'accès aux données** :
+  1. **X-API-Key** validée par un middleware backend dédié — limite l'exposition à un scrape massif depuis l'extérieur.
+  2. **Bearer Firebase token** validé par le Firebase Admin SDK côté backend — garantit que la requête provient d'un utilisateur authentifié et fournit son `uid`.
+- **L'AI Generator est isolé du client** : seul le backend l'appelle, jamais l'application iOS directement. Ce choix volontaire permet de cacher la clé OpenAI/Mistral et d'appliquer caching et throttling côté backend.
+- **MongoDB Atlas est externe au système Arbore** mais piloté exclusivement par le backend. L'application iOS n'ouvre **jamais** de connexion MongoDB directe.
+- **Backend et AI Generator partagent le même VPS** mais communiquent via le réseau Docker interne (`http://ai-generator:8000`) plutôt que via l'IP publique. La latence reste inférieure à 5 ms.
+- **HTTPS est utilisé en sortie de l'iOS** mais le backend lui-même reste accessible en HTTP simple à la date de rédaction (cf. issue #121). Ce point sécurité est inscrit au Sprint 3.
+
+## Choix d'infrastructure
+
+- **VPS Fedora unique** : un serveur unique héberge backend, AI generator et le stockage des thumbnails de plantes. Cette topologie simple convient à l'échelle actuelle (équipe de cinq personnes). Une séparation en services indépendants sera à envisager si l'application monte en charge.
+- **Docker Compose** orchestre les deux containers via le fichier `docker-compose.yml` à la racine du dépôt. Kubernetes est volontairement écarté à ce stade pour limiter la complexité opérationnelle.
+- **Firebase est un service managé** : le projet consomme l'authentification sans en assumer l'exploitation. Le compromis vendor lock-in / vitesse de delivery sera tracé dans l'ADR 0004 (Phase 5).
+
+## Hors-scope de cette vue
+
+- Le détail des **modules à l'intérieur** d'un container relève du niveau 3 (Component), traité dans `03-components-*.md` (Phase 2).
+- Le **schéma de données MongoDB** (collections, champs, relations) est documenté dans `04-data-model.md` (Phase 2).
+- Les **parcours utilisateur** (signup, AR placement, sauvegarde de jardin) sont décrits dans `flows/*.md` (Phase 3).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,127 @@
+# Glossaire
+
+Vocabulaire du domaine Arbore. Tout terme métier, technique iOS ou raccourci interne doit faire l'objet d'une entrée afin de permettre l'onboarding d'un nouveau développeur en moins de dix minutes.
+
+Convention : ordre alphabétique, **terme** en gras, définition tenant en une à trois phrases.
+
+---
+
+## AR (Augmented Reality)
+
+Réalité augmentée — superposition d'objets virtuels (plantes 3D) sur le flux caméra. Sur iOS, repose sur **ARKit** (tracking, plan detection) et sur **SceneKit** (rendu actuel) ou **RealityKit** (cible, cf. issue #83).
+
+## ARWorldMap
+
+Sérialisation **ARKit** de l'état d'une session AR (points caractéristiques et ancres). Sauvegardée sur disque par jardin (`worldmap_{id}.arworldmap`), elle est rechargée à la réouverture du jardin pour replacer les plantes aux mêmes coordonnées. Très sensible aux changements d'éclairage entre sessions (cf. issue #96).
+
+## Anchor (ARAnchor)
+
+Point fixe attaché à une position dans le monde réel, suivi par ARKit. Chaque plante placée se voit associer un `ARAnchor`. Les ancres sont sérialisées dans la WorldMap pour assurer la persistance entre sessions.
+
+## Boundary
+
+Polygone fermé au sol qui délimite la zone du jardin. Tracé par l'utilisateur en mode `gardenPerimeter` (non-LiDAR) ou dérivé du scan **RoomPlan** (LiDAR). Représenté en mémoire sous la forme `[SIMD3<Float>]`.
+
+## C4 Model
+
+Modèle d'architecture en quatre niveaux (**C**ontext, **C**ontainer, **C**omponent, **C**ode) défini par Simon Brown. Appliqué à Arbore dans `docs/architecture/`. Le niveau Code est volontairement omis : le code source en tient lieu.
+
+## Hero screen
+
+Écran principal et complexe qui justifie une documentation per-screen dédiée. Pour Arbore : `GardenARPlacementView`, `QuestionnaireView` et `PersonalDetailsView`. Les écrans simples (un bouton, une navigation) ne sont pas considérés comme hero screens et ne disposent pas de spec dédiée.
+
+## ICP (Iterative Closest Point)
+
+Algorithme de registration entre deux nuages de points ou meshes. Calcule la transformation rigide (rotation et translation) qui minimise la distance entre correspondances. Pressenti pour la **scene-to-scene registration** (issue #140) en alternative à la reloc-pose ARWorldMap.
+
+## Manual Replace
+
+Flux de re-placement manuel des plantes activé lorsque la relocalisation ARWorldMap échoue. L'utilisateur retrace une nouvelle boundary ; les positions des plantes sont **morphées** via MVC pour suivre la nouvelle forme. Implémenté dans `GardenARPlacementView` (issue #111, mergée).
+
+## MVC (Mean Value Coordinates)
+
+Méthode mathématique (Floater, 2003) pour exprimer un point intérieur d'un polygone comme combinaison pondérée des sommets, puis reconstruire un point équivalent dans un autre polygone à l'aide des mêmes poids. Utilisée dans `GardenMorpher` pour morpher les positions des plantes entre old boundary et new boundary.
+
+## ObjectCapture
+
+API Apple (`PhotogrammetrySession`, iOS 17+, Area mode iOS 18+) qui produit un mesh 3D texturé à partir d'un ensemble de photos. Constitue l'alternative non-LiDAR à RoomPlan, pressentie pour le chemin non-LiDAR de l'issue #140.
+
+## Per-screen spec
+
+Document Markdown qui décrit en détail un seul écran principal (hero screen) : purpose, entry et exit points, widgets, edge cases et dépendances. La liste complète figure dans `docs/screens/_index.md` (Phase 4).
+
+## PhotogrammetrySession
+
+Voir [**ObjectCapture**](#objectcapture).
+
+## Plant
+
+Entrée du catalogue MongoDB : nom, type, image URLs, traductions multilingues, URL du modèle USDZ, indicateur `generated` (modèle issu de Meshy ou non) et `upAxis` (Y- ou Z-up). La structure complète est documentée dans `04-data-model.md` (Phase 2).
+
+## RelocationPhase
+
+Enum Swift défini dans `GardenARPlacementView` qui gère les cinq états du **manual replace** : `.scanning`, `.tracingBoundary`, `.morphingPreview`, `.adjusting` et `.completed`. Diagrammée dans `state-machines/relocation-phase.md` (Phase 3).
+
+## RoomPlan
+
+Framework Apple (iOS 16+, LiDAR uniquement) qui scanne une pièce en 3D et produit un modèle structuré (murs, sols, portes, fenêtres, meubles). Utilisé dans `LiDARScanWizardView` comme alternative au tracé périmètre. Vérifier le support du device via `RoomCaptureSession.isSupported`.
+
+## scanMethod
+
+Enum porté par `GardenWizardState` qui détermine la stratégie de scan : `.gardenPerimeter` (tracé 2D au sol, non-LiDAR) ou `.roomScan` (RoomPlan, LiDAR uniquement). Choisi à l'étape `.scanMethod` du wizard.
+
+## ScreenSpec
+
+Voir [**Per-screen spec**](#per-screen-spec).
+
+## Sprint
+
+Période d'environ un mois matérialisée par un GitHub Milestone. Sprint en cours : Sprint 3 (échéance 2026-06-14). Un sprint regroupe les issues à livrer dans la période.
+
+## Token (Firebase ID Token)
+
+Bearer token JWT signé par Firebase Auth, transmis par l'application iOS et le web dans l'en-tête `Authorization` de chaque requête au backend. Le backend le valide via le Firebase Admin SDK et en extrait l'`uid` Firebase.
+
+## TestFlight
+
+Plateforme Apple de distribution beta. Un build interne est déposé pour l'équipe ainsi que pour le reviewer Apple (compte `apple-review@arbore.app`). La diffusion publique TestFlight est suivie dans l'issue #15 (Sprint 4).
+
+## USDZ
+
+Format de modèle 3D Apple (archive ZIP contenant un fichier USD et ses textures). Tous les modèles de plantes du catalogue sont stockés au format USDZ dans `ArboreBackend/models/`, servis via l'endpoint `GET /models/:filename` et rendus en AR via SceneKit.
+
+## VPS (Fedora)
+
+Serveur unique qui héberge le backend Go et l'AI Generator Python via Docker Compose. L'accès SSH s'effectue via la connexion MCP `ssh-arbore-backend`. Détails dans [`02-containers.md`](architecture/02-containers.md).
+
+## WorldMap
+
+Voir [**ARWorldMap**](#arworldmap).
+
+## Wizard
+
+Flux de création de jardin en dix étapes (`GardenWizardStep`) : intro → style → spaceType → exposure → maintenance → safety → soil → aiSuggestion → scanMethod → summary. Implémenté sous forme de `TabView` dans `QuestionnaireView`. Cible d'une per-screen spec en Phase 4.
+
+---
+
+## Acronymes courts
+
+| Acronyme | Sens |
+|---|---|
+| **ADR** | Architecture Decision Record |
+| **AR** | Augmented Reality |
+| **ATS** | App Transport Security (politique HTTPS iOS) |
+| **CI/CD** | Continuous Integration / Continuous Delivery |
+| **DoD** | Definition of Done |
+| **ER** | Entity-Relationship (diagram) |
+| **IAP** | In-App Purchase |
+| **ICP** | Iterative Closest Point |
+| **JWT** | JSON Web Token |
+| **MADR** | Markdown Architectural Decision Records |
+| **MVC** (math) | Mean Value Coordinates (algorithme de Floater) |
+| **MVC** (GUI, non utilisé dans Arbore) | Model-View-Controller — mentionné pour éviter la confusion avec l'acronyme mathématique ci-dessus |
+| **MVP** | Minimum Viable Product |
+| **RGPD** | Règlement Général sur la Protection des Données |
+| **SfM** | Structure from Motion (reconstruction 3D multi-vues) |
+| **TSDF** | Truncated Signed Distance Field (représentation 3D volumétrique) |
+| **USDZ** | Universal Scene Description Zipped (format 3D Apple) |


### PR DESCRIPTION
Première phase de la documentation prévue dans #141 — pose les fondations.

## Contenu

- **`docs/README.md`** : guide de lecture, structure du répertoire `docs/`, règles de rédaction, mapping besoin → type de diagramme, statut des outils.
- **`docs/architecture/01-context.md`** : niveau 1 du modèle C4. Acteurs (user, Apple reviewer, équipe) et systèmes externes (Firebase, MongoDB Atlas, OpenAI/Mistral, Unsplash, Meshy, GitHub, Apple Connect). Sépare visuellement les systèmes runtime des systèmes operate-time.
- **`docs/architecture/02-containers.md`** : niveau 2 du modèle C4. App iOS, backend Go, AI Generator Python, web Next.js (planifié). Documente les deux barrières de sécurité (X-API-Key + Bearer Firebase token) et l'isolation de l'AI Generator derrière le backend.
- **`docs/glossary.md`** : vocabulaire domaine et acronymes (AR, ARWorldMap, Anchor, Boundary, ICP, MVC, ObjectCapture, RelocationPhase, USDZ, etc.).

## Choix de syntaxe Mermaid

La syntaxe `C4Context` / `C4Container` native de Mermaid reste marquée comme **experimental** et produit des **chevauchements d'arêtes** dès qu'on dépasse une dizaine de relations. La convention adoptée utilise `flowchart` avec des labels préfixés `[Person]`, `[Container]`, `[System Ext]`, etc. La sémantique C4 est intégralement préservée dans les labels, et le moteur de layout de Mermaid (mature) gère correctement les croisements.

Cette décision sera formalisée dans l'ADR `0001-mermaid-for-docs.md` (Phase 5).

## Vérification

- [x] Rendu testé : pas de chevauchement d'arêtes sur les deux diagrammes
- [x] Tous les liens internes pointent vers des fichiers existants ou des phases futures clairement marquées
- [x] Aucun ton informel — documentation rédigée à l'impersonnel
- [x] Phase 1 du plan #141 cochée

## Suite

Phase 2 (1 PR séparée, ~2h) : `03-components-ios.md`, `03-components-backend.md`, `04-data-model.md`.

Closes (partial) #141 — Phase 1 du plan.