### PR TITLE
📚 [Docs Phase 2] Composants iOS + Backend + Modèle de données

### DIFF
--- a/docs/architecture/03-components-backend.md
+++ b/docs/architecture/03-components-backend.md
@@ -1,0 +1,155 @@
+# C4 — Niveau 3 : Composants Backend
+
+Cette vue ouvre le container **Backend API** (Go 1.21 + Gin) et expose ses modules principaux. Le code source est organisé autour d'un fichier monolithique `main.go` (~1 400 lignes) regroupant déclarations de types, handlers et bootstrap, complété par un sous-dossier `middleware/` pour l'authentification.
+
+Pour la vue d'ensemble des containers, consulter [`02-containers.md`](02-containers.md). Pour les composants côté iOS, consulter [`03-components-ios.md`](03-components-ios.md).
+
+## Topologie en couches
+
+```mermaid
+flowchart TB
+    client["📱 Client iOS / Web<br/>(HTTPS)"]
+
+    subgraph backend["⚙️ Backend API (Go / Gin)"]
+        direction TB
+        router["Router & Middleware<br/>(API key + Firebase Auth)"]
+        handlers["Handlers HTTP<br/>(users · plants · gardens · consents · models)"]
+        access["Couche d'accès aux données<br/>(MongoDB driver) + clients externes"]
+
+        router --> handlers
+        handlers --> access
+    end
+
+    mongo[("[System Ext]<br/>MongoDB Atlas")]
+    firebase_admin["[System Ext]<br/>Firebase Admin SDK"]
+    ai_gen["[Container]<br/>AI Generator (FastAPI)"]
+    unsplash["[System Ext]<br/>Unsplash API"]
+
+    client --> router
+    router --> firebase_admin
+    access --> mongo
+    access --> ai_gen
+    access --> unsplash
+
+    classDef ext   fill:#999,stroke:#666,color:#fff
+    classDef layer fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef cont  fill:#2E7D32,stroke:#1B5E20,color:#fff
+    class router,handlers,access layer
+    class client,ai_gen cont
+    class mongo,firebase_admin,unsplash ext
+```
+
+Toutes les requêtes franchissent la chaîne **Router → Middleware → Handler → Accès données**. Cette discipline est imposée par la configuration du `router.Group("/")` dans `main.go`, qui applique les deux middlewares à toutes les routes protégées.
+
+## Middleware
+
+Le sous-dossier `middleware/` expose deux fonctions chaînées dans cet ordre :
+
+| Fichier | Fonction | Rôle |
+|---|---|---|
+| `middleware/api_key.go` | `APIKeyMiddleware()` | Valide l'en-tête `X-API-Key` contre la variable d'environnement `ARBORE_API_KEY`. Bloque toute requête non identifiée par la clé applicative. Renvoie `401 INVALID_API_KEY`. |
+| `middleware/firebase_auth.go` | `InitFirebase()` | Initialise le SDK Admin Firebase au démarrage du serveur. En `GIN_MODE=release`, toute erreur de credential est fatale (le serveur refuse de démarrer). |
+| `middleware/firebase_auth.go` | `FirebaseAuthMiddleware()` | Vérifie le `Bearer` token, extrait l'`uid` et le pose dans le contexte Gin (`c.Set("uid", ...)`). Renvoie `401 Unauthorized` si la vérification échoue. |
+| `middleware/firebase_auth.go` | `CheckUserBannedFunc` | Hook configurable injecté depuis `main.go` (`checkUserBannedFromDB`) qui rejette les UIDs marqués `banned: true` dans Mongo. |
+
+**Ordre critique** : `APIKeyMiddleware` doit précéder `FirebaseAuthMiddleware`. Cela évite de consommer un appel Firebase pour des requêtes qui n'auraient même pas la clé applicative valide.
+
+## Handlers HTTP (main.go)
+
+Les handlers sont regroupés thématiquement dans `main.go` et exposés sous le groupe `protected`. Tous reçoivent l'`uid` via `c.Get("uid")` après passage des deux middlewares.
+
+### Domaine Users (`/users`)
+
+| Endpoint | Handler | Authz |
+|---|---|---|
+| `POST /users` | `createUser` | uid issu du token, ignore tout `uid` envoyé dans le body |
+| `GET /users/:uid` | inline (anonyme) | self-only : `tokenUID == :uid` sinon `403` |
+| `POST /users/:uid/photo` | `uploadUserPhoto` | self-only |
+| `GET /users/:uid/photo` | `getUserPhoto` | self-only |
+| `GET /users/export` | `exportUserData` | RGPD art. 20 — renvoie users + gardens + consents au format JSON |
+| `PATCH /users/me` | `updateUserSelf` | self-only, trim + cap 100 chars (issue #138) |
+| `DELETE /users` | `deleteUser` | cascade — supprime gardens + consents avant le user |
+
+### Domaine Plants (`/plants`)
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `POST /plants` | `createPlant` | Insertion admin (pas d'authz spécifique au-delà de l'auth standard) |
+| `GET /plants` | `getPlants` | Liste complète du catalogue |
+| `GET /plants/:id` | `getPlantByID` | Validation `ObjectIDFromHex` |
+| `POST /plants/generate` | `generatePlantWithAI` | Génère une fiche multilingue via l'AI Generator |
+| `POST /plants/generate-multiple` | `generateMultiplePlantsHandler` | Variante batch, retourne created/skipped |
+
+### Domaine Gardens (`/gardens`)
+
+| Endpoint | Handler | Authz |
+|---|---|---|
+| `POST /gardens` | `createGarden` | uid issu du token, garden.UID forcé |
+| `GET /gardens` | `listGardens` | Filtre par `uid` |
+| `GET /gardens/:id` | `getGardenByID` | Lecture (pas de filtre `uid` à ce stade — revue pending) |
+| `PUT /gardens/:id` | `updateGarden` | Filtre `_id AND uid` pour l'ownership |
+| `DELETE /gardens/:id` | `deleteGarden` | Filtre `_id AND uid` pour l'ownership |
+
+### Domaine Consents (`/consents`) — RGPD
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `POST /consents` | `recordConsent` | Capture IP et User-Agent automatiquement si absents |
+| `GET /consents` | `getUserConsents` | Tri par timestamp descendant |
+| `GET /consents/latest` | `getLatestUserConsents` | Dernière entrée par `consentType` |
+
+### Domaine Models 3D (`/models`)
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `GET /models/:filename` | inline (anonyme) | Sécurité : reject `..` et `/`, exige `.usdz`. Sert le fichier depuis `./models/`. |
+| `GET /models/thumbnails/:filename` | inline (anonyme, **public**) | Hors du groupe `protected` — sert les PNGs sans auth. |
+| `POST /models/thumbnails/:plantId` | `uploadPlantThumbnail` | Restreint à `THUMBNAIL_UPLOAD_ALLOWED_UIDS` ; validation PNG (max 100 MB). |
+
+### Endpoint public (`/health`)
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `GET /health` | inline | Healthcheck Docker — pas de protection. Renvoie `{status, service, version}`. |
+
+## Couche d'accès aux données et clients externes
+
+| Fichier / fonction | Rôle |
+|---|---|
+| Variable globale `client *mongo.Client` (main.go) | Connexion MongoDB initialisée au démarrage. Le `URI` provient de `MONGODB_URI`. |
+| Collections — `users`, `plants`, `gardens`, `consents` | Schéma documenté dans [`04-data-model.md`](04-data-model.md). |
+| `unsplash.go` — `fetchUnsplashImageURLs(query, count)` | Appelle l'API Unsplash avec `UNSPLASH_ACCESS_KEY`. Retourne les URLs de photos. |
+| `setdefault.go` — `Plant.SetDefaults()` | Applique les valeurs par défaut aux plantes lors de l'insertion. |
+| `generateAndInsertPlant` (main.go) | Pipeline complet : appel HTTP à l'AI Generator → enrichissement Unsplash → insertion Mongo. |
+| `checkUserBannedFromDB` (main.go) | Hook injecté dans le middleware Firebase — vérifie le flag `banned` du user. |
+| `loadDotEnv` (main.go) | Charge un `.env` local au démarrage (utile en dev). Sur le VPS les variables viennent de l'environnement Docker. |
+
+## Variables d'environnement
+
+| Variable | Rôle | Sensibilité |
+|---|---|---|
+| `MONGODB_URI` | URI de connexion Mongo Atlas | 🔒 **secret** |
+| `ARBORE_API_KEY` | Clé applicative attendue dans `X-API-Key` | 🔒 **secret** |
+| `FIREBASE_SERVICE_ACCOUNT_PATH` | Chemin vers le JSON du service account Firebase | 🔒 **secret** |
+| `OPENAI_API_KEY` | Forwardée à l'AI Generator | 🔒 **secret** |
+| `UNSPLASH_ACCESS_KEY` | Clé API Unsplash | 🔒 **secret** |
+| `AI_GENERATOR_URL` | URL interne Docker (`http://ai-generator:8000`) | configuration |
+| `THUMBNAILS_DIR` | Chemin disque pour les thumbnails PNG | configuration |
+| `THUMBNAIL_UPLOAD_ALLOWED_UIDS` | Liste d'UIDs autorisés à uploader des thumbnails | configuration |
+| `GIN_MODE` | `release` en prod, `debug` en local | configuration |
+| `PORT` | Port d'écoute HTTP (8080 par défaut) | configuration |
+
+## Points clés
+
+- **Monolithe Go contenu** : tout vit dans `main.go` plus `middleware/`. Cette concentration est volontaire à l'échelle actuelle, et la séparation par packages sera envisagée si le code dépasse 2 000-2 500 lignes.
+- **Aucun ORM** : le driver MongoDB officiel est utilisé directement avec `bson.M{...}` pour les filtres. La conséquence positive est une grande lisibilité ; la conséquence négative est l'absence de protection structurelle contre les fautes de frappe sur les noms de champs.
+- **Self-only authz omniprésente** : la quasi-totalité des handlers `users`/`gardens` filtre par `uid` extrait du token, jamais par l'`uid` envoyé dans le body ou l'URL. Cette discipline empêche un utilisateur d'agir au nom d'un autre.
+- **L'AI Generator est traité comme un service interne** : appelé via `http://ai-generator:8000` sur le réseau Docker, jamais exposé directement au client. La clé OpenAI ne quitte pas le VPS.
+- **MongoDB credentials hardcodés en fallback** (lignes 1166-1169 de `main.go`) — issue #119 ouverte pour suppression et rotation. À traiter avant toute exposition publique du dépôt.
+- **Backend reachable en HTTP simple** — issue #121 ouverte pour migration HTTPS et durcissement ATS côté iOS.
+
+## Hors-scope de cette vue
+
+- Le détail des sequences (signup avec rollback, save garden) sera couvert dans `flows/*.md` (Phase 3).
+- Le schéma des collections est documenté dans [`04-data-model.md`](04-data-model.md).
+- Les décisions architecturales (choix Firebase, choix Mongo, choix monolithe) seront tracées dans `decisions/` (Phase 5).

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -77,6 +77,88 @@ Les flèches reflètent la **règle de dépendance** : la présentation peut app
 | `Config/AppConfig.swift` | Lit `baseURL` et `apiKey` depuis `Secrets.xcconfig` non versionné (cf. issue #117 résolue : rotation + purge historique). |
 | `ARGarden/ArboreLog.swift` | Wrapper `os_log` catégorisé (`plants`, `network`, `AR`). Utilisé par tous les modules. |
 
+## Câblage inter-modules
+
+Le diagramme ci-dessous restaure les **dépendances réelles** entre modules à travers les trois couches. Il complète la topologie générale et les tableaux : chaque flèche correspond à un appel direct identifié dans le code.
+
+```mermaid
+flowchart TB
+    user["👤 Utilisateur"]
+
+    subgraph ui["Présentation"]
+        direction TB
+        login["LoginAuth/<br/>SignUpView"]
+        wizard["GardenSteps/<br/>QuestionnaireView"]
+        ar["ARGarden/<br/>GardenARPlacementView"]
+        profile["Profile/<br/>PersonalDetailsView"]
+        measure["measure app/<br/>ARViewContainerMeasure"]
+    end
+
+    subgraph domain["Domaine"]
+        direction TB
+        save_auth["saveAuthDB<br/>(retry + rollback)"]
+        garden_svc["GardenProjectService"]
+        user_svc["UserService"]
+        manual["ManualReplacement/<br/>(zoom dédié)"]
+    end
+
+    subgraph infra["Infrastructure"]
+        direction TB
+        net["NetworkManager<br/>(singleton)"]
+        local["GardenLocalStore<br/>(disque iOS)"]
+        cache["ModelCacheManager<br/>(USDZ cache)"]
+    end
+
+    fb["Firebase Auth SDK"]
+    backend["Backend API"]
+
+    user --> login
+    user --> wizard
+    user --> ar
+    user --> profile
+    user --> measure
+
+    login --> save_auth
+    login --> fb
+    save_auth --> net
+
+    wizard --> garden_svc
+    garden_svc --> net
+
+    profile --> net
+    profile --> fb
+    user_svc --> net
+
+    ar --> manual
+    ar --> local
+    ar --> cache
+    cache --> net
+
+    measure --> local
+
+    net --> fb
+    net --> backend
+
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef ui_n   fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef dom_n  fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef inf_n  fill:#6A1B9A,stroke:#4A148C,color:#fff
+    classDef ext_n  fill:#999,stroke:#666,color:#fff
+    class user person
+    class login,wizard,ar,profile,measure ui_n
+    class save_auth,garden_svc,user_svc,manual dom_n
+    class net,local,cache inf_n
+    class fb,backend ext_n
+```
+
+Lectures recommandées de ce diagramme :
+
+- **Signup** : `SignUpView` → `saveAuthDB` (retry + rollback, issue #137) → `NetworkManager` → Backend ; en parallèle, `SignUpView` → Firebase Auth SDK pour la création de compte.
+- **Wizard de jardin** : `QuestionnaireView` → `GardenProjectService` → `NetworkManager` → Backend.
+- **Placement AR** : `GardenARPlacementView` ramifie vers trois dépendances — `ManualReplacement/` (UI overlays + math morphing), `GardenLocalStore` (persistance WorldMap), `ModelCacheManager` (USDZ via le réseau).
+- **Profil** : `PersonalDetailsView` → `NetworkManager` (PATCH /users/me, issue #138) **et** Firebase Auth SDK (mise à jour `displayName`).
+- **Tracé périmètre non-LiDAR** : `ARViewContainerMeasure` écrit la boundary dans `GardenLocalStore` sans passer par le réseau.
+
 ## Zoom Manual Replacement
 
 Le sous-dossier `ARGarden/ManualReplacement/` regroupe la machine d'états du **Manual Replace** introduite par l'issue #111. La granularité fine permet de tester la couche mathématique indépendamment de l'UI.

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -12,43 +12,48 @@ Le diagramme ci-dessous expose **tous les modules et leurs dépendances**. Les f
 flowchart TB
     user["👤 Utilisateur"]
 
-    subgraph ios["📱 App iOS Arbore"]
+    subgraph ui_layer["📱 Couche présentation — SwiftUI Views"]
         direction TB
+        login["LoginAuth/<br/>SignUpView · LoginView · VerifyEmailView · ReAuthView"]
+        wizard["Views/GardenSteps/<br/>QuestionnaireView · ScanMethodSelectionView · WizardSummaryStepView · LiDARScanWizardView"]
+        ar_view["ARGarden/<br/>GardenARPlacementView · PlantCatalogView"]
+        manual_rep["ARGarden/ManualReplacement/<br/>RelocationPhase · GardenMorpher · MVC · DistortionAnalyzer · Overlays"]
+        profile["Views/Profile/<br/>PersonalDetailsView · DataExportView · PrivacySettingsView · CloseAccountView"]
+        measure["measure app/<br/>ARViewContainerMeasure"]
+    end
 
-        subgraph ui_layer["Couche présentation"]
-            direction TB
-            login["LoginAuth/<br/>SignUpView · LoginView · VerifyEmailView · ReAuthView"]
-            wizard["Views/GardenSteps/<br/>QuestionnaireView · ScanMethodSelectionView · WizardSummaryStepView · LiDARScanWizardView"]
-            ar_view["ARGarden/<br/>GardenARPlacementView · PlantCatalogView"]
-            manual_rep["ARGarden/ManualReplacement/<br/>RelocationPhase · GardenMorpher · MVC · DistortionAnalyzer · Overlays"]
-            profile["Views/Profile/<br/>PersonalDetailsView · DataExportView · PrivacySettingsView · CloseAccountView"]
-            measure["measure app/<br/>ARViewContainerMeasure"]
-        end
+    subgraph domain_layer["🌿 Couche domaine — Models et Services métier"]
+        direction TB
+        models["Models/<br/>User · Plant · GardenProject · WizardPlantFilter · WateringRoutine · PotMeasurement"]
+        user_svc["UserService.swift"]
+        garden_svc["GardenProjectService.swift"]
+        suggest["Services/GardenSuggestionEngine.swift"]
+        calendar["Services/CalendarService.swift"]
+        save_auth["LoginAuth/saveAuthDB.swift<br/>(retry exponentiel + rollback Firebase)"]
+    end
 
-        subgraph domain_layer["Couche domaine"]
-            direction TB
-            models["Models/<br/>User · Plant · GardenProject · WizardPlantFilter · WateringRoutine · PotMeasurement"]
-            user_svc["UserService.swift"]
-            garden_svc["GardenProjectService.swift"]
-            suggest["Services/GardenSuggestionEngine.swift"]
-            calendar["Services/CalendarService.swift"]
-            save_auth["LoginAuth/saveAuthDB.swift<br/>(retry exponentiel + rollback Firebase)"]
-        end
-
-        subgraph infra_layer["Couche infrastructure"]
-            direction TB
-            network["Services/NetworkManager.swift<br/>(singleton HTTP)"]
-            model_cache["Services/ModelCacheManager.swift<br/>(cache USDZ)"]
-            local_store["Views/GardenLocalStore.swift<br/>(WorldMap + scene JSON)"]
-            firestore["DatabaseFireBaseStore/<br/>(deprecated)"]
-            config["Config/AppConfig.swift<br/>(Secrets.xcconfig)"]
-            logger["ARGarden/ArboreLog.swift<br/>(os_log catégorisé)"]
-        end
+    subgraph infra_layer["⚙️ Couche infrastructure"]
+        direction TB
+        network["Services/NetworkManager.swift<br/>(singleton HTTP)"]
+        model_cache["Services/ModelCacheManager.swift<br/>(cache USDZ)"]
+        local_store["Views/GardenLocalStore.swift<br/>(WorldMap + scene JSON)"]
+        firestore["DatabaseFireBaseStore/<br/>(deprecated)"]
+        config["Config/AppConfig.swift<br/>(Secrets.xcconfig)"]
+        logger["ARGarden/ArboreLog.swift<br/>(os_log catégorisé)"]
     end
 
     fb_auth_ext["[System Ext] Firebase Auth SDK"]
     backend_ext["[Container] Backend API"]
 
+    %% Edges invisibles pour forcer le stack vertical des subgraphs
+    %% (Mermaid ignore "direction TB" dans un subgraph si ses noeuds ont
+    %% des liens vers l'extérieur. Voir mermaid-js/mermaid#6438.)
+    user ~~~ ui_layer
+    ui_layer ~~~ domain_layer
+    domain_layer ~~~ infra_layer
+    infra_layer ~~~ backend_ext
+
+    %% Edges réelles
     user --> login
     user --> wizard
     user --> ar_view

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -1,0 +1,138 @@
+# C4 — Niveau 3 : Composants iOS
+
+Cette vue ouvre le container **App iOS Arbore** et expose ses modules principaux. Le code source SwiftUI est organisé en dossiers fonctionnels regroupés en trois couches : présentation, domaine et infrastructure.
+
+Pour la vue d'ensemble des containers, consulter [`02-containers.md`](02-containers.md). Pour les composants côté backend, consulter [`03-components-backend.md`](03-components-backend.md).
+
+## Topologie en couches
+
+```mermaid
+flowchart TB
+    user["👤 Utilisateur"]
+
+    subgraph ios["📱 App iOS Arbore"]
+        direction TB
+        ui["Couche présentation<br/>SwiftUI Views"]
+        domain["Couche domaine<br/>Models + Services métier"]
+        infra["Couche infrastructure<br/>Network + Cache + Persistance"]
+
+        ui --> domain
+        domain --> infra
+    end
+
+    fb_auth_ext["[System Ext]<br/>Firebase Auth SDK"]
+    backend_ext["[Container]<br/>Backend API"]
+
+    user --> ui
+    infra --> fb_auth_ext
+    infra --> backend_ext
+
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef layer  fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef ext    fill:#999,stroke:#666,color:#fff
+    class user person
+    class ui,domain,infra layer
+    class fb_auth_ext,backend_ext ext
+```
+
+Les flèches reflètent la **règle de dépendance** : la présentation peut appeler le domaine, le domaine peut appeler l'infrastructure ; jamais l'inverse. Cette règle est appliquée par convention de dossiers et revue lors des PRs (pas de framework qui l'enforce).
+
+## Modules par couche
+
+### Couche présentation — SwiftUI Views
+
+| Dossier / fichier | Rôle |
+|---|---|
+| `LoginAuth/` | Signup, login, vérification email, reset mot de passe (`SignUpView`, `LoginView`, `VerifyEmailView`, `ReAuthView`). |
+| `Views/GardenSteps/` | Wizard de création de jardin en 10 étapes (`QuestionnaireView`, `ScanMethodSelectionView`, `WizardSummaryStepView`, `LiDARScanWizardView`). |
+| `ARGarden/` | Placement et visualisation des plantes en AR (`GardenARPlacementView` ~3 300 LOC, `PlantCatalogView`). |
+| `ARGarden/ManualReplacement/` | Sous-module dédié au flow de re-placement manuel (#111). Voir [zoom dédié](#zoom-manual-replacement) plus bas. |
+| `Views/Profile/` | Gestion du compte (`PersonalDetailsView`, `DataExportView`, `PrivacySettingsView`, `CloseAccountView`). |
+| `measure app/` | Tracé du périmètre du jardin au sol via raycasts ARKit (`ARViewContainerMeasure`), utilisé en non-LiDAR. |
+
+### Couche domaine — Models et Services métier
+
+| Fichier | Rôle |
+|---|---|
+| `Models/User.swift` | Struct utilisateur, miroir du document MongoDB côté serveur. |
+| `Models/Plant.swift` | Struct catalogue plante avec traductions multilingues et URL USDZ. |
+| `Models/GardenProject.swift` | Représentation locale d'un jardin (boundary, plants placées, métadonnées). |
+| `Models/WizardPlantFilter.swift` | Filtre les plantes du catalogue selon les choix du wizard (luminosité, entretien, etc.). |
+| `Models/WateringRoutine.swift` | Routine d'arrosage attachée à une plante. |
+| `Models/PotMeasurement.swift` | Mesure du diamètre d'un pot via ARKit (feature secondaire). |
+| `UserService.swift` | Récupère l'utilisateur courant via `GET /users/:uid`. |
+| `Models/GardenProjectService.swift` | CRUD des jardins via le backend. |
+| `Services/GardenSuggestionEngine.swift` | Filtre et propose les plantes adaptées au profil. |
+| `Services/CalendarService.swift` | Génère le calendrier d'arrosage à partir des `WateringRoutine`. |
+| `LoginAuth/saveAuthDB.swift` | Pont entre Firebase Auth et `POST /users` — implémente retry exponentiel et rollback Firebase (issue #137). |
+
+### Couche infrastructure
+
+| Fichier | Rôle |
+|---|---|
+| `Services/NetworkManager.swift` | Singleton HTTP. Injecte automatiquement `X-API-Key` (depuis `AppConfig`) et `Bearer` token Firebase. Retry unique sur erreurs réseau transitoires (issue #90). |
+| `Services/ModelCacheManager.swift` | Télécharge et cache les modèles USDZ depuis `GET /models/:filename` (issue #91). |
+| `Views/GardenLocalStore.swift` | Persistance disque iOS — `worldmap_{id}.arworldmap` (binaire ARKit) et `scene_{id}.json` (positions des plantes). Local-only à ce jour (origine de l'issue #114). |
+| `DatabaseFireBaseStore/` | Wrappers historiques autour de Firestore. **En cours de dépréciation** : les nouveaux écrans passent par le backend Go via `NetworkManager`. |
+| `Config/AppConfig.swift` | Lit `baseURL` et `apiKey` depuis `Secrets.xcconfig` non versionné (cf. issue #117 résolue : rotation + purge historique). |
+| `ARGarden/ArboreLog.swift` | Wrapper `os_log` catégorisé (`plants`, `network`, `AR`). Utilisé par tous les modules. |
+
+## Zoom Manual Replacement
+
+Le sous-dossier `ARGarden/ManualReplacement/` regroupe la machine d'états du **Manual Replace** introduite par l'issue #111. La granularité fine permet de tester la couche mathématique indépendamment de l'UI.
+
+```mermaid
+flowchart TB
+    coord["GardenARPlacementView<br/>(Coordinator)"]
+
+    subgraph mr["ARGarden/ManualReplacement/"]
+        direction TB
+        phase["RelocationPhase<br/>(enum 5 états)"]
+        morpher["GardenMorpher<br/>(orchestration)"]
+        mvc["MeanValueCoordinates<br/>(math pure, testable)"]
+        distort["DistortionAnalyzer<br/>(score par plante)"]
+        warn["DistortionWarning<br/>(struct UI)"]
+        ghost["GhostRenderer<br/>(matériau doré SCN)"]
+        overlay["Overlays SwiftUI<br/>Scanning · BoundaryTracing · MorphingPreview · Adjusting"]
+    end
+
+    coord --> phase
+    coord --> overlay
+    coord --> morpher
+    morpher --> mvc
+    morpher --> distort
+    distort --> warn
+    overlay --> ghost
+
+    classDef coord fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef sub   fill:#2E7D32,stroke:#1B5E20,color:#fff
+    class coord coord
+    class phase,morpher,mvc,distort,warn,ghost,overlay sub
+```
+
+`MeanValueCoordinates` reste **pure math** (algorithme Floater 2003), sans dépendance UIKit ni ARKit. Elle est testable en isolation — c'est la pièce qu'il convient de couvrir en priorité par des tests unitaires (issue #123).
+
+La machine d'états correspondante sera diagrammée dans `state-machines/relocation-phase.md` (Phase 3).
+
+## Points clés
+
+- **Trois couches sont clairement séparées** par convention de dossiers : présentation, domaine, infrastructure. Aucun framework MVVM n'est imposé ; la discipline tient à la review des PRs.
+- **`GardenARPlacementView` est le seul god object** du codebase (≈ 3 300 lignes). Sa refactorisation est suivie par l'issue #124.
+- **`NetworkManager` est le point d'entrée unique** des appels HTTP. Toute requête sortante passe par ce singleton afin de garantir l'injection des credentials et le retry réseau.
+- **`saveAuthDB.swift` est le seul appelant** à implémenter un retry métier avec backoff exponentiel et un rollback Firebase Auth. Cette logique est dédiée à la signup (issue #137).
+- **`DatabaseFireBaseStore/` est en cours de dépréciation** au profit du backend Go pour toutes les opérations métier hors authentification.
+- **`GardenLocalStore` est local-only** : aucune donnée n'est partagée entre appareils, ce qui motive l'issue #114 (récupération cross-install).
+
+## Frameworks Apple utilisés
+
+- **SwiftUI** pour l'ensemble de la couche UI (sauf SCNView/ARSCNView intégrés via `UIViewRepresentable`).
+- **ARKit** pour le tracking AR et la sérialisation `ARWorldMap`.
+- **SceneKit** pour le rendu 3D des plantes — migration vers RealityKit suivie par l'issue #83.
+- **RealityKit** pour les previews de thumbnails et la mesure de pots.
+- **RoomPlan** (LiDAR uniquement) pour le scan structuré de pièces.
+- **FirebaseAuth** pour l'auth utilisateur ; **GoogleSignIn** pour Google.
+
+## Hors-scope de cette vue
+
+- Le détail interne de `GardenARPlacementView` (gestures, raycasts, cycle de vie ARKit) relève d'une per-screen spec (Phase 4).
+- Les champs et invariants des modèles côté backend sont documentés dans [`04-data-model.md`](04-data-model.md).

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -6,62 +6,46 @@ Pour la vue d'ensemble des containers, consulter [`02-containers.md`](02-contain
 
 ## Diagramme
 
-Le diagramme ci-dessous expose **tous les modules et leurs dépendances**. Les flèches reflètent les appels effectifs identifiés dans le code ; la règle de dépendance est respectée : la présentation appelle le domaine, le domaine appelle l'infrastructure, jamais l'inverse.
+Le diagramme ci-dessous expose **tous les modules et leurs dépendances**. Les flèches reflètent les appels effectifs identifiés dans le code.
+
+**Convention de couleurs** : chaque module est colorisé selon sa couche d'appartenance.
+
+- 🔵 **Bleu** — Couche présentation (SwiftUI Views)
+- 🟢 **Vert** — Couche domaine (Models et Services métier)
+- 🟣 **Violet** — Couche infrastructure (Network, persistance, config)
+- ⚪ **Gris** — Systèmes externes (Firebase Auth SDK, Backend API)
+- 🟦 **Bleu marine** — Acteurs humains
+
+Cette représentation par classes plutôt que par subgraphs imbriqués est un parti pris assumé : la codebase contient des appels qui sautent la couche domaine (`GardenARPlacementView` qui écrit directement dans `GardenLocalStore`, par exemple), ce que les subgraphs imbriqués peinent à rendre lisiblement. L'approche par color-coding est utilisée par Shopify Polaris, Material Design 3 et IBM Carbon pour les mêmes raisons, et reste conforme à la sémantique C4 (la couche est portée par le label et la couleur du nœud).
 
 ```mermaid
 flowchart TB
     user["👤 Utilisateur"]
 
-    subgraph ui_layer["📱 Couche présentation — SwiftUI Views"]
-        direction TB
-        login["LoginAuth/<br/>SignUpView · LoginView · VerifyEmailView · ReAuthView"]
-        wizard["Views/GardenSteps/<br/>QuestionnaireView · ScanMethodSelectionView · WizardSummaryStepView · LiDARScanWizardView"]
-        ar_view["ARGarden/<br/>GardenARPlacementView · PlantCatalogView"]
-        manual_rep["ARGarden/ManualReplacement/<br/>RelocationPhase · GardenMorpher · MVC · DistortionAnalyzer · Overlays"]
-        profile["Views/Profile/<br/>PersonalDetailsView · DataExportView · PrivacySettingsView · CloseAccountView"]
-        measure["measure app/<br/>ARViewContainerMeasure"]
-    end
+    login["📱 LoginAuth/<br/>SignUpView · LoginView · VerifyEmailView · ReAuthView"]
+    wizard["📱 Views/GardenSteps/<br/>QuestionnaireView · ScanMethodSelectionView · WizardSummaryStepView · LiDARScanWizardView"]
+    ar_view["📱 ARGarden/<br/>GardenARPlacementView · PlantCatalogView"]
+    manual_rep["📱 ARGarden/ManualReplacement/<br/>RelocationPhase · GardenMorpher · MVC · DistortionAnalyzer · Overlays"]
+    profile["📱 Views/Profile/<br/>PersonalDetailsView · DataExportView · PrivacySettingsView · CloseAccountView"]
+    measure["📱 measure app/<br/>ARViewContainerMeasure"]
 
-    subgraph domain_layer["🌿 Couche domaine — Models et Services métier"]
-        direction TB
-        models["Models/<br/>User · Plant · GardenProject · WizardPlantFilter · WateringRoutine · PotMeasurement"]
-        user_svc["UserService.swift"]
-        garden_svc["GardenProjectService.swift"]
-        suggest["Services/GardenSuggestionEngine.swift"]
-        calendar["Services/CalendarService.swift"]
-        save_auth["LoginAuth/saveAuthDB.swift<br/>(retry exponentiel + rollback Firebase)"]
-    end
+    models["🌿 Models/<br/>User · Plant · GardenProject · WizardPlantFilter · WateringRoutine · PotMeasurement"]
+    user_svc["🌿 UserService.swift"]
+    garden_svc["🌿 GardenProjectService.swift"]
+    suggest["🌿 Services/GardenSuggestionEngine.swift"]
+    calendar["🌿 Services/CalendarService.swift"]
+    save_auth["🌿 LoginAuth/saveAuthDB.swift<br/>(retry exponentiel + rollback Firebase)"]
 
-    subgraph infra_layer["⚙️ Couche infrastructure"]
-        direction TB
-        network["Services/NetworkManager.swift<br/>(singleton HTTP)"]
-        model_cache["Services/ModelCacheManager.swift<br/>(cache USDZ)"]
-        local_store["Views/GardenLocalStore.swift<br/>(WorldMap + scene JSON)"]
-        firestore["DatabaseFireBaseStore/<br/>(deprecated)"]
-        config["Config/AppConfig.swift<br/>(Secrets.xcconfig)"]
-        logger["ARGarden/ArboreLog.swift<br/>(os_log catégorisé)"]
-    end
+    network["⚙️ Services/NetworkManager.swift<br/>(singleton HTTP)"]
+    model_cache["⚙️ Services/ModelCacheManager.swift<br/>(cache USDZ)"]
+    local_store["⚙️ Views/GardenLocalStore.swift<br/>(WorldMap + scene JSON)"]
+    firestore["⚙️ DatabaseFireBaseStore/<br/>(deprecated)"]
+    config["⚙️ Config/AppConfig.swift<br/>(Secrets.xcconfig)"]
+    logger["⚙️ ARGarden/ArboreLog.swift<br/>(os_log catégorisé)"]
 
     fb_auth_ext["[System Ext] Firebase Auth SDK"]
     backend_ext["[Container] Backend API"]
 
-    %% Edges invisibles pour forcer le stack vertical des subgraphs.
-    %% Mermaid ignore "direction TB" dans un subgraph si ses noeuds ont
-    %% des liens vers l'extérieur (mermaid-js/mermaid#6438). Le fix
-    %% officiel est d'ajouter des liens invisibles entre subgraphs.
-    %% Plusieurs liens node-à-node sont nécessaires pour contrebalancer
-    %% les edges réels ui→infra qui sautent la couche domaine et tendent
-    %% à rapprocher ui et infra dans le layout Dagre.
-    user ~~~ ui_layer
-    ui_layer ~~~ domain_layer
-    domain_layer ~~~ infra_layer
-    infra_layer ~~~ backend_ext
-    measure ~~~ user_svc
-    measure ~~~ suggest
-    measure ~~~ calendar
-    manual_rep ~~~ save_auth
-
-    %% Edges réelles
     user --> login
     user --> wizard
     user --> ar_view

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -4,7 +4,9 @@ Cette vue ouvre le container **App iOS Arbore** et expose ses modules principaux
 
 Pour la vue d'ensemble des containers, consulter [`02-containers.md`](02-containers.md). Pour les composants côté backend, consulter [`03-components-backend.md`](03-components-backend.md).
 
-## Topologie en couches
+## Diagramme
+
+Le diagramme ci-dessous expose **tous les modules et leurs dépendances**. Les flèches reflètent les appels effectifs identifiés dans le code ; la règle de dépendance est respectée : la présentation appelle le domaine, le domaine appelle l'infrastructure, jamais l'inverse.
 
 ```mermaid
 flowchart TB
@@ -12,30 +14,85 @@ flowchart TB
 
     subgraph ios["📱 App iOS Arbore"]
         direction TB
-        ui["Couche présentation<br/>SwiftUI Views"]
-        domain["Couche domaine<br/>Models + Services métier"]
-        infra["Couche infrastructure<br/>Network + Cache + Persistance"]
 
-        ui --> domain
-        domain --> infra
+        subgraph ui_layer["Couche présentation"]
+            direction TB
+            login["LoginAuth/<br/>SignUpView · LoginView · VerifyEmailView · ReAuthView"]
+            wizard["Views/GardenSteps/<br/>QuestionnaireView · ScanMethodSelectionView · WizardSummaryStepView · LiDARScanWizardView"]
+            ar_view["ARGarden/<br/>GardenARPlacementView · PlantCatalogView"]
+            manual_rep["ARGarden/ManualReplacement/<br/>RelocationPhase · GardenMorpher · MVC · DistortionAnalyzer · Overlays"]
+            profile["Views/Profile/<br/>PersonalDetailsView · DataExportView · PrivacySettingsView · CloseAccountView"]
+            measure["measure app/<br/>ARViewContainerMeasure"]
+        end
+
+        subgraph domain_layer["Couche domaine"]
+            direction TB
+            models["Models/<br/>User · Plant · GardenProject · WizardPlantFilter · WateringRoutine · PotMeasurement"]
+            user_svc["UserService.swift"]
+            garden_svc["GardenProjectService.swift"]
+            suggest["Services/GardenSuggestionEngine.swift"]
+            calendar["Services/CalendarService.swift"]
+            save_auth["LoginAuth/saveAuthDB.swift<br/>(retry exponentiel + rollback Firebase)"]
+        end
+
+        subgraph infra_layer["Couche infrastructure"]
+            direction TB
+            network["Services/NetworkManager.swift<br/>(singleton HTTP)"]
+            model_cache["Services/ModelCacheManager.swift<br/>(cache USDZ)"]
+            local_store["Views/GardenLocalStore.swift<br/>(WorldMap + scene JSON)"]
+            firestore["DatabaseFireBaseStore/<br/>(deprecated)"]
+            config["Config/AppConfig.swift<br/>(Secrets.xcconfig)"]
+            logger["ARGarden/ArboreLog.swift<br/>(os_log catégorisé)"]
+        end
     end
 
-    fb_auth_ext["[System Ext]<br/>Firebase Auth SDK"]
-    backend_ext["[Container]<br/>Backend API"]
+    fb_auth_ext["[System Ext] Firebase Auth SDK"]
+    backend_ext["[Container] Backend API"]
 
-    user --> ui
-    infra --> fb_auth_ext
-    infra --> backend_ext
+    user --> login
+    user --> wizard
+    user --> ar_view
+    user --> profile
+    user --> measure
+
+    login --> save_auth
+    login --> fb_auth_ext
+    save_auth --> network
+
+    wizard --> garden_svc
+    wizard --> models
+    garden_svc --> models
+    garden_svc --> network
+
+    ar_view --> manual_rep
+    ar_view --> local_store
+    ar_view --> model_cache
+    ar_view --> models
+    model_cache --> network
+
+    profile --> network
+    profile --> fb_auth_ext
+
+    measure --> local_store
+    suggest --> models
+    calendar --> models
+    user_svc --> network
+
+    network --> config
+    network --> fb_auth_ext
+    network --> backend_ext
 
     classDef person fill:#08427B,stroke:#073B6F,color:#fff
-    classDef layer  fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef ui     fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef domain fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef infra  fill:#6A1B9A,stroke:#4A148C,color:#fff
     classDef ext    fill:#999,stroke:#666,color:#fff
     class user person
-    class ui,domain,infra layer
+    class login,wizard,ar_view,manual_rep,profile,measure ui
+    class models,user_svc,garden_svc,suggest,calendar,save_auth domain
+    class network,model_cache,local_store,firestore,config,logger infra
     class fb_auth_ext,backend_ext ext
 ```
-
-Les flèches reflètent la **règle de dépendance** : la présentation peut appeler le domaine, le domaine peut appeler l'infrastructure ; jamais l'inverse. Cette règle est appliquée par convention de dossiers et revue lors des PRs (pas de framework qui l'enforce).
 
 ## Modules par couche
 
@@ -46,7 +103,7 @@ Les flèches reflètent la **règle de dépendance** : la présentation peut app
 | `LoginAuth/` | Signup, login, vérification email, reset mot de passe (`SignUpView`, `LoginView`, `VerifyEmailView`, `ReAuthView`). |
 | `Views/GardenSteps/` | Wizard de création de jardin en 10 étapes (`QuestionnaireView`, `ScanMethodSelectionView`, `WizardSummaryStepView`, `LiDARScanWizardView`). |
 | `ARGarden/` | Placement et visualisation des plantes en AR (`GardenARPlacementView` ~3 300 LOC, `PlantCatalogView`). |
-| `ARGarden/ManualReplacement/` | Sous-module dédié au flow de re-placement manuel (#111). Voir [zoom dédié](#zoom-manual-replacement) plus bas. |
+| `ARGarden/ManualReplacement/` | Sous-module dédié au flow de re-placement manuel (#111). Composants : `RelocationPhase`, `MeanValueCoordinates`, `GardenMorpher`, `DistortionAnalyzer`, `DistortionWarning`, `GhostRenderer`, plus quatre overlays SwiftUI (`Scanning`, `BoundaryTracing`, `MorphingPreview`, `Adjusting`). La machine d'états sera diagrammée dans `state-machines/relocation-phase.md` (Phase 3). |
 | `Views/Profile/` | Gestion du compte (`PersonalDetailsView`, `DataExportView`, `PrivacySettingsView`, `CloseAccountView`). |
 | `measure app/` | Tracé du périmètre du jardin au sol via raycasts ARKit (`ARViewContainerMeasure`), utilisé en non-LiDAR. |
 
@@ -77,125 +134,6 @@ Les flèches reflètent la **règle de dépendance** : la présentation peut app
 | `Config/AppConfig.swift` | Lit `baseURL` et `apiKey` depuis `Secrets.xcconfig` non versionné (cf. issue #117 résolue : rotation + purge historique). |
 | `ARGarden/ArboreLog.swift` | Wrapper `os_log` catégorisé (`plants`, `network`, `AR`). Utilisé par tous les modules. |
 
-## Câblage inter-modules
-
-Le diagramme ci-dessous restaure les **dépendances réelles** entre modules à travers les trois couches. Il complète la topologie générale et les tableaux : chaque flèche correspond à un appel direct identifié dans le code.
-
-```mermaid
-flowchart TB
-    user["👤 Utilisateur"]
-
-    subgraph ui["Présentation"]
-        direction TB
-        login["LoginAuth/<br/>SignUpView"]
-        wizard["GardenSteps/<br/>QuestionnaireView"]
-        ar["ARGarden/<br/>GardenARPlacementView"]
-        profile["Profile/<br/>PersonalDetailsView"]
-        measure["measure app/<br/>ARViewContainerMeasure"]
-    end
-
-    subgraph domain["Domaine"]
-        direction TB
-        save_auth["saveAuthDB<br/>(retry + rollback)"]
-        garden_svc["GardenProjectService"]
-        user_svc["UserService"]
-        manual["ManualReplacement/<br/>(zoom dédié)"]
-    end
-
-    subgraph infra["Infrastructure"]
-        direction TB
-        net["NetworkManager<br/>(singleton)"]
-        local["GardenLocalStore<br/>(disque iOS)"]
-        cache["ModelCacheManager<br/>(USDZ cache)"]
-    end
-
-    fb["Firebase Auth SDK"]
-    backend["Backend API"]
-
-    user --> login
-    user --> wizard
-    user --> ar
-    user --> profile
-    user --> measure
-
-    login --> save_auth
-    login --> fb
-    save_auth --> net
-
-    wizard --> garden_svc
-    garden_svc --> net
-
-    profile --> net
-    profile --> fb
-    user_svc --> net
-
-    ar --> manual
-    ar --> local
-    ar --> cache
-    cache --> net
-
-    measure --> local
-
-    net --> fb
-    net --> backend
-
-    classDef person fill:#08427B,stroke:#073B6F,color:#fff
-    classDef ui_n   fill:#1168BD,stroke:#0B4884,color:#fff
-    classDef dom_n  fill:#2E7D32,stroke:#1B5E20,color:#fff
-    classDef inf_n  fill:#6A1B9A,stroke:#4A148C,color:#fff
-    classDef ext_n  fill:#999,stroke:#666,color:#fff
-    class user person
-    class login,wizard,ar,profile,measure ui_n
-    class save_auth,garden_svc,user_svc,manual dom_n
-    class net,local,cache inf_n
-    class fb,backend ext_n
-```
-
-Lectures recommandées de ce diagramme :
-
-- **Signup** : `SignUpView` → `saveAuthDB` (retry + rollback, issue #137) → `NetworkManager` → Backend ; en parallèle, `SignUpView` → Firebase Auth SDK pour la création de compte.
-- **Wizard de jardin** : `QuestionnaireView` → `GardenProjectService` → `NetworkManager` → Backend.
-- **Placement AR** : `GardenARPlacementView` ramifie vers trois dépendances — `ManualReplacement/` (UI overlays + math morphing), `GardenLocalStore` (persistance WorldMap), `ModelCacheManager` (USDZ via le réseau).
-- **Profil** : `PersonalDetailsView` → `NetworkManager` (PATCH /users/me, issue #138) **et** Firebase Auth SDK (mise à jour `displayName`).
-- **Tracé périmètre non-LiDAR** : `ARViewContainerMeasure` écrit la boundary dans `GardenLocalStore` sans passer par le réseau.
-
-## Zoom Manual Replacement
-
-Le sous-dossier `ARGarden/ManualReplacement/` regroupe la machine d'états du **Manual Replace** introduite par l'issue #111. La granularité fine permet de tester la couche mathématique indépendamment de l'UI.
-
-```mermaid
-flowchart TB
-    coord["GardenARPlacementView<br/>(Coordinator)"]
-
-    subgraph mr["ARGarden/ManualReplacement/"]
-        direction TB
-        phase["RelocationPhase<br/>(enum 5 états)"]
-        morpher["GardenMorpher<br/>(orchestration)"]
-        mvc["MeanValueCoordinates<br/>(math pure, testable)"]
-        distort["DistortionAnalyzer<br/>(score par plante)"]
-        warn["DistortionWarning<br/>(struct UI)"]
-        ghost["GhostRenderer<br/>(matériau doré SCN)"]
-        overlay["Overlays SwiftUI<br/>Scanning · BoundaryTracing · MorphingPreview · Adjusting"]
-    end
-
-    coord --> phase
-    coord --> overlay
-    coord --> morpher
-    morpher --> mvc
-    morpher --> distort
-    distort --> warn
-    overlay --> ghost
-
-    classDef coord fill:#1168BD,stroke:#0B4884,color:#fff
-    classDef sub   fill:#2E7D32,stroke:#1B5E20,color:#fff
-    class coord coord
-    class phase,morpher,mvc,distort,warn,ghost,overlay sub
-```
-
-`MeanValueCoordinates` reste **pure math** (algorithme Floater 2003), sans dépendance UIKit ni ARKit. Elle est testable en isolation — c'est la pièce qu'il convient de couvrir en priorité par des tests unitaires (issue #123).
-
-La machine d'états correspondante sera diagrammée dans `state-machines/relocation-phase.md` (Phase 3).
-
 ## Points clés
 
 - **Trois couches sont clairement séparées** par convention de dossiers : présentation, domaine, infrastructure. Aucun framework MVVM n'est imposé ; la discipline tient à la review des PRs.
@@ -217,4 +155,5 @@ La machine d'états correspondante sera diagrammée dans `state-machines/relocat
 ## Hors-scope de cette vue
 
 - Le détail interne de `GardenARPlacementView` (gestures, raycasts, cycle de vie ARKit) relève d'une per-screen spec (Phase 4).
+- La machine d'états de `ManualReplacement/` (`RelocationPhase`) sera diagrammée dans `state-machines/relocation-phase.md` (Phase 3).
 - Les champs et invariants des modèles côté backend sont documentés dans [`04-data-model.md`](04-data-model.md).

--- a/docs/architecture/03-components-ios.md
+++ b/docs/architecture/03-components-ios.md
@@ -45,13 +45,21 @@ flowchart TB
     fb_auth_ext["[System Ext] Firebase Auth SDK"]
     backend_ext["[Container] Backend API"]
 
-    %% Edges invisibles pour forcer le stack vertical des subgraphs
-    %% (Mermaid ignore "direction TB" dans un subgraph si ses noeuds ont
-    %% des liens vers l'extérieur. Voir mermaid-js/mermaid#6438.)
+    %% Edges invisibles pour forcer le stack vertical des subgraphs.
+    %% Mermaid ignore "direction TB" dans un subgraph si ses noeuds ont
+    %% des liens vers l'extérieur (mermaid-js/mermaid#6438). Le fix
+    %% officiel est d'ajouter des liens invisibles entre subgraphs.
+    %% Plusieurs liens node-à-node sont nécessaires pour contrebalancer
+    %% les edges réels ui→infra qui sautent la couche domaine et tendent
+    %% à rapprocher ui et infra dans le layout Dagre.
     user ~~~ ui_layer
     ui_layer ~~~ domain_layer
     domain_layer ~~~ infra_layer
     infra_layer ~~~ backend_ext
+    measure ~~~ user_svc
+    measure ~~~ suggest
+    measure ~~~ calendar
+    manual_rep ~~~ save_auth
 
     %% Edges réelles
     user --> login

--- a/docs/architecture/04-data-model.md
+++ b/docs/architecture/04-data-model.md
@@ -1,0 +1,179 @@
+# Modèle de données — MongoDB
+
+Cette vue décrit le schéma des collections MongoDB utilisées par Arbore. Le backend Go est le **seul** consommateur direct de cette base ; l'application iOS et le futur front web passent obligatoirement par l'API REST.
+
+Le schéma est volontairement **dénormalisé** sur certains aspects (traductions plantes embarquées, plantes placées embarquées dans le jardin) afin de réduire le nombre d'aller-retours Mongo lors des appels API. Aucune contrainte d'intégrité référentielle n'est appliquée par Mongo : la cohérence est assurée applicativement par le backend.
+
+## Diagramme ER
+
+```mermaid
+erDiagram
+    USERS ||--o{ GARDENS  : "possède"
+    USERS ||--o{ CONSENTS : "fournit"
+    PLANTS ||--o{ PLACED_PLANTS : "instancié dans"
+    GARDENS ||--|{ PLACED_PLANTS : "contient (embedded)"
+
+    USERS {
+        string uid PK "Firebase UID"
+        string email
+        string name
+        string createdAt "ISO 8601"
+        string photoData "base64 optionnel"
+        string photoContentType
+        bool   banned
+    }
+
+    PLANTS {
+        ObjectID _id PK
+        string name
+        string type
+        array  imageURLs
+        string description
+        string modelURL "fichier USDZ"
+        map    translations "fr/en/es/de"
+        bool   generated "modèle IA Meshy"
+        string upAxis "Y ou Z"
+    }
+
+    GARDENS {
+        ObjectID _id PK
+        string uid FK "uid de USERS"
+        string name
+        object wizard "GardenWizardData embedded"
+        array  plants "PLACED_PLANTS embedded"
+        string thumbnailKey
+        date   createdAt
+        date   updatedAt
+    }
+
+    PLACED_PLANTS {
+        ObjectID plantId FK "vers PLANTS"
+        float x
+        float y
+        float z
+        string note
+    }
+
+    CONSENTS {
+        ObjectID _id PK
+        string uid FK "uid de USERS"
+        string consentType "terms · privacy · marketing · etc"
+        string version
+        bool   granted
+        date   timestamp
+        string ipAddress
+        string userAgent
+    }
+```
+
+## Collections
+
+### `users`
+
+Document représentant un utilisateur authentifié. La clé fonctionnelle est `uid` (UID Firebase), pas l'`_id` Mongo, ce qui permet de retrouver un user via son token sans index secondaire.
+
+| Champ | Type | Notes |
+|---|---|---|
+| `uid` | string | UID Firebase. Sert de clé fonctionnelle dans tous les filtres `bson.M{"uid": ...}`. |
+| `email` | string | Email tel que fourni par Firebase Auth. |
+| `name` | string | Nom complet affiché. Modifiable via `PATCH /users/me` (issue #138). |
+| `createdAt` | string | Date d'inscription au format ISO 8601. |
+| `photoData` | string (optionnel) | Photo de profil encodée en base64. Source de vérité pour la photo. |
+| `photoContentType` | string (optionnel) | MIME type associé. |
+| `banned` | bool | Hook de modération vérifié par le middleware Firebase à chaque requête. |
+
+### `plants`
+
+Document du catalogue de plantes. Chaque plante embarque ses traductions multilingues afin qu'un seul `findOne` rapatrie toutes les informations nécessaires.
+
+| Champ | Type | Notes |
+|---|---|---|
+| `_id` | ObjectID | Clé primaire Mongo. Référencée par `PlacedPlant.plantId`. |
+| `name` | string | Nom canonique. |
+| `type` | string | Famille / type botanique. |
+| `imageURLs` | array<string> | Photos Unsplash récupérées via `fetchUnsplashImageURLs`. |
+| `description` | string | Description en français (rapide à servir au client iOS par défaut). |
+| `modelURL` | string | Nom de fichier USDZ servi par `GET /models/:filename`. |
+| `translations` | map<lang, LanguageData> | Sous-document par langue (`fr`, `en`, `es`, `de`) avec sun/water/soilAndPot/health/lifeCycle/care. |
+| `generated` | bool (optionnel) | `true` si le modèle 3D vient de Meshy (cf. badge BETA, issue #84). |
+| `upAxis` | string (optionnel) | `"Y"` ou `"Z"`. Permet l'application d'une rotation au chargement du modèle (issue #89). |
+
+Le sous-document `translations[lang]` (type `LanguageData`) regroupe :
+
+```
+LanguageData {
+  description, plantType,
+  sun: {lightType, durationPerDay, orientation, windowDistance, recommendedRooms, tips},
+  water: {frequency, amount, method, humidity, signsLack, signsExcess, recommendedWater},
+  soilAndPot: {substrate, drainage, potSize, repotFrequency, repotSigns},
+  health: {commonProblems, symptomsAndCauses, pests, treatments, prevention},
+  lifeCycle: {growth, flowering, dormancy, fertilizer, pruning},
+  care: {weekly, monthly, yearly, extraTips}
+}
+```
+
+### `gardens`
+
+Document représentant un jardin créé par un utilisateur. Les plantes placées sont **embedded** dans le document plutôt que stockées dans une collection séparée — la lecture d'un jardin entier ne coûte qu'un `findOne`.
+
+| Champ | Type | Notes |
+|---|---|---|
+| `_id` | ObjectID | Clé primaire Mongo. |
+| `uid` | string | UID du propriétaire (FK logique vers `users.uid`). Filtré dans tous les CRUD. |
+| `name` | string | Nom affiché à l'utilisateur. |
+| `wizard` | `GardenWizardData` | Choix du wizard de création (style, spaceType, exposure, maintenance, safety, soil, scanMethod). |
+| `plants` | array<`PlacedPlant`> | Plantes placées dans le jardin (voir ci-dessous). |
+| `thumbnailKey` | string (optionnel) | Clé d'image utilisée par la home pour la vignette du jardin. |
+| `createdAt`, `updatedAt` | date | Timestamps gérés par le backend (`updateGarden` met à jour `updatedAt`). |
+
+Sous-document `PlacedPlant` :
+
+| Champ | Type | Notes |
+|---|---|---|
+| `plantId` | ObjectID | FK vers `plants._id`. |
+| `x`, `y`, `z` | float | Position 3D **dans le repère du jardin** (pas dans le repère monde ARKit, qui est local-only iOS). |
+| `note` | string (optionnel) | Note libre attachée à la plante. |
+
+⚠️ **Limite actuelle** : la position 3D persistée côté serveur n'inclut pas la rotation ni l'échelle. Les transformations 4×4 réelles vivent uniquement dans le `scene_{id}.json` local côté iOS (cf. issue #114 sur la perte de données après réinstallation).
+
+### `consents` — RGPD
+
+Trace d'audit des consentements donnés ou retirés par l'utilisateur. Une entrée est créée à chaque action (accept/decline), jamais modifiée — l'historique complet est ainsi préservé pour les obligations RGPD.
+
+| Champ | Type | Notes |
+|---|---|---|
+| `_id` | ObjectID | Clé primaire. |
+| `uid` | string | UID utilisateur (FK logique vers `users.uid`). |
+| `consentType` | string | `"terms"`, `"privacy"`, `"marketing"`, etc. Issue #67 prévoit d'étendre la liste. |
+| `version` | string | Version du document de consentement présenté (pour traçabilité d'évolution des CGU). |
+| `granted` | bool | `true` si accepté, `false` si refusé/retiré. |
+| `timestamp` | date | Date de l'action. Auto-set à `time.Now()` si absent. |
+| `ipAddress` | string | IP du client. Auto-set à `c.ClientIP()` si absent. |
+| `userAgent` | string | User-Agent HTTP. Auto-set si absent. |
+
+## Index recommandés
+
+Aucun index custom n'est défini explicitement à ce jour ; Mongo crée automatiquement l'index sur `_id`. Les filtres les plus fréquents et qui devraient bénéficier d'index sont :
+
+| Collection | Filtre fréquent | Index suggéré |
+|---|---|---|
+| `users` | `bson.M{"uid": uid}` | `{uid: 1}` unique |
+| `gardens` | `bson.M{"uid": uid}` | `{uid: 1, updatedAt: -1}` composite (tri Home) |
+| `gardens` | `bson.M{"_id": id, "uid": uid}` | `{uid: 1, _id: 1}` |
+| `consents` | `bson.M{"uid": uid}` avec sort timestamp | `{uid: 1, timestamp: -1}` |
+
+À évaluer une fois le volume réel des collections connu en production.
+
+## Relations entre collections
+
+Toutes les relations sont **logiques** (par `uid` ou `ObjectID`), aucune n'est imposée par Mongo. La cohérence repose sur :
+
+- `deleteUser` qui supprime en cascade : gardens puis consents puis le user lui-même (cf. main.go).
+- Les filtres `bson.M{"_id": id, "uid": uid}` qui garantissent l'ownership sur update et delete des jardins.
+- Les middlewares qui injectent l'`uid` issu du token, jamais accepté du body.
+
+## Hors-scope de cette vue
+
+- Le détail des fonctions de génération de plantes (`generateAndInsertPlant` et son pipeline IA + Unsplash) relève de [`03-components-backend.md`](03-components-backend.md).
+- Les flows de sauvegarde côté iOS (`GardenLocalStore` qui produit `scene_{id}.json` et `worldmap_{id}.arworldmap`) sont propres au client et n'apparaissent pas dans Mongo. Ils sont décrits dans [`03-components-ios.md`](03-components-ios.md).
+- Les sequences de signup et de save jardin seront documentées dans `flows/*.md` (Phase 3).


### PR DESCRIPTION
Phase 2 de la documentation prévue dans #141 — ouvre les containers iOS et Go vus en phase 1 (PR #142).

## Contenu

- **`docs/architecture/03-components-ios.md`** : trois couches (présentation, domaine, infrastructure) avec diagramme de topologie vertical, tableaux détaillant les modules de chaque couche, et zoom dédié sur le sous-module `ManualReplacement/` (RelocationPhase, MeanValueCoordinates, GardenMorpher, DistortionAnalyzer, overlays). Frameworks Apple utilisés listés.
- **`docs/architecture/03-components-backend.md`** : chaîne de middleware (`APIKeyMiddleware` → `FirebaseAuthMiddleware`), handlers regroupés par domaine (`users`, `plants`, `gardens`, `consents`, `models`), couche d'accès aux données et clients externes (Mongo, Unsplash, AI Generator), variables d'environnement et leur sensibilité, et points clés sécurité (références aux issues #119 et #121).
- **`docs/architecture/04-data-model.md`** : diagramme ER MongoDB et schémas détaillés des quatre collections (`users`, `plants`, `gardens`, `consents`). Sous-documents `PlacedPlant` et `LanguageData` documentés. Index recommandés à activer une fois le volume connu.

## Choix de rendu

Suite à la review de la PR #142 (chevauchements d'arêtes sur les diagrammes denses), tous les diagrammes de cette phase sont conçus en **`flowchart TB` vertical** avec un **diagramme de topologie réduit + tableaux prose** pour le détail des modules. Cette approche reste lisible dans la preview VSCode et sur la mobile view de GitHub.

## Vérification

- [x] Pas de chevauchement d'arêtes sur les trois diagrammes
- [x] Tableaux prose pour le détail des modules (au lieu d'entasser tout dans un méga-diagramme)
- [x] Ton documentation formel (impersonnel) maintenu
- [x] Liens internes cohérents (vers `01-context.md`, `02-containers.md`, et phases ultérieures clairement marquées)
- [x] Références issues vérifiées (#84, #89, #90, #91, #111, #114, #117, #119, #121, #123, #124, #138)

## Suite

Phase 3 (1 PR, ~2h) : `state-machines/relocation-phase.md`, `flows/auth-signup.md`, `flows/garden-creation.md`, `flows/ar-placement.md`.

Refs #141 — Phase 2 du plan.