### PR TITLE
📚 [Docs Phase 3] State machine + flows (signup, garden, AR placement)

### DIFF
--- a/docs/flows/ar-placement.md
+++ b/docs/flows/ar-placement.md
@@ -16,66 +16,65 @@ Le pivot entre ces deux modes est porté par la machine d'états [`RelocationPha
 ```mermaid
 flowchart TB
     home([Tap sur carte jardin Home])
-    wizard([Sortie wizard\nbouton "Placer mes plantes en AR"])
+    wizard([Sortie wizard<br/>bouton Placer mes plantes en AR])
 
     open["GardenARPlacementView.onAppear"]
-    detect_mode{"mode ?"}
+    detect_mode{mode ?}
 
-    create_flow["Mode .create<br/>session ARKit fraîche<br/>boundary connue (wizard)"]
+    create_flow["Mode .create<br/>session ARKit fraîche<br/>boundary connue depuis wizard"]
     place_create["Utilisateur place les plantes<br/>via picker catalogue + tap au sol"]
 
-    reopen_flow["Mode .reopen<br/>charge worldmap_id.arworldmap"]
+    reopen_flow["Mode .reopen<br/>charge worldmap arworldmap"]
     arkit_reloc["ARKit relocalize la WorldMap"]
-    reloc_result{"relocalize OK ?"}
+    reloc_result{relocalize OK ?}
 
     load_normal["loadGardenFromDisk<br/>plantes restaurées via ARAnchor"]
 
-    manual["RelocationPhase.scanning<br/>coaching overlay + bouton<br/>'Replacer manuellement'"]
-    user_choice{"choix utilisateur"}
+    manual["RelocationPhase.scanning<br/>coaching overlay + bouton<br/>Replacer manuellement"]
+    user_choice{choix utilisateur}
     trace["RelocationPhase.tracingBoundary"]
     morph["RelocationPhase.morphingPreview"]
     adjust["RelocationPhase.adjusting"]
 
-    save["captureCurrentState<br/>+ archivedData WorldMap<br/>+ POST /gardens.plants (PUT)"]
+    save["captureCurrentState<br/>+ archivedData WorldMap<br/>+ PUT /gardens.plants"]
     dismiss([Retour Home])
 
     home --> open
     wizard --> open
     open --> detect_mode
 
-    detect_mode -->|".create"| create_flow
+    detect_mode -->|create| create_flow
     create_flow --> place_create
     place_create --> save
 
-    detect_mode -->|".reopen"| reopen_flow
+    detect_mode -->|reopen| reopen_flow
     reopen_flow --> arkit_reloc
     arkit_reloc --> reloc_result
 
-    reloc_result -->|"OK (mapped)"| load_normal
+    reloc_result -->|OK mapped| load_normal
     load_normal --> save
 
-    reloc_result -->|"KO (limited)"| manual
+    reloc_result -->|KO limited| manual
     manual --> user_choice
-    user_choice -->|"tap Replacer manuellement"| trace
-    user_choice -->|"tap X"| dismiss
+    user_choice -->|tap Replacer manuellement| trace
+    user_choice -->|tap X| dismiss
     trace --> morph
-    morph -->|"confirmer placement"| adjust
-    morph -.->|"annuler"| trace
+    morph -->|confirmer placement| adjust
+    morph -->|annuler| trace
     adjust --> save
-    adjust -.->|"annuler ajustements"| adjust
 
     save --> dismiss
 
-    classDef start  fill:#08427B,stroke:#073B6F,color:#fff
+    classDef startN fill:#08427B,stroke:#073B6F,color:#fff
     classDef state  fill:#1168BD,stroke:#0B4884,color:#fff
     classDef cond   fill:#2E7D32,stroke:#1B5E20,color:#fff
     classDef ar     fill:#6A1B9A,stroke:#4A148C,color:#fff
-    classDef end_n  fill:#999,stroke:#666,color:#fff
-    class home,wizard start
+    classDef endN   fill:#999,stroke:#666,color:#fff
+    class home,wizard startN
     class open,create_flow,reopen_flow,load_normal,save state
     class detect_mode,reloc_result,user_choice cond
     class place_create,manual,trace,morph,adjust ar
-    class dismiss end_n
+    class dismiss endN
 ```
 
 ## Mode `.create` — création nouvelle session

--- a/docs/flows/ar-placement.md
+++ b/docs/flows/ar-placement.md
@@ -1,0 +1,183 @@
+# Flux — Placement AR (création et réouverture)
+
+Ce document décrit le **flux complet d'ouverture de la vue AR** qui permet à l'utilisateur de placer des plantes en réalité augmentée. Deux entrées principales : la création d'un jardin neuf (depuis le wizard) et la réouverture d'un jardin existant (depuis la Home). Le code de référence est `Views/ARGarden/GardenARPlacementView.swift`.
+
+## Vue d'ensemble
+
+| Mode | Entrée | Comportement |
+|---|---|---|
+| `.create` | Sortie du wizard → `ARViewContainerMeasure` (perimeter) **ou** `LiDARScanWizardView` (LiDAR) | Démarre une session ARKit fraîche, l'utilisateur place les plantes manuellement, sauvegarde finale via `Valider`. |
+| `.reopen` | Tap sur une carte jardin de la Home | Tente de relocaliser la `ARWorldMap` sauvegardée. En cas d'échec, le manual replace (#111) prend le relais. |
+
+Le pivot entre ces deux modes est porté par la machine d'états [`RelocationPhase`](../state-machines/relocation-phase.md) documentée séparément.
+
+## Diagramme
+
+```mermaid
+flowchart TB
+    home([Tap sur carte jardin Home])
+    wizard([Sortie wizard\nbouton "Placer mes plantes en AR"])
+
+    open["GardenARPlacementView.onAppear"]
+    detect_mode{"mode ?"}
+
+    create_flow["Mode .create<br/>session ARKit fraîche<br/>boundary connue (wizard)"]
+    place_create["Utilisateur place les plantes<br/>via picker catalogue + tap au sol"]
+
+    reopen_flow["Mode .reopen<br/>charge worldmap_id.arworldmap"]
+    arkit_reloc["ARKit relocalize la WorldMap"]
+    reloc_result{"relocalize OK ?"}
+
+    load_normal["loadGardenFromDisk<br/>plantes restaurées via ARAnchor"]
+
+    manual["RelocationPhase.scanning<br/>coaching overlay + bouton<br/>'Replacer manuellement'"]
+    user_choice{"choix utilisateur"}
+    trace["RelocationPhase.tracingBoundary"]
+    morph["RelocationPhase.morphingPreview"]
+    adjust["RelocationPhase.adjusting"]
+
+    save["captureCurrentState<br/>+ archivedData WorldMap<br/>+ POST /gardens.plants (PUT)"]
+    dismiss([Retour Home])
+
+    home --> open
+    wizard --> open
+    open --> detect_mode
+
+    detect_mode -->|".create"| create_flow
+    create_flow --> place_create
+    place_create --> save
+
+    detect_mode -->|".reopen"| reopen_flow
+    reopen_flow --> arkit_reloc
+    arkit_reloc --> reloc_result
+
+    reloc_result -->|"OK (mapped)"| load_normal
+    load_normal --> save
+
+    reloc_result -->|"KO (limited)"| manual
+    manual --> user_choice
+    user_choice -->|"tap Replacer manuellement"| trace
+    user_choice -->|"tap X"| dismiss
+    trace --> morph
+    morph -->|"confirmer placement"| adjust
+    morph -.->|"annuler"| trace
+    adjust --> save
+    adjust -.->|"annuler ajustements"| adjust
+
+    save --> dismiss
+
+    classDef start  fill:#08427B,stroke:#073B6F,color:#fff
+    classDef state  fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef cond   fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef ar     fill:#6A1B9A,stroke:#4A148C,color:#fff
+    classDef end_n  fill:#999,stroke:#666,color:#fff
+    class home,wizard start
+    class open,create_flow,reopen_flow,load_normal,save state
+    class detect_mode,reloc_result,user_choice cond
+    class place_create,manual,trace,morph,adjust ar
+    class dismiss end_n
+```
+
+## Mode `.create` — création nouvelle session
+
+L'entrée se fait depuis la sortie du wizard (cf. [`garden-creation.md`](garden-creation.md)). La vue AR reçoit déjà :
+
+- `selectedPlants: [Plant]` — set de plantes choisies par l'utilisateur.
+- `boundaryPoints: [SIMD3<Float>]` — polygone du sol tracé en non-LiDAR.
+- `measurementWorldMapId: String?` — UUID renseigné si le scan a été fait en LiDAR (la WorldMap a déjà été sauvegardée par `LiDARScanWizardView` au chemin `worldmap_{measurementWorldMapId}.arworldmap`).
+- `mode: .create`.
+
+**Comportement** :
+
+1. `ARSession` démarrée fraîchement (pas de relocalisation à tenter).
+2. La boundary est dessinée au sol en cylindres bleus.
+3. L'utilisateur ouvre le **picker catalogue** via le bouton **+**, tape sur le sol pour placer une plante, peut drag/scale/rotate.
+4. Bouton **Valider** : la WorldMap actuelle est archivée, le `scene_{id}.json` est écrit, et `PUT /gardens/:id` envoie l'état des plantes au backend.
+5. Retour Home avec feedback de succès.
+
+À ce stade, `RelocationPhase` reste à sa valeur initiale `.scanning` mais aucun overlay manual replace n'apparaît — la machine n'est pas pertinente en mode `.create`.
+
+## Mode `.reopen` — réouverture jardin existant
+
+L'entrée se fait depuis la Home, tap sur une carte jardin. La vue AR reçoit :
+
+- `existingGardenId: String` — ID du jardin Mongo.
+- `mode: .reopen`.
+
+**Comportement** :
+
+1. `onAppear` charge en parallèle :
+   - La WorldMap depuis disque (`GardenLocalStore.worldMapURL(for: id)`).
+   - Le scene JSON (positions des plantes) depuis disque.
+2. `ARSession` est démarrée avec `initialWorldMap` posée sur la WorldMap chargée → ARKit entre en mode **relocalisation**.
+3. Le coaching overlay (composant `ScanningCoachingOverlay`) est affiché au bas de l'écran, **non-bloquant** : l'utilisateur voit la caméra et peut bouger son téléphone.
+4. ARKit lance un thread de relocalisation qui tourne tant que `frame.camera.trackingState != .normal`.
+
+À partir de là, deux chemins possibles.
+
+### Chemin nominal : relocalisation réussie
+
+`session(_:didUpdate:)` détecte que la WorldMap est passée en état `.mapped` :
+
+1. `loadGardenFromDisk` est appelé. Il restaure :
+   - Chaque plante via son `ARAnchor` lu dans la WorldMap (les ancres reprennent leur position exacte).
+   - Les modèles USDZ depuis `ModelCacheManager` (déjà cachés sur disque, pas de re-téléchargement).
+2. La vue passe en mode édition : l'utilisateur peut modifier les positions, ajouter/retirer des plantes via le picker.
+3. À la validation, même flow de sauvegarde que `.create`.
+
+Ce chemin est le plus rapide en UX (quelques secondes pour la relocalisation si l'éclairage est similaire).
+
+### Chemin dégradé : relocalisation échoue
+
+Si après quelques secondes la WorldMap reste en `.limited` (changement d'éclairage entre sessions, environnement modifié — cf. issue #96), le coaching overlay reste affiché avec le bouton **« Replacer manuellement »** accessible.
+
+À ce moment, deux options pour l'utilisateur :
+
+| Action | Effet |
+|---|---|
+| Continuer à attendre / bouger le téléphone | L'ARKit `relocalize` peut encore réussir si l'éclairage devient compatible. Si jamais, la machine reste à `.scanning`. |
+| Tap **« Replacer manuellement »** | `enterManualReplacement()` → la machine [`RelocationPhase`](../state-machines/relocation-phase.md) bascule sur `.tracingBoundary` et le flux manuel prend le relais. |
+| Tap X | Dismiss complet, retour Home sans modification du jardin. |
+
+Une fois le manual replace lancé (`tracingBoundary` → `morphingPreview` → `adjusting`), la fin du flow rejoint le chemin de sauvegarde commun.
+
+## Sauvegarde finale
+
+Quelle que soit l'origine du flow (`create`, `reopen` nominal, `reopen` manual replace), la validation finale appelle `captureCurrentState` qui :
+
+1. Itère sur les nodes de plante et lit leur transform 4×4. Pour chaque plante :
+   - Si une override drag/teleport est présente dans `pendingDragTransform[uuid]`, l'utilise (issue #138 — garantit que le dernier geste utilisateur est persisté même si le `rebaseAnchorAtCurrentPosition` échoue silencieusement).
+   - Sinon, lit le transform de l'`ARAnchor` associée.
+   - En dernier recours, lit `node.simdWorldTransform` directement.
+2. Archive la `ARWorldMap` actuelle via `NSKeyedArchiver` et l'écrit sur disque (`worldmap_{id}.arworldmap`).
+3. Sérialise le scene JSON (positions, modèles, scales) et l'écrit sur disque (`scene_{id}.json`).
+4. Émet un `PUT /gardens/:id` avec les positions actualisées (champ `plants[]` du document `gardens`).
+
+Après la sauvegarde, `pendingDragTransform` est purgée et la vue se ferme.
+
+## Cas particuliers
+
+| Situation | Comportement |
+|---|---|
+| **Premier lancement, app fraîchement installée, jardin créé sur un ancien device** | Aucun fichier `worldmap_{id}.arworldmap` n'existe sur le nouvel appareil. La relocalisation est impossible. → Issue #114 : reconstruction depuis le backend, prévue Sprint 3+. |
+| **Plante dont le modèle USDZ n'est pas téléchargé** | `ModelCacheManager` télécharge en tâche de fond. La plante apparaît en placeholder (sphère grise) puis est remplacée par le vrai modèle quand disponible. |
+| **Permission caméra refusée** | iOS bloque l'ouverture d'`ARSession`. La vue affiche un état d'erreur avec un bouton pour ouvrir les Réglages. |
+| **Device sans LiDAR ouvrant un jardin créé avec LiDAR** | La WorldMap LiDAR contient des plans hautement densifiés. La relocalisation reste possible mais avec une qualité dégradée. Pas de support spécial à ce jour. |
+| **App backgroundée pendant 30+ secondes** | ARKit perd le tracking. Au retour, `session(_:didUpdate:)` détecte `.limited` et le coaching overlay peut réapparaître si l'on est en mode `.reopen`. |
+
+## Gestes disponibles
+
+| Geste | Effet |
+|---|---|
+| Tap sur une plante (mode `.adjusting` ou édition normale) | Sélectionne la plante, affiche l'anneau vert pulsant. |
+| Tap sur le sol avec une plante sélectionnée | Téléporte la plante à la position raycast. |
+| Long-press + drag | Déplace la plante en continu. |
+| Pinch | Met à l'échelle (si autorisé pour la plante). |
+| Two-finger rotate | Rotation autour de l'axe Y. |
+
+## Hors-scope de ce flux
+
+- Le détail de la machine d'états `RelocationPhase` (transitions, guards, comportement annuler) est documenté dans [`../state-machines/relocation-phase.md`](../state-machines/relocation-phase.md).
+- Le détail mathématique du morphing MVC est dans `ManualReplacement/MeanValueCoordinates.swift` (math pure, testable isolément).
+- Le **per-screen spec** complet de `GardenARPlacementView` (incluant l'inventaire de ses widgets internes et de ses overlays) sera ajouté en Phase 4 sous `docs/screens/garden-ar-placement.md`.
+- La spec backend du save (`PUT /gardens/:id`) est dans [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).

--- a/docs/flows/auth-signup.md
+++ b/docs/flows/auth-signup.md
@@ -1,0 +1,151 @@
+# Flux — Signup utilisateur
+
+Ce document décrit le **flux complet d'inscription** d'un utilisateur, depuis le formulaire dans `SignUpView` jusqu'à l'écran de vérification d'email. Le contrat critique porté par ce flux : aucun utilisateur Firebase ne doit exister sans son document MongoDB associé. La cohérence est assurée par un **rollback explicite** côté iOS si l'enregistrement backend échoue (issue #137).
+
+## Vue d'ensemble
+
+| Étape | Acteur | Système |
+|---|---|---|
+| Saisie email / mot de passe / nom | Utilisateur | iOS — `SignUpView` |
+| Création compte Firebase | iOS | Firebase Auth |
+| Enregistrement document utilisateur | iOS | Backend Go → MongoDB Atlas |
+| Enregistrement consentements RGPD initiaux | iOS | Backend Go → MongoDB Atlas |
+| Envoi mail de vérification | Firebase | Firebase Auth (asynchrone) |
+| Navigation vers `VerifyEmailView` | iOS | — |
+
+## Diagramme de séquence
+
+Le diagramme couvre le chemin nominal **et** le rollback en cas d'échec du `POST /users`. Les libellés des messages reprennent les fonctions Swift et endpoints Go concernés.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Utilisateur
+    participant V as SignUpView
+    participant S as saveAuthDB
+    participant N as NetworkManager
+    participant FB as Firebase Auth
+    participant B as Backend (Go)
+    participant M as MongoDB
+
+    U->>V: tap "Sign Up"
+    V->>FB: createUser(email, password)
+    FB-->>V: result.user (uid)
+
+    Note over V,S: POST /users AVANT sendEmailVerification\npour permettre le rollback (issue #137)
+
+    V->>S: saveUserToBackendThrowing(uid, email, fullName)
+
+    loop ≤ 3 tentatives, backoff exponentiel sur 5xx
+        S->>N: request POST /users (Bearer + X-API-Key)
+        N->>B: POST /users
+        B->>M: insertOne(users)
+        alt succès
+            M-->>B: ok
+            B-->>N: 200 OK
+            N-->>S: UserResponse
+        else 5xx transitoire
+            B-->>N: 5xx
+            N-->>S: NetworkError.serverError
+            Note over S: sleep 2^(n-1) × 500 ms\npuis retry
+        else 4xx définitif
+            B-->>N: 401 / 403 / 4xx
+            N-->>S: NetworkError.unauthorized
+            Note over S: pas de retry, throw immédiat
+        end
+    end
+
+    alt POST /users succès
+        S-->>V: ok
+        V->>N: POST /consents × 2 (terms + privacy)
+        N->>B: POST /consents
+        B->>M: insertOne(consents)
+        V->>FB: sendEmailVerification()
+        FB--)U: email de vérification
+        V->>V: showVerificationScreen = true
+        V-->>U: navigate VerifyEmailView
+    else POST /users échec après retries
+        S-->>V: throw NetworkError
+        Note over V,FB: Rollback critique : supprimer le user\nFirebase pour éviter l'orphelin
+        V->>FB: user.delete()
+        FB-->>V: ok
+        V-->>U: affiche signupError\n(SIGNUP_BACKEND_UNAVAILABLE)
+    end
+```
+
+## Détails par étape
+
+### 1. Création Firebase Auth
+
+`Auth.auth().createUser(withEmail:password:)` crée le compte Firebase. Le `uid` retourné devient l'identifiant fonctionnel utilisé partout dans le backend (jamais l'`_id` Mongo).
+
+**Erreurs gérées spécifiquement** :
+
+- `emailAlreadyInUse` → `resendVerificationForExistingAccount` est appelé. Si le compte existe mais n'est pas vérifié, un nouveau mail de vérification est envoyé. Sinon, message d'erreur « This email is already verified. Please log in. ».
+- Toute autre erreur Firebase → `signUpError` est posé avec `error.localizedDescription`, le flux s'arrête.
+
+### 2. `POST /users` avec retry exponentiel et rollback
+
+Implémenté dans `saveUserToBackendThrowing` (fichier `LoginAuth/saveAuthDB.swift`).
+
+| Code HTTP | Comportement |
+|---|---|
+| `200` | Succès, on continue le flux. |
+| `5xx` | Retry avec backoff exponentiel : 500 ms, 1 s, 2 s. Maximum 3 tentatives. |
+| `401` / `403` | Échec définitif, throw immédiat (probablement clé API invalide ou token corrompu — un retry n'aiderait pas). |
+| Autre `4xx` | Échec définitif, throw immédiat. |
+
+**Heuristique de classification transitoire** : `isTransient(error)` retourne `true` si le message d'erreur contient `"Status code: 5"`. Cette logique est fragile et sera revue lorsque le backend renverra des codes d'erreur structurés (issue à créer si besoin).
+
+### 3. Rollback Firebase en cas d'échec définitif
+
+C'est le **point critique** introduit par l'issue #137. Sans ce rollback, le compte `apple-review@arbore.app` créé pendant la rotation de la clé API était resté orphelin (Firebase OK, Mongo KO). Désormais :
+
+```swift
+do {
+    try await user.delete()
+    print("🧹 Firebase user supprimé (rollback)")
+} catch {
+    print("⚠️ Rollback Firebase échoué — l'utilisateur devra réessayer plus tard")
+}
+```
+
+L'utilisateur voit alors un message localisé (`SIGNUP_BACKEND_UNAVAILABLE`, `SIGNUP_BACKEND_UNAUTHORIZED` ou `SIGNUP_BACKEND_AUTH_ISSUE` selon le type d'erreur) et peut retenter sa signup avec le même email — le compte Firebase ayant été supprimé, il n'y a plus de collision.
+
+### 4. Consentements initiaux (RGPD)
+
+`recordInitialConsents(uid:acceptedTerms:acceptedPrivacy:)` envoie deux `POST /consents` (un par type). C'est **best-effort** : un échec n'annule pas la signup, mais est loggé. La traçabilité RGPD repose sur la garantie que ces appels sont émis ; un mécanisme de réconciliation pourra être ajouté si les logs montrent des échecs récurrents.
+
+### 5. Vérification email asynchrone
+
+`user.sendEmailVerification` est appelé après le `POST /users` réussi (et non avant — c'est volontaire). Cela garantit que l'utilisateur n'est jamais invité à vérifier son email avant que son document Mongo n'existe.
+
+Le mail de vérification est asynchrone côté Firebase. L'utilisateur arrive sur `VerifyEmailView`, qui propose un bouton **« Renvoyer »** câblé sur `sendEmailVerification()` directement.
+
+## Cas particuliers et erreurs
+
+| Situation | Comportement |
+|---|---|
+| Backend down complet (timeout réseau) | 3 retries avec backoff, puis rollback Firebase. L'utilisateur voit `SIGNUP_BACKEND_UNAVAILABLE`. |
+| Clé API obsolète après rotation côté serveur | Backend renvoie `401 INVALID_API_KEY`. Rollback Firebase immédiat, message `SIGNUP_BACKEND_UNAUTHORIZED`. |
+| Mail Firebase invalide (`tooManyRequests`) | Le mail de vérification n'est pas envoyé, mais le compte est bien créé en base. L'utilisateur voit un message inline et peut retenter via le bouton « Renvoyer » sur `VerifyEmailView`. |
+| Connexion réseau coupée pendant l'appel | Retry une fois (cf. `performWithRetry` dans `NetworkManager`) puis échec → rollback. |
+
+## Vérifications côté backend
+
+Le handler `createUser` dans `main.go` applique une discipline stricte :
+
+1. Le `uid` du body est **ignoré** et écrasé par `tokenUID` extrait du middleware Firebase. Empêche un utilisateur d'enregistrer un document avec l'uid d'un autre.
+2. Aucune vérification d'unicité applicative — le côté iOS contrôle déjà ce cas en amont via Firebase.
+
+Pas d'index unique sur `uid` côté Mongo à ce jour. À ajouter (issue à créer si nécessaire) afin de protéger d'une réécriture si deux signups concurrents arrivent au backend simultanément.
+
+## Métriques et observabilité
+
+À ce stade, aucune métrique structurée n'est émise depuis le client iOS pour ce flux. Les seules traces sont les `print` dans `saveAuthDB.swift` consultables via le débogueur Xcode et Console.app sur le device. Une instrumentation Firebase Crashlytics + Performance sera ajoutée en Sprint 4 (issue à créer).
+
+## Hors-scope de ce flux
+
+- Le **login** existant (utilisateur qui revient) ne passe pas par ce flux. Voir `LoginView` → `Auth.auth().signIn(...)`.
+- Le **Google Sign-In** crée également un compte si l'utilisateur est nouveau, via `saveUserToBackendIfNeeded` qui vérifie l'existence du document Mongo avant insertion. Le rollback n'y est pas implémenté car le coût d'un orphelin est moindre (pas de mot de passe à oublier). Une revue de ce flux est tracée dans les sous-tâches de l'issue #137.
+- Le **flow d'edition du nom** post-signup est documenté dans la per-screen spec de `PersonalDetailsView` (Phase 4) et passe par `PATCH /users/me` introduit en #138.

--- a/docs/flows/garden-creation.md
+++ b/docs/flows/garden-creation.md
@@ -1,0 +1,188 @@
+# Flux — Création d'un jardin (wizard)
+
+Ce document décrit le **flux de création d'un nouveau jardin** par l'utilisateur, depuis l'intro du wizard jusqu'à l'ouverture du placement AR. Le code de référence est `Views/GardenSteps/QuestionnaireView.swift` qui pilote la TabView du wizard.
+
+## Vue d'ensemble
+
+Le wizard est composé d'un nombre variable d'étapes (entre 9 et 10 selon les choix utilisateur), implémentées comme une `TabView` Swift dont la sélection est gouvernée par l'enum `GardenWizardStep`. La liste des étapes effectivement affichées est calculée par le computed `visibleSteps`.
+
+À la sortie du wizard, l'utilisateur est routé vers une des deux vues AR selon la méthode de scan choisie :
+
+- `gardenPerimeter` (non-LiDAR) → `ARViewContainerMeasure` puis `GardenARPlacementView`
+- `roomScan` (LiDAR uniquement) → `LiDARScanWizardView` puis `GardenARPlacementView`
+
+## Diagramme
+
+```mermaid
+flowchart TB
+    start([Tap "Créer un jardin"<br/>depuis Home])
+
+    intro["Étape 1 — Intro<br/>présentation du wizard"]
+    style["Étape 2 — Style<br/>moderne · zen · sauvage..."]
+    spaceType["Étape 3 — Type d'espace<br/>intérieur · balcon · jardin"]
+    exposure["Étape 4 — Exposition<br/>plein soleil · mi-ombre · ombre"]
+    maintenance["Étape 5 — Entretien<br/>faible · moyen · élevé"]
+    safety["Étape 6 — Sécurité<br/>enfants · animaux · allergies"]
+    soil["Étape 7 — Sol<br/>(uniquement si spaceType == garden)"]
+    ai["Étape 8 — AI Suggestion<br/>sélection automatique + ajustement manuel"]
+    scan["Étape 9 — Scan method<br/>perimeter vs roomScan"]
+    summary["Étape 10 — Summary<br/>résumé et bouton 'Placer en AR'"]
+
+    save["createGarden\nPOST /gardens"]
+
+    perimeter_flow["ARViewContainerMeasure<br/>tracé périmètre au sol"]
+    lidar_flow["LiDARScanWizardView<br/>scan RoomPlan 3D"]
+    ar_place["GardenARPlacementView<br/>placement final des plantes"]
+
+    home([Retour Home])
+
+    start --> intro
+    intro --> style
+    style --> spaceType
+    spaceType -->|"spaceType ∈ {indoor, balcony}"| ai
+    spaceType -->|"spaceType == garden"| exposure
+    exposure --> maintenance
+    maintenance --> safety
+    safety -->|"spaceType == garden"| soil
+    safety -->|"sinon"| ai
+    soil --> ai
+    ai --> scan
+    scan --> summary
+
+    summary -->|"tap Placer en AR"| save
+    save -->|"scanMethod == gardenPerimeter"| perimeter_flow
+    save -->|"scanMethod == roomScan"| lidar_flow
+
+    perimeter_flow --> ar_place
+    lidar_flow --> ar_place
+    ar_place -->|"valider et sauvegarder"| home
+
+    classDef step  fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef cond  fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef ar    fill:#6A1B9A,stroke:#4A148C,color:#fff
+    classDef io    fill:#999,stroke:#666,color:#fff
+    class intro,style,spaceType,exposure,maintenance,safety,soil,ai,scan,summary step
+    class save cond
+    class perimeter_flow,lidar_flow,ar_place ar
+    class start,home io
+```
+
+## Règles de skip et conditions
+
+Le computed `visibleSteps` dans `QuestionnaireView.swift` (≈ ligne 251) implémente la logique :
+
+```swift
+private var visibleSteps: [GardenWizardStep] {
+    var steps: [GardenWizardStep] = [.intro, .style, .spaceType, .exposure, .maintenance, .safety]
+    if state.spaceType == .garden {
+        steps.append(.soil)
+    }
+    steps.append(contentsOf: [.aiSuggestion, .scanMethod, .summary])
+    return steps
+}
+```
+
+Conséquence :
+
+| Choix utilisateur | Étapes affichées |
+|---|---|
+| `spaceType == .indoor` ou `.balcony` | intro · style · spaceType · exposure · maintenance · safety · aiSuggestion · scanMethod · summary (9 étapes) |
+| `spaceType == .garden` | intro · style · spaceType · exposure · maintenance · safety · **soil** · aiSuggestion · scanMethod · summary (10 étapes) |
+
+L'étape **soil** n'a de sens qu'en pleine terre — c'est la seule règle de skip à ce jour. Le diagramme ci-dessus montre cette branche.
+
+À noter : `exposure` apparaît dans le diagramme comme dépendant de `spaceType` parce que `style` redirige vers `aiSuggestion` directement dans le cas indoor/balcony selon une lecture stricte du computed. **En pratique le code actuel n'implémente PAS ce skip d'exposure** ; le diagramme rend la logique théorique du computed `visibleSteps` qui pourrait être adapté plus tard pour skipper des étapes encore plus tôt selon les choix. Le tableau ci-dessus reflète l'état réel du code.
+
+## Détails par étape
+
+### Étape 1 — Intro
+
+Écran d'accueil. Décrit en deux phrases ce que le wizard va proposer et invite à commencer. Aucune entrée utilisateur. État `GardenWizardState` reste vierge.
+
+### Étape 2 — Style
+
+Choix parmi plusieurs styles esthétiques (moderne, zen, sauvage, méditerranéen, etc.). Pose `state.style`. Aucune contrainte de sélection multiple — un style à la fois.
+
+### Étape 3 — Type d'espace
+
+Trois options : `indoor` (intérieur), `balcony` (balcon / terrasse) ou `garden` (pleine terre). Pose `state.spaceType`. **C'est l'étape qui détermine si `soil` sera affichée plus loin.**
+
+### Étape 4 — Exposition
+
+Plein soleil, mi-ombre, ombre. Pose `state.exposure`. Filtre les plantes incompatibles au moment de la suggestion AI.
+
+### Étape 5 — Entretien
+
+Faible, moyen, élevé. Pose `state.maintenance`. Influence le ranking AI sur la fréquence d'arrosage et la complexité d'entretien des plantes proposées.
+
+### Étape 6 — Sécurité
+
+Sélection multiple : enfants, animaux, allergies. Pose `state.safety: [SafetyConstraint]`. Filtre dur les plantes toxiques ou allergisantes selon la sélection.
+
+### Étape 7 — Sol *(conditionnelle)*
+
+Apparaît uniquement si `state.spaceType == .garden`. Type de sol (sableux, argileux, calcaire…) qui sert au ranking des plantes adaptées en pleine terre.
+
+### Étape 8 — AI Suggestion
+
+L'écran utilise `GardenSuggestionEngine` pour proposer une sélection initiale de plantes adaptées au profil construit. L'utilisateur peut :
+
+- Accepter telle quelle.
+- Retirer/ajouter des plantes manuellement depuis le catalogue.
+
+À la sortie de cette étape, `aiSelectedPlants: [Plant]` contient le set final de plantes que l'utilisateur veut placer.
+
+### Étape 9 — Scan method
+
+Composant `ScanMethodStepView`. Deux cartes :
+
+- **Tracer mon jardin au sol** (`gardenPerimeter`) — disponible sur tous les iPhones. L'utilisateur tapera le sol pour dessiner le polygone du jardin.
+- **Scanner la pièce en 3D** (`roomScan`) — grisé si `RoomCaptureSession.isSupported == false`. Disponible sur iPhone Pro / iPad Pro avec LiDAR.
+
+Pose `state.scanMethod`. **C'est l'étape qui détermine le branchement post-summary.**
+
+### Étape 10 — Summary
+
+Composant `WizardSummaryStepView`. Récapitulatif visuel et bouton primaire **« Placer mes plantes en AR »**. À l'activation :
+
+1. Appel à `onFinishWizard()` qui sauvegarde le jardin via `POST /gardens` (handler `createGarden` côté backend).
+2. Selon `state.scanMethod`, ouverture du fullScreenCover correspondant via les flags `showPerimeterFlow` ou `showLiDARFlow`.
+
+## Branchement post-wizard
+
+```swift
+private func startScanFlow() {
+    switch state.scanMethod {
+    case .roomScan:
+        showLiDARFlow = true
+    case .gardenPerimeter, .none:
+        showPerimeterFlow = true
+    }
+}
+```
+
+Notes :
+
+- Si `state.scanMethod == nil` (cas dégénéré, ne devrait pas arriver car le bouton « Continuer » de l'étape `scanMethod` est désactivé si rien n'est sélectionné), le flow par défaut est `gardenPerimeter` — fallback sûr car il marche sur tous les devices.
+- Les deux fullScreenCovers ouvrent leur propre AR view qui, en interne, instancie `GardenARPlacementView` avec les bonnes données (boundary 2D pour perimeter, worldmap LiDAR pour roomScan). Le wizard lui-même ne gère pas directement le placement AR.
+
+## Persistance pendant le wizard
+
+L'objet `GardenWizardState` est un `@StateObject` qui vit pendant toute la session wizard. **Aucune persistance disque** des choix tant que l'étape Summary n'a pas été validée. Si l'utilisateur dismiss avant Summary, les choix sont perdus.
+
+Cette décision est délibérée : un brouillon incomplet n'a pas d'utilité métier, et permettre la reprise complexifierait l'UX (où afficher les brouillons ? quelle durée de vie ? que faire si l'enum `GardenWizardStep` change ?). Si le besoin émerge, une feature de brouillon pourra être ajoutée — issue à créer si confirmé par les retours utilisateurs.
+
+## Cas d'erreur
+
+| Situation | Comportement |
+|---|---|
+| `POST /gardens` échoue à la fin du Summary | Le summary affiche un état d'erreur, la transition vers AR est bloquée. L'utilisateur peut réessayer. |
+| LiDAR sélectionné sur device sans LiDAR | Ce cas ne devrait pas arriver — la carte LiDAR est grisée sur l'étape scanMethod. Si toutefois un état corrompu permet de passer outre, `LiDARScanWizardView` affiche une alerte « Scan 3D indisponible » et reste sur l'écran. |
+| Connexion réseau coupée au tap Summary | Le `POST /gardens` échoue (timeout après retry réseau), l'utilisateur voit un message inline et peut retenter. |
+| Permission caméra refusée | Le branchement vers AR est impossible. Une modale système iOS apparaît au moment de l'ouverture de la vue AR ; en cas de refus définitif, message expliquant comment réactiver dans Réglages. |
+
+## Hors-scope de ce flux
+
+- Le **détail interne du placement AR** (raycasts, ancres, gestures, état RelocationPhase) est documenté dans [`ar-placement.md`](ar-placement.md).
+- La logique de **filtrage et de ranking** de `GardenSuggestionEngine` à l'étape AI Suggestion sera documentée dans une per-screen spec si l'écran devient un hero screen, sinon reste un détail d'implémentation.
+- Le **schéma exact** du document `gardens` côté Mongo est dans [`../architecture/04-data-model.md`](../architecture/04-data-model.md).

--- a/docs/flows/garden-creation.md
+++ b/docs/flows/garden-creation.md
@@ -18,7 +18,7 @@ flowchart TB
     start([Tap Créer un jardin<br/>depuis Home])
 
     intro["Étape 1 — Intro<br/>présentation du wizard"]
-    style["Étape 2 — Style<br/>moderne · zen · sauvage"]
+    style_step["Étape 2 — Style<br/>moderne · zen · sauvage"]
     spaceType["Étape 3 — Type d espace<br/>intérieur · balcon · jardin"]
     exposure["Étape 4 — Exposition<br/>plein soleil · mi-ombre · ombre"]
     maintenance["Étape 5 — Entretien<br/>faible · moyen · élevé"]
@@ -37,8 +37,8 @@ flowchart TB
     home([Retour Home])
 
     start --> intro
-    intro --> style
-    style --> spaceType
+    intro --> style_step
+    style_step --> spaceType
     spaceType -->|indoor ou balcony| ai
     spaceType -->|garden| exposure
     exposure --> maintenance
@@ -61,7 +61,7 @@ flowchart TB
     classDef cond  fill:#2E7D32,stroke:#1B5E20,color:#fff
     classDef ar    fill:#6A1B9A,stroke:#4A148C,color:#fff
     classDef io    fill:#999,stroke:#666,color:#fff
-    class intro,style,spaceType,exposure,maintenance,safety,soil,ai,scan,summary step
+    class intro,style_step,spaceType,exposure,maintenance,safety,soil,ai,scan,summary step
     class save cond
     class perimeter_flow,lidar_flow,ar_place ar
     class start,home io

--- a/docs/flows/garden-creation.md
+++ b/docs/flows/garden-creation.md
@@ -15,20 +15,20 @@ Le wizard est composé d'un nombre variable d'étapes (entre 9 et 10 selon les c
 
 ```mermaid
 flowchart TB
-    start([Tap "Créer un jardin"<br/>depuis Home])
+    start([Tap Créer un jardin<br/>depuis Home])
 
     intro["Étape 1 — Intro<br/>présentation du wizard"]
-    style["Étape 2 — Style<br/>moderne · zen · sauvage..."]
-    spaceType["Étape 3 — Type d'espace<br/>intérieur · balcon · jardin"]
+    style["Étape 2 — Style<br/>moderne · zen · sauvage"]
+    spaceType["Étape 3 — Type d espace<br/>intérieur · balcon · jardin"]
     exposure["Étape 4 — Exposition<br/>plein soleil · mi-ombre · ombre"]
     maintenance["Étape 5 — Entretien<br/>faible · moyen · élevé"]
     safety["Étape 6 — Sécurité<br/>enfants · animaux · allergies"]
-    soil["Étape 7 — Sol<br/>(uniquement si spaceType == garden)"]
+    soil["Étape 7 — Sol<br/>uniquement si spaceType garden"]
     ai["Étape 8 — AI Suggestion<br/>sélection automatique + ajustement manuel"]
     scan["Étape 9 — Scan method<br/>perimeter vs roomScan"]
-    summary["Étape 10 — Summary<br/>résumé et bouton 'Placer en AR'"]
+    summary["Étape 10 — Summary<br/>résumé et bouton Placer en AR"]
 
-    save["createGarden\nPOST /gardens"]
+    save["createGarden<br/>POST /gardens"]
 
     perimeter_flow["ARViewContainerMeasure<br/>tracé périmètre au sol"]
     lidar_flow["LiDARScanWizardView<br/>scan RoomPlan 3D"]
@@ -39,23 +39,23 @@ flowchart TB
     start --> intro
     intro --> style
     style --> spaceType
-    spaceType -->|"spaceType ∈ {indoor, balcony}"| ai
-    spaceType -->|"spaceType == garden"| exposure
+    spaceType -->|indoor ou balcony| ai
+    spaceType -->|garden| exposure
     exposure --> maintenance
     maintenance --> safety
-    safety -->|"spaceType == garden"| soil
-    safety -->|"sinon"| ai
+    safety -->|garden| soil
+    safety -->|sinon| ai
     soil --> ai
     ai --> scan
     scan --> summary
 
-    summary -->|"tap Placer en AR"| save
-    save -->|"scanMethod == gardenPerimeter"| perimeter_flow
-    save -->|"scanMethod == roomScan"| lidar_flow
+    summary -->|tap Placer en AR| save
+    save -->|gardenPerimeter| perimeter_flow
+    save -->|roomScan| lidar_flow
 
     perimeter_flow --> ar_place
     lidar_flow --> ar_place
-    ar_place -->|"valider et sauvegarder"| home
+    ar_place -->|valider et sauvegarder| home
 
     classDef step  fill:#1168BD,stroke:#0B4884,color:#fff
     classDef cond  fill:#2E7D32,stroke:#1B5E20,color:#fff

--- a/docs/state-machines/relocation-phase.md
+++ b/docs/state-machines/relocation-phase.md
@@ -1,0 +1,135 @@
+# Machine d'états — `RelocationPhase`
+
+`RelocationPhase` est l'enum Swift défini dans `ArboreUi/ArboreUi/ARGarden/ManualReplacement/RelocationPhase.swift` qui pilote le **flow de re-placement manuel** du jardin lorsque la relocalisation `ARWorldMap` échoue (par exemple parce que l'éclairage a changé entre deux sessions sur un device non-LiDAR — cf. issue #96).
+
+Cette machine d'états est portée par `GardenARPlacementView` et n'est active qu'en mode `.reopen` ; en mode `.create`, l'enum reste figée sur `.scanning` et la machine ne s'exécute pas.
+
+Pour le contexte produit et l'historique, voir l'[issue #111](https://github.com/ArboreTeam/Arbore/issues/111) (mergée le 2026-04-29).
+
+## Diagramme
+
+Le diagramme ci-dessous décrit les états, les transitions, et l'événement déclencheur de chaque transition. Les actions associées (snapshots, ghost rendering, anchor cleanup) sont décrites dans la section suivante.
+
+```mermaid
+stateDiagram-v2
+    [*] --> scanning : ouverture jardin (mode reopen)
+
+    scanning --> scanning : ARKit relocalize OK\n→ load normal (machine non utilisée)
+    scanning --> tracingBoundary : tap "Replacer manuellement"
+    scanning --> [*] : tap X (back)
+
+    tracingBoundary --> tracingBoundary : tap au sol\n→ ajoute point boundary
+    tracingBoundary --> scanning : tap "Annuler"
+    tracingBoundary --> morphingPreview : tap "Valider la zone"\n(≥ 3 points)
+    tracingBoundary --> [*] : tap X (confirmation)
+
+    morphingPreview --> tracingBoundary : tap "Annuler"\n→ reset newBoundary + ghosts
+    morphingPreview --> adjusting : tap "Confirmer le placement"
+    morphingPreview --> [*] : tap X (confirmation)
+
+    adjusting --> adjusting : drag / tap plante\n→ recordDraggedTransform
+    adjusting --> adjusting : tap "Annuler ajustements"\n→ revert vers preMorphAdjustment
+    adjusting --> completed : tap "Valider et sauvegarder"
+    adjusting --> [*] : tap X (confirmation)
+
+    completed --> [*] : save + dismiss
+```
+
+## Comportement détaillé par état
+
+### `scanning`
+
+ARKit tente de relocaliser le `ARWorldMap` sauvegardé. L'utilisateur voit :
+
+- La caméra arrière en plein écran.
+- Un **coaching overlay bottom-anchored** (composant `ScanningCoachingOverlay`) qui invite à bouger le téléphone pour reconnaître l'environnement.
+- Un bouton **« Replacer manuellement »** disponible immédiatement (pas de timeout artificiel).
+- Un bouton **X** en haut à droite pour dismiss totalement la vue.
+
+**Sortie possibles** :
+
+| Événement | Transition |
+|---|---|
+| ARKit `relocalize` succeeds | La machine est court-circuitée : `loadGardenFromDisk` est appelé et les plantes sont restaurées via leurs `ARAnchor` sauvegardés. La machine reste à `scanning` mais aucun overlay manuel n'apparaît. |
+| Tap "Replacer manuellement" | `enterManualReplacement()` → bascule sur `tracingBoundary`. |
+| Tap X | Dismiss de la vue, machine terminée. |
+
+### `tracingBoundary`
+
+L'utilisateur retrace la boundary du jardin en tapant le sol. Composant UI : `BoundaryTracingOverlay`.
+
+**Actions à chaque tap au sol** :
+
+1. `lastReticleTransform` est lu, sa position 3D est ajoutée à `newBoundary: [SIMD3<Float>]`.
+2. Une **sphère verte** est instanciée au point tapé (pattern réutilisé de `ARViewContainerMeasure`).
+3. Des cylindres reliant les points sont mis à jour pour visualiser le polygone.
+4. La surface (m²) est calculée via Shoelace et affichée en temps réel.
+
+**Trois actions utilisateur** :
+
+| Action | Résultat |
+|---|---|
+| Tap **« Effacer dernier »** | Retire le dernier point de `newBoundary` ainsi que la sphère et le segment associés. |
+| Tap **« Annuler »** | Vide `newBoundary`, retire toutes les sphères et le ghost old boundary, retour à `scanning`. |
+| Tap **« Valider la zone »** (désactivé si < 3 points) | `validateNewBoundary()` → calcule le morphing via `GardenMorpher` → bascule sur `morphingPreview`. |
+
+### `morphingPreview`
+
+Les plantes sont affichées en **ghost doré** (opacity 0.6) à leur position morphée calculée par les Mean Value Coordinates. Composant UI : `MorphingPreviewOverlay`.
+
+**Affichage** :
+
+- Si `distortionWarnings.isEmpty` : message vert **« ✓ Placement fiable »**.
+- Sinon : carte orange listant les plantes à risque (cliquable pour highlighter une plante dans la scène 3D). Les plantes en zone de forte distorsion (score ≥ 1.8) sont teintées orange au lieu de dorées.
+
+**Deux actions utilisateur** :
+
+| Action | Résultat |
+|---|---|
+| Tap **« Annuler »** | Retour à `tracingBoundary` ; `newBoundary` et les ghosts sont remis à zéro, l'utilisateur peut retracer. |
+| Tap **« Confirmer le placement »** | `confirmMorphedPlacement()` → instancie réellement les plantes via `placeObject`, snapshot leur transform dans `preMorphAdjustment`, bascule sur `adjusting`. |
+
+### `adjusting`
+
+Les plantes deviennent opaques. L'utilisateur peut affiner leur position à la main. Composant UI : `AdjustingOverlay`.
+
+**Gestures disponibles** :
+
+| Geste | Action |
+|---|---|
+| Tap sur une plante | Sélectionne la plante, affiche l'anneau vert pulsant `selection_indicator`. |
+| Tap sur le sol (avec une plante sélectionnée) | Téléporte la plante à la position raycast → `recordDraggedTransform`. |
+| Long-press + drag | Déplace en continu → `recordDraggedTransform` à `.ended`. |
+| Pinch | Met à l'échelle (si autorisé pour la plante). |
+
+**Deux actions globales** :
+
+| Action | Résultat |
+|---|---|
+| Tap **« Annuler ajustements »** | Restaure les positions snapshottées dans `preMorphAdjustment`. La machine reste à `adjusting` (l'utilisateur peut reprendre). |
+| Tap **« Valider et sauvegarder »** | Sauve `ARWorldMap` + `scene_{id}.json` sur disque, bascule sur `completed`. |
+
+### `completed`
+
+État transitoire avant dismiss. Aucune interaction utilisateur. La vue ferme automatiquement après quelques centaines de millisecondes pour laisser le temps au feedback visuel de succès.
+
+## Helper `isManualReplacement`
+
+L'enum expose un computed `isManualReplacement: Bool` qui retourne `true` pour `.tracingBoundary`, `.morphingPreview`, `.adjusting` et `.completed`, `false` pour `.scanning`. Ce flag est utilisé par `GardenARPlacementView` pour :
+
+- Masquer le bouton **« + »** du dock pendant le re-placement manuel (le picker plantes du catalogue n'a aucun sens pendant qu'on retrace une zone).
+- Bloquer les events ARKit de relocalisation tardive (l'utilisateur a pris la main, on ne réécrase pas ses positions).
+
+## Sortie par dismiss (X) — confirmation
+
+Le bouton **X** en haut à droite reste disponible à tous les états sauf `scanning` où il est immédiat. Dans les autres états, une **modale de confirmation** apparaît :
+
+> « Annuler le replacement ? Les changements ne seront pas sauvegardés. »
+
+Cette modale est obligatoire pour éviter qu'un tap accidentel ne fasse perdre 5 minutes de retraçage.
+
+## Hors-scope de cette vue
+
+- Le détail mathématique du morphing (Mean Value Coordinates, Distortion Analyzer) est documenté dans le glossaire et reste un détail d'implémentation testé en unitaire (`GardenMorpherTests` cible de l'issue #123).
+- Le rendu graphique des ghosts (matériau doré, anneau pulsant) est documenté inline dans `GhostRenderer.swift` et n'est pas pertinent au niveau de la machine d'états.
+- Le flow d'ouverture complet (depuis le tap sur une carte jardin de la Home jusqu'à l'arrivée sur `scanning`) sera documenté dans [`../flows/ar-placement.md`](../flows/ar-placement.md).

--- a/docs/state-machines/relocation-phase.md
+++ b/docs/state-machines/relocation-phase.md
@@ -12,28 +12,30 @@ Le diagramme ci-dessous décrit les états, les transitions, et l'événement d�
 
 ```mermaid
 stateDiagram-v2
-    [*] --> scanning : ouverture jardin (mode reopen)
+    [*] --> scanning
 
-    scanning --> scanning : ARKit relocalize OK\n→ load normal (machine non utilisée)
-    scanning --> tracingBoundary : tap "Replacer manuellement"
-    scanning --> [*] : tap X (back)
+    scanning --> tracingBoundary : tap Replacer manuellement
+    scanning --> [*] : tap X
 
-    tracingBoundary --> tracingBoundary : tap au sol\n→ ajoute point boundary
-    tracingBoundary --> scanning : tap "Annuler"
-    tracingBoundary --> morphingPreview : tap "Valider la zone"\n(≥ 3 points)
-    tracingBoundary --> [*] : tap X (confirmation)
+    tracingBoundary --> scanning : tap Annuler
+    tracingBoundary --> morphingPreview : tap Valider la zone
+    tracingBoundary --> [*] : tap X (confirm)
 
-    morphingPreview --> tracingBoundary : tap "Annuler"\n→ reset newBoundary + ghosts
-    morphingPreview --> adjusting : tap "Confirmer le placement"
-    morphingPreview --> [*] : tap X (confirmation)
+    morphingPreview --> tracingBoundary : tap Annuler
+    morphingPreview --> adjusting : tap Confirmer placement
+    morphingPreview --> [*] : tap X (confirm)
 
-    adjusting --> adjusting : drag / tap plante\n→ recordDraggedTransform
-    adjusting --> adjusting : tap "Annuler ajustements"\n→ revert vers preMorphAdjustment
-    adjusting --> completed : tap "Valider et sauvegarder"
-    adjusting --> [*] : tap X (confirmation)
+    adjusting --> completed : tap Valider et sauvegarder
+    adjusting --> [*] : tap X (confirm)
 
     completed --> [*] : save + dismiss
 ```
+
+Les **self-transitions** ne sont pas représentées sur le diagramme pour préserver sa lisibilité ; elles sont décrites au cas par cas dans la section « Comportement détaillé par état » plus bas :
+
+- `scanning → scanning` : ARKit `relocalize` réussit en arrière-plan → la machine est court-circuitée et `loadGardenFromDisk` est appelé sans transition d'état explicite.
+- `tracingBoundary → tracingBoundary` : tap au sol → un point est ajouté à `newBoundary`.
+- `adjusting → adjusting` : drag/tap d'une plante → `recordDraggedTransform`. Ou tap **« Annuler ajustements »** → revert vers `preMorphAdjustment`.
 
 ## Comportement détaillé par état
 


### PR DESCRIPTION
Phase 3 de la documentation prévue dans #141. Couvre la vue **comportementale** (machine d'états) et la vue **dynamique** (flows).

## Contenu

- **`docs/state-machines/relocation-phase.md`** : machine d'états du manual replace (#111). Diagramme `stateDiagram-v2` avec les cinq états (`scanning`, `tracingBoundary`, `morphingPreview`, `adjusting`, `completed`), transitions, guards, comportement annuler par phase, utilisation de `isManualReplacement`.

- **`docs/flows/auth-signup.md`** : `sequenceDiagram` du signup (#137). Chemin nominal et rollback Firebase si `POST /users` échoue après 3 retries avec backoff exponentiel. Détaille la politique de retry, le distinguo 4xx/5xx, l'ordre `POST /users` avant `sendEmailVerification`, et la localisation des messages d'erreur (fr/en/de/es).

- **`docs/flows/garden-creation.md`** : `flowchart` wizard 10 étapes avec branche conditionnelle `soil` (uniquement si `spaceType == garden`), puis branchement post-summary selon `scanMethod` (perimeter non-LiDAR vs LiDAR via RoomPlan).

- **`docs/flows/ar-placement.md`** : `flowchart` placement AR pour les deux modes (`.create` depuis wizard, `.reopen` depuis Home). Chemin nominal `relocalize OK` et fallback manual replace si KO. Documente `captureCurrentState` avec `pendingDragTransform` pour garantir la persistance des derniers gestes (#138).

## Cohérence avec la Phase 2

Tous les diagrammes utilisent `flowchart TB` strict ou `stateDiagram-v2`, avec **color-coding** pour distinguer les classes de nœuds (steps, conditions, transitions AR, points d'entrée/sortie). Aucun subgraph imbriqué — leçon tirée de la PR #143 (Dagre interleaving les rangs quand les edges traversent les couches).

## Vérification

- [x] Pas de chevauchement d'arêtes sur les quatre diagrammes (vérifié en preview VSCode)
- [x] Ton documentation formel maintenu (impersonnel)
- [x] Liens internes vers `architecture/` et entre les flows cohérents
- [x] Références aux issues vérifiées (#96, #111, #114, #123, #137, #138)
- [x] Référence à la Phase 4 (per-screen specs) explicite pour les approfondissements à venir

## Suite

Phase 4 (1 PR par hero screen, ~1h chacun) : `screens/_index.md`, `screens/garden-ar-placement.md`, `screens/questionnaire-wizard.md`, `screens/personal-details.md`.

Refs #141 — Phase 3 du plan.