### PR TITLE
📚 [Docs Phase 4] Per-screen specs (3 hero screens + index)

### DIFF
--- a/docs/screens/_index.md
+++ b/docs/screens/_index.md
@@ -1,0 +1,47 @@
+# Per-screen specs — Index
+
+Cette section regroupe les **per-screen specs** des écrans qualifiés de « hero screens » : écrans complexes, business-critical, ou qui concentrent assez de logique pour mériter une documentation dédiée.
+
+Les écrans simples (un bouton, une navigation, une liste statique) ne disposent **pas** de per-screen spec — ils sont décrits en une ligne dans les flows [`../flows/`](../flows/) lorsque c'est pertinent.
+
+## Critères de promotion en hero screen
+
+Un écran devient hero screen, et donc cible d'une per-screen spec, lorsqu'**au moins deux** des critères suivants sont remplis :
+
+- L'écran porte une **machine d'états** explicite (plusieurs phases distinctes avec transitions).
+- Le fichier dépasse **1 000 lignes** de code.
+- L'écran appelle **plus de deux endpoints backend** distincts.
+- L'écran combine **plusieurs frameworks Apple** (ARKit + SceneKit + SwiftUI, par exemple).
+- L'écran est mentionné dans **au moins trois issues GitHub** ouvertes ou closes (signal qu'il concentre de la dette ou des bugs récurrents).
+- L'écran porte un **contrat de sécurité ou de RGPD** spécifique.
+
+## Hero screens documentés
+
+| Écran | Fichier | Critères remplis |
+|---|---|---|
+| `GardenARPlacementView` | [`garden-ar-placement.md`](garden-ar-placement.md) | Machine d'états (`RelocationPhase`), 3 300 LOC, 3 frameworks (ARKit + SceneKit + SwiftUI), ≥ 5 issues (#96, #111, #113, #114, #123, #124, #136, #138). |
+| Wizard de création de jardin | [`questionnaire-wizard.md`](questionnaire-wizard.md) | 10 étapes avec skip rules, `POST /gardens` + branching vers deux flows AR distincts, ≥ 3 issues (#139, #21, #97). |
+| `PersonalDetailsView` | [`personal-details.md`](personal-details.md) | `PATCH /users/me` + mise à jour Firebase `displayName`, machine d'états save (idle → saving → success/error), issue #138. |
+
+## Hero screens non-documentés (à promouvoir si nécessaire)
+
+Les écrans suivants sont en limite mais ne sont pas encore documentés. Ils seront promus si leur complexité augmente ou si plusieurs bugs s'y concentrent :
+
+- `LiDARScanWizardView` — single screen mais RoomPlan + transition vers `GardenARPlacementView`. Suivi par l'issue #139.
+- `ARViewContainerMeasure` — single screen, principalement pour le tracé périmètre non-LiDAR.
+- `SignUpView` — flow critique (#137) mais le détail est déjà dans [`../flows/auth-signup.md`](../flows/auth-signup.md).
+- `CatalogueView` et `PlantCatalogView` — listings avec filtres mais sans logique complexe.
+
+## Structure d'une per-screen spec
+
+Chaque hero screen suit la structure suivante :
+
+1. **Purpose** — une à deux phrases expliquant la raison d'être de l'écran.
+2. **Entry points** — qui peut router vers cet écran et avec quels paramètres.
+3. **Exit points** — où la navigation repart selon les actions utilisateur.
+4. **Screen-level flow** — diagramme Mermaid (`flowchart` ou `stateDiagram-v2`) de l'enchaînement intra-écran.
+5. **Widgets** — sous-sections par widget significatif, avec mini state diagram si nécessaire.
+6. **Edge cases** — comportement en cas de loading, empty state, erreur, mode offline, permissions iOS refusées.
+7. **Dependencies** — APIs backend appelées, états partagés (`@EnvironmentObject`, `@StateObject` externe), permissions iOS, frameworks Apple utilisés.
+
+Cette structure est inspirée des design systems Shopify Polaris et Material Design 3, adaptée au contexte iOS natif.

--- a/docs/screens/garden-ar-placement.md
+++ b/docs/screens/garden-ar-placement.md
@@ -1,0 +1,190 @@
+# Per-screen spec — `GardenARPlacementView`
+
+## Purpose
+
+Cet écran est le **cœur AR de l'application** : il permet à l'utilisateur de placer, déplacer et sauvegarder les plantes 3D dans son jardin via la caméra AR du téléphone. Il fonctionne aussi bien à la création d'un nouveau jardin qu'à la réouverture d'un jardin existant, avec ou sans LiDAR.
+
+Le fichier est aussi le seul **god object** du codebase (≈ 3 300 lignes, suivi par l'issue #124).
+
+## Entry points
+
+| Source | Mode | Paramètres clés |
+|---|---|---|
+| Sortie du wizard de création (chemin perimeter non-LiDAR) | `.create` | `selectedPlants`, `boundaryPoints`, `wizard`, `gardenName`, `existingGardenId == nil`, `measurementWorldMapId == nil` |
+| Sortie du wizard de création (chemin LiDAR) | `.create` | `selectedPlants`, `boundaryPoints == []`, `wizard`, `gardenName`, `existingGardenId == nil`, `measurementWorldMapId == UUID` (WorldMap pré-sauvegardée par `LiDARScanWizardView`) |
+| Tap sur une carte jardin de la Home | `.reopen` | `existingGardenId: String` (ID Mongo), tout le reste lu depuis le disque (`worldmap_{id}.arworldmap` et `scene_{id}.json`) |
+| Tap « Re-mesurer » depuis `ManageGardenView` | `.create` avec flag `measurementOnly` | Cas particulier suivi par l'issue #136 |
+
+## Exit points
+
+| Action utilisateur | Destination |
+|---|---|
+| Tap **« Valider et sauvegarder »** | Sauvegarde puis dismiss → callback `onValidated()` qui retourne à la Home et rafraîchit la liste des jardins. |
+| Tap **X (back button)** en haut à gauche | Dismiss sans sauvegarde. Une modale de confirmation apparaît si l'utilisateur est en cours de manual replace (phase autre que `.scanning`). |
+| Tap **partager** après sauvegarde | Ouvre un share sheet iOS avec une capture annotée de l'écran. |
+| Détection de jardin indisponible (cf. issue #114) | Affiche `gardenUnavailableView` plutôt que `placementBody` — message d'erreur et bouton de retour. |
+
+## Screen-level flow
+
+Le flux global d'ouverture est documenté dans [`../flows/ar-placement.md`](../flows/ar-placement.md). Le diagramme ci-dessous se concentre sur le **flow intra-écran** une fois l'utilisateur dans la session AR active.
+
+```mermaid
+flowchart TB
+    body([placementBody actif<br/>ARSCNView visible])
+
+    relo{relocationPhase ?}
+
+    scanning[Phase scanning<br/>coaching overlay non-bloquant<br/>bouton Replacer manuellement disponible]
+    tracing[Phase tracingBoundary<br/>tap sol = ajouter point<br/>sphères vertes + cylindres]
+    morph[Phase morphingPreview<br/>plantes ghost dorées<br/>warnings distorsion]
+    adjust[Phase adjusting<br/>plantes opaques<br/>tap-to-select + drag + pinch]
+    completed[Phase completed<br/>save WorldMap + scene JSON + PUT /gardens]
+
+    dock[Bottom dock<br/>bouton plus catalogue]
+    picker[Sheet PlantCatalogView<br/>sélection plante]
+    place[placeObject<br/>raycast au sol]
+
+    share[Sheet capture + partage<br/>capturedShareImage]
+
+    body --> relo
+
+    relo -->|scanning| scanning
+    relo -->|tracingBoundary| tracing
+    relo -->|morphingPreview| morph
+    relo -->|adjusting| adjust
+    relo -->|completed| completed
+
+    scanning -->|relocalize OK ou create| dock
+    dock --> picker
+    picker --> place
+    place --> dock
+
+    tracing -->|valider zone| morph
+    morph -->|confirmer placement| adjust
+    adjust -->|valider et sauvegarder| completed
+    completed --> share
+
+    classDef body fill:#08427B,stroke:#073B6F,color:#fff
+    classDef phase fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef widget fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef terminal fill:#6A1B9A,stroke:#4A148C,color:#fff
+    classDef cond fill:#999,stroke:#666,color:#fff
+    class body body
+    class scanning,tracing,morph,adjust,completed phase
+    class dock,picker,place widget
+    class share terminal
+    class relo cond
+```
+
+## Widgets
+
+### `ARSCNView` (le canvas AR)
+
+Vue ARKit + SceneKit pleine page. Délégates :
+
+- `ARSCNViewDelegate` pour les ajouts/mises à jour d'`ARAnchor`.
+- `ARSessionDelegate` pour les changements de tracking state et la détection de relocalisation réussie.
+- `UIGestureRecognizerDelegate` pour gérer les conflits entre long-press, pan et pinch.
+
+**Gestes attachés** : tap, long-press, pan, pinch, two-finger rotation. Tous routés à travers le **Coordinator** qui dispatche selon `relocationPhase` et selon la présence d'une plante sélectionnée.
+
+### Bottom dock (bouton **+** catalogue)
+
+Visible uniquement lorsque `relocationPhase == .scanning || relocationPhase == .completed` (cf. helper `isManualReplacement`). Ouvre la sheet `PlantCatalogView` qui propose la liste filtrée des plantes selon le profil du jardin.
+
+**Pourquoi cette restriction** : le picker catalogue n'a pas de sens pendant qu'on retrace une zone ou qu'on prévisualise un morphing. Décision tracée dans #111.
+
+### `PlantCatalogView` (sheet)
+
+Sheet modale (présentée via `.sheet(isPresented: $showPicker)`). Liste filtrée des plantes du catalogue. À la sélection :
+
+1. Le modèle USDZ est téléchargé via `ModelCacheManager` si pas déjà en cache.
+2. Pendant le téléchargement, `isDownloadingModel = true` → un loader apparaît dans la dock bar.
+3. À la fin du téléchargement, le tap suivant sur le sol invoque `placeObject` pour instancier la plante.
+
+### Selection indicator (anneau pulsant)
+
+Quand une plante est sélectionnée via tap, un `SCNTorus` vert pulsant (`selection_indicator`) est ajouté en enfant du nœud plante (cf. issue #111). L'animation oscille l'opacité entre 0.45 et 0.95 toutes les 0.6 s.
+
+### Overlays Manual Replacement
+
+Quatre overlays SwiftUI exclusifs au flow de #111, alternativement affichés selon `relocationPhase` :
+
+| Overlay | Phase | Composant |
+|---|---|---|
+| Coaching | `.scanning` | `ScanningCoachingOverlay` — bottom-anchored, bouton « Replacer manuellement ». |
+| Boundary tracing | `.tracingBoundary` | `BoundaryTracingOverlay` — compteur de points, surface live, trois boutons (effacer dernier, annuler, valider). |
+| Morphing preview | `.morphingPreview` | `MorphingPreviewOverlay` — résumé des `distortionWarnings`, bouton « Confirmer » ou « Annuler ». |
+| Adjusting | `.adjusting` | `AdjustingOverlay` — hint discret, deux boutons (annuler ajustements, valider et sauvegarder). |
+
+### Share sheet (capture)
+
+Après une sauvegarde réussie, l'utilisateur peut tap sur un bouton de partage. Une capture de l'écran AR est prise (`shouldCaptureSharePhoto = true` déclenche le `snapshot()` du `ARSCNView`), puis présentée dans une sheet de prévisualisation, puis dans le `UIActivityViewController` natif iOS.
+
+### Lux widget
+
+Petit widget en surimpression qui affiche la luminosité (lux) mesurée par `LuxAnalyzer`. Aide l'utilisateur à comprendre si les conditions d'éclairage sont compatibles avec une relocalisation AR fiable.
+
+### Auto-placement (IA, en cours, #125)
+
+`isAutoPlacing` et `autoPlaceToast` sont les états dédiés au placement automatique des plantes par une IA en cours de spécification (issue #125, Sprint 3). Le widget est masqué tant que la feature n'est pas activée.
+
+## Edge cases
+
+| Situation | Comportement |
+|---|---|
+| Permission caméra refusée | iOS bloque le démarrage de l'`ARSession`. `gardenUnavailable = true` et l'utilisateur voit un message « Activez l'accès caméra dans Réglages » avec un bouton vers l'app Settings. |
+| Pas de tracking AR (device incompatible) | `ARWorldTrackingConfiguration.isSupported == false`. L'écran retombe sur `gardenUnavailableView`. |
+| Réouverture d'un jardin avec WorldMap absente (issue #114) | `gardenUnavailable = true`, message dédié. À terme, reconstruction depuis le backend. |
+| Modèle USDZ inaccessible (404 backend) | Logge l'erreur, retombe sur un placeholder gris pour la plante concernée. Le bouton de sauvegarde reste actif. |
+| Relocalisation prend > 30 s sans succès | Aucun timeout dur — l'utilisateur peut continuer à attendre ou basculer en manual replace. |
+| Backgrounding > 30 s | ARKit perd le tracking. Au retour, `session(_:cameraDidChangeTrackingState:)` détecte `.limited`. En mode `.reopen`, le coaching overlay peut réapparaître. |
+| Save backend échoue après sauvegarde locale réussie | Les fichiers locaux (`worldmap_{id}.arworldmap` et `scene_{id}.json`) sont écrits avant le `PUT /gardens`. Si le `PUT` échoue, un retry réseau est tenté ; en cas d'échec définitif, l'écran reste ouvert avec un message d'erreur et un bouton « Réessayer ». |
+| Coordinator deinit pendant un téléchargement de modèle | Le `ModelCacheManager` annule la tâche réseau (signal via le contexte du Combine cancellable). |
+
+## Dependencies
+
+### Endpoints backend
+
+- `GET /models/:filename` (via `ModelCacheManager`) — téléchargement des USDZ.
+- `POST /gardens` (en mode `.create`) — création initiale du document jardin si pas encore présent.
+- `PUT /gardens/:id` — sauvegarde des positions actualisées en fin de session.
+- `GET /plants/:id` (occasionnellement, via le picker) — détails d'une plante absente du catalogue local.
+
+### États partagés et services
+
+- `ModelCacheManager.shared` — cache disque + LRU des USDZ.
+- `GardenLocalStore` — lecture/écriture de `worldmap_{id}.arworldmap` et `scene_{id}.json`.
+- `NetworkManager.shared` — toutes les requêtes HTTP passent par ce singleton.
+- `LuxAnalyzer` — instance par session AR, lit la luminosité depuis l'environnement ARKit.
+
+### Permissions iOS
+
+- **Caméra** — obligatoire (`NSCameraUsageDescription` dans `Info.plist`).
+- **Photo Library** (Add Only) — uniquement si l'utilisateur active la sauvegarde de la capture de partage dans sa photothèque.
+
+### Frameworks Apple utilisés
+
+- **ARKit** (`ARWorldTrackingConfiguration`, `ARSCNView`, `ARWorldMap`, `ARAnchor`).
+- **SceneKit** (`SCNNode`, `SCNScene`, `SCNTorus` pour l'anneau de sélection, `SCNAction` pour les pulses).
+- **SwiftUI** pour tous les overlays et le dock.
+- **Combine** pour les Cancellables de téléchargement et les pipelines réactifs.
+
+## Dette et issues associées
+
+| # | Sujet |
+|---|---|
+| #124 | Refactor god object — séparer le coordinator en sous-coordinators thématiques. |
+| #123 | Race conditions identifiées dans le coordinator et tests manquants pour le morphing. |
+| #114 | Récupération du jardin après désinstallation/réinstallation. |
+| #113 | Plantes en hauteur mal repositionnées au reload. |
+| #138 | Wired récemment — `pendingDragTransform` qui garantit la persistance du dernier drag. |
+| #111 | Manual replacement — mergée mais reste à enrichir. |
+| #97 | Pipeline neural depth-anything pour améliorer la relocalisation non-LiDAR. |
+| #96 | Relocalisation échoue si l'éclairage change — racine de tous les flows manuels. |
+
+## Hors-scope de cette spec
+
+- Le détail mathématique du morphing MVC (méthode Floater 2003) reste dans `ManualReplacement/MeanValueCoordinates.swift`.
+- Les transitions précises de `RelocationPhase` sont dans [`../state-machines/relocation-phase.md`](../state-machines/relocation-phase.md).
+- Le rendu graphique des plantes (matériaux, ombres, sky-light) n'est pas couvert ici — c'est un détail SceneKit/RealityKit auquel un développeur AR aura accès via le code.

--- a/docs/screens/personal-details.md
+++ b/docs/screens/personal-details.md
@@ -1,0 +1,135 @@
+# Per-screen spec — `PersonalDetailsView`
+
+## Purpose
+
+Cet écran permet à l'utilisateur d'**éditer son nom de profil** et de consulter son email. Il était auparavant un *no-op visuel* (le bouton « Enregistrer » ne faisait que `dismiss()`, ce qui donnait l'illusion d'une sauvegarde sans rien persister — issue #138). Depuis son recâblage, il appelle `PATCH /users/me` côté backend puis met à jour le `displayName` Firebase Auth, garantissant la cohérence entre les deux sources de vérité.
+
+Implémenté dans `Views/Profile/PersonalDetailsView.swift`.
+
+## Entry points
+
+| Source | Paramètres clés |
+|---|---|
+| Section **« Informations personnelles »** depuis `ProfileView` | Aucun paramètre — l'utilisateur courant est lu via `Auth.auth().currentUser`. |
+
+## Exit points
+
+| Action utilisateur | Destination |
+|---|---|
+| Tap **« Enregistrer les modifications »** (succès) | Affichage du toast inline « Modifications enregistrées ✓ » pendant 600 ms, puis `dismiss()` automatique. |
+| Tap **« Enregistrer les modifications »** (erreur backend) | L'écran reste ouvert, message d'erreur inline en rouge (`PERSONAL_DETAILS_SAVE_ERROR`), `isSaving = false`, l'utilisateur peut retenter. |
+| Tap **système de retour** (swipe ou back nav) | `dismiss()` immédiat sans sauvegarde. Bloqué pendant `isSaving == true` via `.interactiveDismissDisabled(isSaving)`. |
+
+## Screen-level flow
+
+Le bouton « Enregistrer » porte une **mini machine d'états** sur quatre statuts dérivés de trois `@State` : `isSaving`, `errorMessage`, `didSave`. Cette machine est implicite dans le code Swift mais explicite ci-dessous pour faciliter la review et le maintien.
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+
+    idle --> saving : tap Enregistrer<br/>canSave true
+    idle --> idle : tap Enregistrer<br/>canSave false (ignoré)
+
+    saving --> success : PATCH 200<br/>+ Firebase displayName ok
+    saving --> error : PATCH 4xx ou 5xx<br/>ou réseau down
+
+    success --> dismissed : sleep 600 ms<br/>puis dismiss()
+    error --> idle : utilisateur corrige<br/>et retape
+
+    dismissed --> [*]
+```
+
+L'état `idle` est l'état par défaut au mount. `canSave` est un computed qui retourne `true` uniquement si :
+
+- L'écran n'est pas en cours de sauvegarde (`isSaving == false`).
+- Le nom trimé n'est pas vide (`!trimmedName.isEmpty`).
+- Le nom a été modifié depuis le mount (`trimmedName != initialName`).
+
+Cette dernière condition empêche l'utilisateur de tap « Enregistrer » alors qu'il n'a rien changé.
+
+## Widgets
+
+### `inputField` (nom complet)
+
+Composant interne basé sur `AppTextField` avec une icône système et un placeholder localisé. Lié à `$fullName: String`. Désactivé pendant `isSaving == true`.
+
+### `readOnlyField` (email)
+
+Composant interne en lecture seule. Affiche l'email courant du compte Firebase (`Auth.auth().currentUser?.email`). L'icône `envelope` et le style atténué (opacity 0.5 sur le fond de carte) signalent visuellement que le champ n'est pas éditable.
+
+**Pourquoi en lecture seule** : Firebase Auth est la source de vérité pour l'email. Une modification implique un flow de vérification (mail de confirmation, ré-authentification), qui n'est pas dans le scope de cet écran. Si la feature est demandée, elle fera l'objet d'un écran dédié `ChangeEmailView`.
+
+### Bouton primaire « Enregistrer »
+
+Bouton plein-largeur stylé via `.buttonStyle(.arborePrimary)`. Comportement visuel selon l'état :
+
+| État | Apparence |
+|---|---|
+| `idle` et `canSave == false` | Opacité 0.5, désactivé. |
+| `idle` et `canSave == true` | Pleine opacité, tap réactif. |
+| `saving == true` | Pleine opacité, `ProgressView()` à gauche du label. Désactivé. |
+
+### Toast feedback (succès)
+
+Affiché sous le formulaire, au-dessus du bouton, en vert (`ArboreDesign.Colors.success`). Apparaît brièvement avant le `dismiss()` automatique.
+
+### Toast feedback (erreur)
+
+Affiché sous le formulaire, en rouge (`ArboreDesign.Colors.danger`). Le message provient soit du `NetworkError.errorDescription`, soit du fallback localisé `PERSONAL_DETAILS_SAVE_ERROR`.
+
+## Edge cases
+
+| Situation | Comportement |
+|---|---|
+| Backend renvoie 401 / 403 | `NetworkError.unauthorized` ou `.forbidden`. Le message d'erreur est affiché tel quel par `errorDescription`. L'utilisateur peut retenter, mais en pratique cela signifie qu'il faut relancer l'app (token expiré) ou que le device est banni. |
+| Backend renvoie 422 (nom trop long, > 100 caractères) | Message backend transmis via `NetworkError.serverError(message)`. L'utilisateur voit « Le nom est trop long (max 100 caractères) » et peut raccourcir. |
+| Backend renvoie 400 (nom vide après trim) | Ne devrait pas arriver puisque le `canSave` côté iOS empêche déjà le tap si trim est vide. Si toutefois cela passe (cas de course par exemple), le message backend est affiché. |
+| Connexion réseau coupée | `NetworkManager` tente un retry transparent (cf. `performWithRetry`). Si toujours échec, `NetworkError.serverError` est levée. Message fallback `PERSONAL_DETAILS_SAVE_ERROR`. |
+| Backend down (5xx) | Idem : retry interne `NetworkManager` puis fallback. Aucun backoff explicite spécifique à cet écran — la requête est petite et l'utilisateur peut retenter manuellement. |
+| Firebase `commitChanges()` échoue alors que `PATCH` a réussi | Le backend a la nouvelle source de vérité. Firebase reste désynchronisé jusqu'à la prochaine session (l'erreur est silencieusement loggée — `try? await`). À surveiller en cas de retours utilisateurs ; un retry plus robuste pourra être ajouté. |
+| Utilisateur dismiss pendant `isSaving == true` | `.interactiveDismissDisabled(isSaving)` empêche le swipe-to-dismiss iOS. Le bouton de retour reste accessible mais le dismiss est bloqué le temps de la requête. |
+| Email Firebase nul (compte non-vérifié) | `email` affiché en read-only avec le tiret « — ». L'utilisateur peut éditer son nom sans bloquer. |
+
+## Dependencies
+
+### Endpoints backend
+
+- **`PATCH /users/me`** — endpoint introduit par l'issue #138. Payload : `{ "name": "..." }`. Authz self-only via le token Firebase. Validation backend : trim + max 100 caractères.
+
+### États partagés et services
+
+- `NetworkManager.shared` — appel `PATCH /users/me`.
+- `Auth.auth().currentUser` — lecture initiale du `displayName` et de l'`email`, puis appel à `createProfileChangeRequest()` pour mettre à jour le `displayName` côté Firebase après succès backend.
+- `ThemeManager` (`@EnvironmentObject`) — pour le `colorScheme` et les couleurs adaptatives.
+
+### Localisation
+
+Trois clés ajoutées en fr/en/de/es par l'issue #138 :
+
+- `PERSONAL_DETAILS_SAVE_BUTTON` — déjà existante.
+- `PERSONAL_DETAILS_SAVE_SUCCESS` — toast vert après succès.
+- `PERSONAL_DETAILS_SAVE_ERROR` — fallback si le `NetworkError` n'a pas de message localisé.
+
+### Permissions iOS
+
+Aucune permission iOS requise par cet écran.
+
+### Frameworks Apple utilisés
+
+- **SwiftUI** pour toute la vue.
+- **FirebaseAuth** pour la lecture du profil courant et la mise à jour du `displayName`.
+
+## Issues associées
+
+| # | Sujet |
+|---|---|
+| #138 | Wiring du bouton Save (cet écran). |
+| #137 | Signup rollback — flow complémentaire qui garantit qu'un utilisateur Firebase a toujours son document Mongo associé. |
+| #67 | Consentements RGPD étendus — la gestion des préférences marketing/notifications passera par un écran similaire (à créer). |
+
+## Hors-scope de cette spec
+
+- La gestion de la **photo de profil** passe par l'endpoint `POST /users/:uid/photo` (multipart) et n'est pas exposée par cet écran. Un éditeur de photo distinct sera ajouté si nécessaire.
+- Le **changement d'email** et le **changement de mot de passe** sont des flows séparés non encore implémentés.
+- La spec backend de `PATCH /users/me` est dans [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).

--- a/docs/screens/questionnaire-wizard.md
+++ b/docs/screens/questionnaire-wizard.md
@@ -1,0 +1,152 @@
+# Per-screen spec — `GardenWizardView` (wizard de création)
+
+## Purpose
+
+Cet écran guide l'utilisateur à travers la **création complète d'un jardin** : profil esthétique et fonctionnel (style, espace, exposition, entretien, sécurité, sol), sélection de plantes assistée par IA, choix de la méthode de scan, et validation finale. À sa sortie, l'utilisateur est routé vers une vue AR adaptée à sa méthode de scan.
+
+Implémenté dans `Views/GardenSteps/QuestionnaireView.swift`. Composé de 10 étapes maximum (entre 9 et 10 selon les choix), portées par une `TabView` non-paginable dont la sélection est gouvernée par l'enum `GardenWizardStep`.
+
+## Entry points
+
+| Source | Paramètres clés |
+|---|---|
+| Bouton **« Créer un jardin »** depuis la Home | `uid: String`, `selectedPlants: [Plant]` (généralement `[]`), `onFinish: (GardenWizardState) -> Void` |
+| Action « Recommencer » depuis la fin du wizard | Mêmes paramètres, état `GardenWizardState` réinitialisé |
+
+## Exit points
+
+| Action utilisateur | Destination |
+|---|---|
+| Tap **« Placer mes plantes en AR »** à l'étape Summary, `scanMethod == gardenPerimeter` | `fullScreenCover` vers `ARViewContainerMeasure` (tracé périmètre non-LiDAR) → puis `GardenARPlacementView`. |
+| Tap **« Placer mes plantes en AR »** à l'étape Summary, `scanMethod == roomScan` | `fullScreenCover` vers `LiDARScanWizardView` (RoomPlan) → puis `GardenARPlacementView`. |
+| Tap **« Retour »** sur la première étape (intro) | `dismiss()` — retour à la Home, aucun jardin créé. |
+| Tap **X (close)** en haut de l'écran | Idem — retour à la Home, aucun jardin créé. Aucune confirmation à ce stade puisque rien n'est encore persisté. |
+
+## Screen-level flow
+
+Le flux complet est documenté dans [`../flows/garden-creation.md`](../flows/garden-creation.md). Le diagramme ci-dessous se concentre sur la **navigation interne entre étapes**, gérée par le computed `visibleSteps` et les helpers `goToNext` / `goToPrevious`.
+
+```mermaid
+flowchart TB
+    intro[1 intro]
+    style_step[2 style]
+    spaceType[3 spaceType]
+    exposure[4 exposure]
+    maintenance[5 maintenance]
+    safety[6 safety]
+    soil[7 soil — conditionnel]
+    ai[8 aiSuggestion]
+    scan[9 scanMethod]
+    summary[10 summary]
+
+    intro --> style_step --> spaceType
+    spaceType --> exposure --> maintenance --> safety
+    safety -->|spaceType garden| soil --> ai
+    safety -->|sinon| ai
+    ai --> scan --> summary
+
+    classDef step fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef cond fill:#2E7D32,stroke:#1B5E20,color:#fff
+    class intro,style_step,spaceType,exposure,maintenance,safety,ai,scan,summary step
+    class soil cond
+```
+
+## Widgets
+
+### `WizardProgressHeader`
+
+Barre de progression en haut de l'écran. Affiche l'étape courante (`currentIndex + 1`) et le nombre total d'étapes visibles (`visibleSteps.count`). La barre s'allonge à mesure que l'utilisateur progresse.
+
+Mis à jour automatiquement quand `visibleSteps` est recalculé (par exemple si l'utilisateur change `spaceType` en arrière puis revient en avant : `soil` apparaît/disparaît et le total change).
+
+### Boutons de navigation
+
+Chaque écran d'étape expose deux boutons standardisés :
+
+| Bouton | Style | Action |
+|---|---|---|
+| **« Continuer »** | Primary | `goToNext()` — incrémente `currentIndex` dans `visibleSteps`. Désactivé tant que l'étape n'a pas reçu de réponse valide. |
+| **« Retour »** | Secondary | `goToPrevious()` — décrémente `currentIndex`. Désactivé à l'étape `intro`. |
+
+Les styles `PrimaryWizardButtonStyle` et `SecondaryWizardButtonStyle` sont partagés entre toutes les étapes pour garantir la cohérence visuelle.
+
+### `ImprovedSelectableCard`
+
+Composant carte sélectionnable utilisé sur la plupart des étapes (style, spaceType, exposure, maintenance, scanMethod). Affiche une icône système, un titre, un sous-titre et un dégradé de couleur. Quand `isSelected == true`, une bordure colorée et un check apparaissent.
+
+Réutilisé partout pour éviter la divergence visuelle entre étapes.
+
+### `ScanMethodStepView` (étape 9)
+
+Composant dédié au choix de la méthode de scan. Deux cartes :
+
+- **Tracer mon jardin au sol** (`gardenPerimeter`) — toujours active.
+- **Scanner la pièce en 3D** (`roomScan`) — `opacity(0.4)` et tap désactivé si `RoomCaptureSession.isSupported == false` (pas de LiDAR sur le device).
+
+À l'activation d'une carte, `state.scanMethod` est posée et le bouton « Continuer » est déverrouillé.
+
+### `WizardSummaryStepView` (étape 10)
+
+Écran final récapitulatif. Affiche une carte unique avec un titre, un sous-titre, et trois `BenefitRow` qui rappellent les choix faits. Le bouton primaire évolue selon `isSaving` :
+
+| État | Label du bouton |
+|---|---|
+| `isSaving == false` | « Placer mes plantes en AR » + icône `arkit` |
+| `isSaving == true` | « Sauvegarde… » + icône `arrow.triangle.2.circlepath` |
+
+À l'activation :
+
+1. `onFinishWizard()` est appelé en parent → `POST /gardens` côté backend.
+2. À la résolution, `state.scanMethod` détermine le branchement via `startScanFlow()` :
+   - `.gardenPerimeter` ou `nil` → `showPerimeterFlow = true`
+   - `.roomScan` → `showLiDARFlow = true`
+3. Le `fullScreenCover` correspondant s'ouvre.
+
+## Edge cases
+
+| Situation | Comportement |
+|---|---|
+| Utilisateur tap « Retour » multiple fois jusqu'à l'étape `intro` | Le bouton « Retour » devient désactivé. Pas de pop arrière implicite — l'utilisateur doit utiliser le X pour quitter. |
+| `state.spaceType` modifié en allant en arrière | `visibleSteps` est recalculé à chaque accès au computed. Si l'utilisateur passe de `garden` à `indoor`, l'étape `soil` disparaît à la prochaine évaluation. Un `onChange(of: visibleSteps)` repositionne `currentStep` sur `.summary` si l'étape courante n'est plus dans la liste. |
+| Backend down au tap final du Summary | `isSaving = true`, puis `NetworkError` levée. L'utilisateur voit un message inline « Impossible de créer le jardin. Réessayez. » et peut retenter. |
+| LiDAR sélectionné mais non supporté | Ne devrait pas arriver — la carte est grisée. Si toutefois `state.scanMethod == .roomScan` sur un device sans LiDAR, le `fullScreenCover` `LiDARScanWizardView` affiche immédiatement une alerte « Scan 3D indisponible » et propose de revenir au choix. |
+| Permission caméra refusée à l'étape suivante | La permission est demandée par `ARViewContainerMeasure` ou `LiDARScanWizardView` après dismissal du wizard. Si refusée, l'utilisateur revient au wizard avec un message d'erreur en bas du Summary. |
+| `selectedPlants == []` à l'étape 8 | L'utilisateur peut continuer mais le résumé final indique « 0 plantes — ajoutez-en depuis le picker AR ». Cas dégénéré toléré. |
+| Brouillon perdu si dismiss avant Summary | Aucune persistance disque pendant le wizard. Décision tracée dans [`../flows/garden-creation.md`](../flows/garden-creation.md). |
+
+## Dependencies
+
+### Endpoints backend
+
+- `GET /plants` — chargement du catalogue pour l'étape 8 (AI Suggestion). Appelé à `onAppear`.
+- `POST /gardens` — création du document jardin à la validation du Summary.
+
+### États partagés et services
+
+- `GardenWizardState` (`@StateObject`) — vit le temps du wizard. Stocke toutes les sélections (style, spaceType, exposure, maintenance, safety, soil, scanMethod, etc.) et les données de scan (`measuredBoundaryPoints`, `measuredArea`, `measuredPerimeter`).
+- `GardenSuggestionEngine` — pour l'étape AI Suggestion, filtre et propose les plantes adaptées au profil.
+- `TabRouter` (`@EnvironmentObject`) — pour rediriger vers la Home après création.
+- `NetworkManager.shared` — appel `POST /gardens`.
+
+### Permissions iOS
+
+Aucune permission iOS n'est requise pendant le wizard lui-même. Les permissions caméra/LiDAR sont demandées par les vues qui ouvrent après le Summary.
+
+### Frameworks Apple utilisés
+
+- **SwiftUI** pour l'intégralité de la vue, y compris la `TabView` non-paginable (`PageTabViewStyle` désactivé).
+- **RoomPlan** importé pour utiliser `RoomCaptureSession.isSupported` côté `ScanMethodStepView`.
+
+## Issues associées
+
+| # | Sujet |
+|---|---|
+| #139 | Validation LiDAR end-to-end (côté mate) — bouton « roomScan » du wizard. |
+| #97 | Pipeline neural Depth Anything V2 / SuperPoint / LightGlue — alternative future à RoomPlan pour le scan non-LiDAR. |
+| #21 | Sauvegarde des modèles de jardin avec autosave et versions — pourrait introduire la persistance des brouillons. |
+
+## Hors-scope de cette spec
+
+- Le détail du flux post-Summary (création de la session AR, placement des plantes) est documenté dans [`garden-ar-placement.md`](garden-ar-placement.md) et [`../flows/ar-placement.md`](../flows/ar-placement.md).
+- Le scoring exact du filtrage AI à l'étape 8 (algorithme de `GardenSuggestionEngine`) reste un détail d'implémentation testable en unitaire.
+- La spec backend du handler `createGarden` est dans [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).


### PR DESCRIPTION
Phase 4 de la documentation prévue dans #141. Couvre les **per-screen specs** des écrans complexes qui méritent une documentation dédiée.

## Contenu

- **`docs/screens/_index.md`** : critères de promotion d'un écran en hero screen (≥ 2 conditions parmi : machine d'états, > 1000 LOC, > 2 endpoints, 3+ frameworks Apple, ≥ 3 issues, contrat sécurité). Liste des trois hero screens retenus et des écrans qui pourraient être promus plus tard.

- **`docs/screens/garden-ar-placement.md`** : god object (~3300 LOC). Documente les deux modes (`.create` / `.reopen`), la machine `RelocationPhase`, les widgets (ARSCNView, bottom dock, picker, selection ring, overlays Manual Replacement, share sheet, lux widget, auto-placement IA), les edge cases (permission, WorldMap manquante, modèle USDZ inaccessible, backgrounding, save échoué) et toutes les dépendances. Référence les issues #96, #111, #113, #114, #123, #124, #136, #138.

- **`docs/screens/questionnaire-wizard.md`** : wizard 10 étapes (`GardenWizardStep`). Documente la `TabView` non-paginable, le recalcul de `visibleSteps` quand `spaceType` change, `ScanMethodStepView` avec gating LiDAR, et `WizardSummaryStepView` avec ses deux états `isSaving`. Edge cases : navigation arrière, brouillon perdu si dismiss avant Summary, permission caméra refusée.

- **`docs/screens/personal-details.md`** : machine d'états save sur 4 statuts (`idle`, `saving`, `success`, `error`). Documente `PATCH /users/me` + mise à jour Firebase `displayName`, `canSave` computed (modification + non-vide + pas en cours), edge cases backend (401, 422 oversize, 5xx down). Référence l'issue #138 mergée.

## Cohérence avec les phases précédentes

Tous les diagrammes utilisent `flowchart TB` ou `stateDiagram-v2` strict, avec labels courts et sans caractères spéciaux problématiques (`{}`, `\n`, quotes inner dans stadium nodes, mots réservés comme `style` ou `end`). Leçons des PR #143 et #145 appliquées d'entrée.

## Vérification

- [x] Pas de chevauchement d'arêtes sur les trois diagrammes
- [x] Aucun mot réservé Mermaid (`style`, `end`, `class`, etc.) comme node ID
- [x] Aucun `\n` dans les labels, partout `<br/>`
- [x] Aucune double quote inner dans les stadium nodes `([...])`
- [x] Ton documentation formel maintenu
- [x] Liens internes cohérents (vers `state-machines/`, `flows/`, `architecture/`)
- [x] Références aux issues vérifiées

## Suite

Phase 5 (au fil de l'eau, 5 ADRs prioritaires) : `decisions/0001-mermaid-for-docs.md`, `0002-scan-stacks.md`, `0003-relocation-strategy.md`, `0004-firebase-auth.md`, `0005-patch-users-me-self-authz.md`.

Refs #141 — Phase 4 du plan.