### PR TITLE
📚 [Docs Phase 5] ADRs rétro (5 décisions architecturales)

### DIFF
--- a/docs/decisions/0001-mermaid-for-docs.md
+++ b/docs/decisions/0001-mermaid-for-docs.md
@@ -1,0 +1,63 @@
+# ADR 0001 — Mermaid + sémantique C4 portée par flowchart
+
+- **Statut** : Accepted
+- **Date** : 2026-05-10
+- **Décideurs** : Équipe Arbore
+
+## Contexte
+
+La documentation technique de l'application doit être versionnée dans le dépôt Git, rendue automatiquement sur GitHub, et rester compréhensible par tout nouveau contributeur. Plusieurs options ont été évaluées au moment de structurer `docs/` (cf. issue #141) :
+
+- **Mermaid** — text-based, rendu natif GitHub, diff-able comme du code.
+- **PlantUML** — text-based, plus complet que Mermaid sur les diagrammes UML, mais ne rend pas nativement sur GitHub (requiert un service externe ou des SVG pré-générés).
+- **Structurizr DSL** — DSL dédié à l'architecture C4, génère du PlantUML, demande un outil de build dédié.
+- **Figma** — visuel propre, partagé par l'équipe Design, mais hors du flux Git.
+
+Concernant le **modèle C4** spécifiquement, deux options de syntaxe existent dans Mermaid :
+
+1. La syntaxe native `C4Context` / `C4Container` / `C4Component`.
+2. La syntaxe `flowchart` avec des labels préfixés `[Person]`, `[Container]`, `[System Ext]`, etc.
+
+La syntaxe native est officiellement marquée [`experimental`](https://mermaid.js.org/syntax/c4.html) au moment de la rédaction (Mermaid v11+). Elle produit des **chevauchements d'arêtes** sur les graphes denses, et ne supporte pas les directives `Lay_U/D/L/R` qui permettraient un contrôle de layout fin.
+
+GitHub natif **ne supporte pas** le renderer alternatif ELK (cf. [github/community#138426](https://github.com/orgs/community/discussions/138426)) qui résoudrait certains de ces problèmes — la licence EUPL du package ELK semble être le bloqueur. Cela élimine ELK pour de la doc portable.
+
+## Décision
+
+La documentation `docs/` utilise **Mermaid** comme outil de diagramme unique, intégré dans des fichiers Markdown. **FigJam** reste utilisé en complément pour la communication non-technique (présentation jury, brainstorming UX) mais n'est pas la source de vérité dev.
+
+La **sémantique du modèle C4** est portée par des diagrammes `flowchart TB` avec des labels préfixés `[Person]`, `[Container]`, `[System Ext]` plutôt que par la syntaxe `C4Context` / `C4Container` native de Mermaid. Le moteur de layout `flowchart` (Dagre) est mature, gère correctement les graphes denses, et reste rendu nativement par GitHub. La sémantique C4 reste intacte — elle est portée par le label, pas par la syntaxe.
+
+## Conséquences
+
+### Positives
+
+- Toute la documentation vit dans le dépôt et bénéficie du flux Git habituel (PR, review, blame, history).
+- Aucune dépendance d'outillage externe — pas de service de génération de diagrammes à maintenir.
+- Les contributeurs n'ont aucune installation à faire pour lire ou modifier la documentation.
+- Le ton documentaire est cohérent avec le ton du code (les deux sont lus dans le même IDE).
+- Le moteur de layout `flowchart` est stable depuis longtemps et ne casse pas entre versions Mermaid.
+
+### Négatives
+
+- Les diagrammes complexes en `flowchart` perdent les **rectangles imbriqués** que la syntaxe `C4Container` aurait pu fournir. Le découpage par couches est porté par des classes CSS (color-coding) plutôt que par des boxes visuelles.
+- Une partie de la rigueur académique du modèle C4 (notamment l'invariance des relations niveau par niveau) repose désormais sur la discipline de l'auteur, pas sur l'outil.
+
+### Neutres
+
+- Si Mermaid C4 sort un jour de son statut `experimental` et supporte un meilleur layout, la migration depuis `flowchart` reste possible — il suffit de changer la syntaxe des diagrammes concernés sans renommer les fichiers.
+- L'absence d'ELK sur GitHub est traitée comme une contrainte permanente. Si GitHub change d'avis, on pourra reconsidérer cette décision dans un ADR de successeur.
+
+## Alternatives considérées
+
+- **PlantUML** — écarté car ne rend pas nativement sur GitHub. Aurait nécessité de pré-générer des SVG dans le dépôt et de les régénérer à chaque modification — friction supplémentaire pour les contributeurs.
+- **Structurizr DSL** — écarté pour le même type de raison (outil de build à ajouter à la CI) et parce que la rigueur C4 pure est superflue pour la taille de l'équipe (cinq personnes).
+- **Figma comme source de vérité** — écarté car non-versionné dans Git et impossible à diff. Reste utilisé en parallèle pour la communication design.
+- **`C4Context` native Mermaid** — testée puis écartée après deux itérations qui ont mis en évidence des chevauchements d'arêtes systématiques sur nos graphes (cf. PR #142 et #143). Le passage en `flowchart` a résolu le problème immédiatement.
+
+## Liens
+
+- [Mermaid — Flowcharts Syntax](https://mermaid.js.org/syntax/flowchart.html)
+- [Mermaid — C4 Diagrams (experimental)](https://mermaid.js.org/syntax/c4.html)
+- [GitHub Community Discussion #138426 — ELK not supported](https://github.com/orgs/community/discussions/138426)
+- [Issue #141 — plan de documentation](https://github.com/ArboreTeam/Arbore/issues/141)

--- a/docs/decisions/0002-scan-stacks.md
+++ b/docs/decisions/0002-scan-stacks.md
@@ -1,0 +1,60 @@
+# ADR 0002 — Stack de scan double : RoomPlan (LiDAR) + tracé périmètre (non-LiDAR)
+
+- **Statut** : Accepted
+- **Date** : 2026-04-15
+- **Décideurs** : Équipe Arbore
+
+## Contexte
+
+L'application doit permettre à l'utilisateur de **capturer son espace** (jardin, balcon, intérieur) afin d'y placer des plantes 3D en réalité augmentée. Plusieurs technologies sont disponibles sur iOS pour réaliser cette capture, avec des contraintes différentes en termes de devices supportés, qualité du résultat, et durée du scan.
+
+Le parc d'utilisateurs cible inclut **tous les iPhone à partir de l'iPhone 11** (iOS 17+), ce qui comprend :
+
+- Les **iPhone Pro / Pro Max / iPad Pro** récents (iPhone 12 Pro+) équipés d'un **capteur LiDAR**, qui ouvre l'accès aux API Apple `ARKit.meshWithClassification` et `RoomPlan`.
+- Les **iPhone non-Pro** (iPhone 11 à 15 non-Pro), qui n'ont pas de LiDAR et doivent se contenter du tracking visuel ARKit.
+
+Le wizard de création de jardin propose donc à l'utilisateur de choisir sa méthode de scan via l'étape `scanMethod` (cf. `Views/GardenSteps/ScanMethodSelectionView.swift`).
+
+## Décision
+
+L'application maintient **deux stacks de scan parallèles**, sélectionnées au runtime selon le device :
+
+- **`gardenPerimeter` (non-LiDAR, défaut universel)** — `ARViewContainerMeasure` utilise les raycasts ARKit pour permettre à l'utilisateur de tracer manuellement le **polygone du sol** point par point. Aucun mesh 3D n'est construit ; seul un `[SIMD3<Float>]` représentant le périmètre est sauvegardé. Marche sur **tous les iPhones** ciblés.
+
+- **`roomScan` (LiDAR uniquement)** — `LiDARScanWizardView` utilise `RoomPlan.RoomCaptureSession` pour produire un modèle structuré (murs, sols, portes, fenêtres). La carte est grisée dans le wizard si `RoomCaptureSession.isSupported == false`.
+
+Apple **ObjectCapture** (`PhotogrammetrySession`, iOS 17+, Area mode iOS 18+) n'est **pas intégrée à ce stade** mais reste en candidate forte pour étendre le scan non-LiDAR à une vraie reconstruction 3D dense. Cette extension fait l'objet de l'issue #140.
+
+## Conséquences
+
+### Positives
+
+- Tous les iPhones du parc cible peuvent utiliser l'application sans dégradation fonctionnelle.
+- Les utilisateurs LiDAR bénéficient d'une qualité de scan supérieure (murs et meubles classifiés).
+- Le wizard expose explicitement le choix à l'utilisateur via `ScanMethodSelectionView`, ce qui rend le compromis lisible.
+
+### Négatives
+
+- Le codebase porte **deux flows AR distincts**, ce qui double la surface de maintenance (cf. issue #81 : unifier les five AR view containers dupliqués).
+- Le rendu visuel diffère sensiblement entre les deux methods, ce qui peut surprendre l'utilisateur qui change de device.
+- Le scan non-LiDAR reste limité au polygone du sol, sans information sur les obstacles 3D, ce qui interdit certaines features futures (snap automatique des plantes à un mur, par exemple).
+
+### Neutres
+
+- Les deux méthodes produisent des données différentes côté `GardenLocalStore` (`boundaryPoints: [SIMD3<Float>]` versus `worldmap_{id}.arworldmap` LiDAR). La couche AR consomme les deux indifféremment via les paramètres de `GardenARPlacementView`.
+- ObjectCapture, si intégrée plus tard (#140), apporterait un troisième stack — mais l'expérience utilisateur prévue (scan dédié 30-60 s + processing 1-2 min) serait suffisamment différente pour cohabiter avec les deux existants plutôt que les remplacer.
+
+## Alternatives considérées
+
+- **ARKit `sceneReconstruction = .meshWithClassification` uniquement (LiDAR-only)** — écarté car réserverait l'app aux iPhone Pro, ce qui amputerait drastiquement le parc utilisateurs.
+- **ObjectCapture pour tous (non-LiDAR universel)** — écarté à court terme parce que l'UX du scan ObjectCapture (30-60 s de capture + 1-2 min de processing) est trop lourde pour le flow de création de jardin actuel. Reste candidate pour des features secondaires (cf. issue #140).
+- **Modèles ML custom de monocular depth (Depth Anything V2, MiDaS)** — pressentis dans l'issue #97 mais hors scope court terme : conversion CoreML non triviale, latence on-device incertaine, et le scan polygone du sol suffit pour l'objectif actuel (placer des plantes en AR sur un terrain plan).
+- **Pas de scan du tout, l'utilisateur place « à l'œil »** — écarté car la mesure du périmètre apporte une vraie utilité métier (surface affichée, suggestion AI calibrée).
+
+## Liens
+
+- [Issue #139 — validation roomScan end-to-end](https://github.com/ArboreTeam/Arbore/issues/139)
+- [Issue #140 — Scene-to-scene ICP registration (où ObjectCapture est candidat)](https://github.com/ArboreTeam/Arbore/issues/140)
+- [Issue #97 — Pipeline neural Depth Anything V2 (alternative future)](https://github.com/ArboreTeam/Arbore/issues/97)
+- [Apple — RoomPlan documentation](https://developer.apple.com/documentation/roomplan)
+- [Apple — Object Capture documentation](https://developer.apple.com/documentation/realitykit/realitykit-object-capture/)

--- a/docs/decisions/0003-relocation-strategy.md
+++ b/docs/decisions/0003-relocation-strategy.md
@@ -1,0 +1,65 @@
+# ADR 0003 — Stratégie de relocalisation : ARWorldMap + fallback manual replace
+
+- **Statut** : Accepted
+- **Date** : 2026-04-29
+- **Décideurs** : Équipe Arbore
+
+## Contexte
+
+Lorsqu'un utilisateur crée un jardin dans l'application, les positions des plantes 3D sont **ancrées au monde réel** via des `ARAnchor`. Pour que ces positions soient restaurées lors de la réouverture du jardin (potentiellement plusieurs jours ou semaines plus tard), il faut sérialiser l'état de la session AR — `ARKit` propose pour cela les **`ARWorldMap`**.
+
+Le problème : la relocalisation contre un `ARWorldMap` sauvegardé n'est pas fiable. ARKit se repose sur des **points caractéristiques visuels** détectés à la création, et ne parvient pas toujours à les retrouver si :
+
+- L'éclairage a changé (jour vs nuit, météo, ombres).
+- L'environnement a été modifié (meubles déplacés, plantes existantes ayant poussé).
+- Le device a changé (caméra différente, calibration différente).
+
+Sur un device LiDAR, la mesh structurelle de la pièce aide. Sur un device non-LiDAR, la relocalisation **échoue régulièrement** (cf. issue #96), ce qui laisserait l'utilisateur bloqué sur un écran de coaching sans solution.
+
+## Décision
+
+L'application adopte une **stratégie de relocalisation à trois étages** documentée dans [`../flows/ar-placement.md`](../flows/ar-placement.md) :
+
+1. **Étage 1 — `ARWorldMap.relocalize`** : tentative classique au démarrage de la session AR. Si l'éclairage est compatible, la relocalisation réussit en quelques secondes et les plantes sont restaurées via leurs `ARAnchor`.
+
+2. **Étage 2 — Manual replacement (issue #111)** : si l'étage 1 ne réussit pas, l'utilisateur peut tap sur **« Replacer manuellement »**. Il retrace le périmètre du jardin, et les positions des plantes sont **morphées automatiquement** via les Mean Value Coordinates (Floater 2003) de l'ancien périmètre vers le nouveau. Un score de distorsion par plante avertit l'utilisateur des zones de forte déformation, et un mode `adjusting` permet d'affiner manuellement les positions avant sauvegarde finale.
+
+3. **Étage 3 — Scene-to-scene ICP (issue #140, futur)** : à terme, capturer une nouvelle scène 3D (LiDAR via `ARKit.meshWithClassification` ou non-LiDAR via `ObjectCapture`) et la **registrer** contre la scène sauvegardée pour calculer une transformation rigide. Le score RMS post-alignement servirait également d'indicateur de similarité à montrer à l'utilisateur (« ton jardin a changé »). Cette piste reste à valider via un spike.
+
+Le pipeline neural depth + matching (issue #97) reste candidat à un quatrième étage **uniquement** si les étages 1-3 s'avèrent insuffisants en production.
+
+## Conséquences
+
+### Positives
+
+- L'utilisateur n'est **jamais bloqué** sur un écran de coaching infini : la manual replace est immédiatement accessible.
+- Le morphing MVC produit des résultats acceptables même lorsque la forme du périmètre change significativement entre sessions.
+- La stratégie est **layered** : on tente le moins coûteux d'abord (ARWorldMap), on dégrade vers le plus coûteux si nécessaire (manual replace, puis ICP).
+
+### Négatives
+
+- L'expérience utilisateur post-manual-replace dépend de la qualité du tracé et du morphing — les plantes peuvent se retrouver en zones de forte distorsion, marquées en orange mais nécessitant un ajustement manuel.
+- Le manual replace ne fonctionne que si **l'ancien périmètre** est lisible en mémoire (chargé depuis le `scene_{id}.json`). Si ce fichier n'existe pas (cas du device fraîchement installé, cf. issue #114), même la manual replace est impossible et l'utilisateur voit le `gardenUnavailableView`.
+- Le code de l'étage 2 a substantiellement augmenté la taille de `GardenARPlacementView` (de ~2 000 à ~3 300 lignes), aggravant la dette technique du god object (issue #124).
+
+### Neutres
+
+- Le morphing MVC est testable isolément (math pure) et fera l'objet de tests unitaires dédiés (issue #123).
+- L'étage 3 (ICP scene-to-scene) reste un parti pris architectural à confirmer — son ajout ne remet pas en cause l'étage 2 mais offre une alternative plus rapide pour les utilisateurs LiDAR.
+
+## Alternatives considérées
+
+- **Tout miser sur `ARWorldMap.relocalize` et bloquer l'utilisateur en cas d'échec** — l'approche initiale, abandonnée après les retours négatifs des testeurs (issue #96).
+- **Sauvegarder les positions des plantes en coordonnées GPS** — écarté car la précision GPS (quelques mètres) est totalement incompatible avec le placement intra-jardin précis dont l'app a besoin.
+- **Imposer une « pose de référence » au démarrage de chaque session** — écarté car friction UX trop importante (l'utilisateur devrait se replacer exactement à l'endroit où il avait sauvegardé, ce qui est rarement possible).
+- **Backend qui stocke les positions et l'utilisateur les replace à zéro** — écarté car perdrait tout l'intérêt AR : la position serait dans un repère abstrait, pas dans le monde réel.
+
+## Liens
+
+- [Issue #96 — Relocalisation échoue si l'éclairage change](https://github.com/ArboreTeam/Arbore/issues/96)
+- [Issue #111 — Manual replace avec morphing (mergée 2026-04-29)](https://github.com/ArboreTeam/Arbore/issues/111)
+- [Issue #140 — Scene-to-scene ICP registration (futur)](https://github.com/ArboreTeam/Arbore/issues/140)
+- [Issue #97 — Pipeline neural depth + matching](https://github.com/ArboreTeam/Arbore/issues/97)
+- [Issue #114 — Garden lost after app reinstall](https://github.com/ArboreTeam/Arbore/issues/114)
+- [Apple — ARWorldMap documentation](https://developer.apple.com/documentation/arkit/arworldmap)
+- [Floater, M. S. (2003). Mean value coordinates. *Computer Aided Geometric Design*.](https://www.cs.jhu.edu/~misha/Fall09/Floater03.pdf)

--- a/docs/decisions/0004-firebase-auth.md
+++ b/docs/decisions/0004-firebase-auth.md
@@ -1,0 +1,67 @@
+# ADR 0004 — Firebase Auth comme provider d'authentification
+
+- **Statut** : Accepted
+- **Date** : 2026-01-20
+- **Décideurs** : Équipe Arbore
+
+## Contexte
+
+L'application doit gérer **l'authentification des utilisateurs** : signup, login email/mot de passe, login Google, reset de mot de passe, vérification d'email, suppression de compte. Côté backend, chaque requête utilisateur doit pouvoir être attribuée à un utilisateur authentifié et vérifié.
+
+Plusieurs critères pèsent sur le choix d'un provider :
+
+- **Vitesse de delivery** — le projet est sous échéance pédagogique (livraisons sprint après sprint).
+- **Coût** — l'équipe étant étudiante, aucun budget significatif n'est disponible.
+- **Conformité RGPD** — les données personnelles (email, nom) doivent être traitées avec un niveau de garantie suffisant.
+- **Sécurité** — la chaîne d'auth doit résister aux attaques classiques (brute force, credential stuffing, session hijacking).
+- **Multi-platform** — la doc cible iOS aujourd'hui, web (Next.js) demain.
+
+## Décision
+
+L'application utilise **Firebase Authentication** comme unique provider d'auth, avec deux méthodes activées :
+
+- **Email + mot de passe** (avec envoi automatique d'un mail de vérification).
+- **Google Sign-In** (via le SDK Google côté iOS).
+
+Côté backend Go, chaque requête protégée est vérifiée par le middleware `FirebaseAuthMiddleware` qui consomme le **Firebase Admin SDK** pour valider le `Bearer` token JWT et en extraire l'`uid`. Cet `uid` devient l'identifiant fonctionnel utilisé dans toutes les collections Mongo.
+
+Le mot de passe n'est **jamais transmis au backend** — Firebase Auth se charge intégralement de la chaîne signup/login/reset.
+
+## Conséquences
+
+### Positives
+
+- L'équipe ne maintient **aucune logique d'authentification custom** : pas de hash de mot de passe, pas de session, pas de gestion du reset par token magique, pas d'OAuth flow à implémenter. Firebase fait tout cela.
+- Les comptes Google sont gérés sans friction côté iOS — un seul SDK Google Sign-In suffit.
+- Le **Firebase Admin SDK** côté Go fournit une vérification de token rapide et fiable (cache des clés publiques en interne).
+- Le système est gratuit jusqu'à des volumes très significatifs (50 000 MAU pour le tier Spark, largement au-delà de l'usage attendu).
+- L'envoi de mails de vérification, de reset, et la gestion des comptes vérifiés/non-vérifiés est intégrée nativement.
+- La même infrastructure d'auth resservira pour le front web Next.js (issues #98-#109) sans duplication.
+
+### Négatives
+
+- **Vendor lock-in fort** : si Firebase devient payant ou indisponible, la migration vers un autre provider impliquerait de migrer tous les `uid` (qui sont des chaînes opaques Firebase) et de recréer un système d'auth équivalent.
+- Les **données personnelles** (email) sont stockées chez Google. Cela impose un consentement RGPD explicite et la mention du sous-traitant dans la politique de confidentialité.
+- Les **logs d'authentification** vivent dans la console Firebase et ne sont pas directement intégrés à notre observabilité côté backend.
+- L'**email de vérification** envoyé par Firebase utilise les templates Firebase par défaut, peu personnalisables sans passer en Pay-as-you-go.
+
+### Neutres
+
+- Le découplage `uid Firebase` ↔ document Mongo (`users.uid`) impose une discipline applicative pour éviter les comptes orphelins (Firebase OK mais Mongo manquant ou inversement). Cette discipline est portée par `saveUserToBackendThrowing` côté iOS qui rollback Firebase si `POST /users` échoue (cf. issue #137 et l'ADR 0005).
+- Le **ban d'utilisateur** est géré applicativement (flag `banned: true` dans Mongo, vérifié par le middleware Firebase via `CheckUserBannedFunc`). Cette approche évite de désactiver le compte côté Firebase ce qui empêcherait l'utilisateur de récupérer ses données via le flow RGPD.
+
+## Alternatives considérées
+
+- **Auth custom avec PostgreSQL + bcrypt** — écarté par coût initial (≥ 2 semaines de dev rien que pour avoir un MVP) et risque sécurité (cryptographie maison rarement bien faite la première fois).
+- **AWS Cognito** — comparable en features à Firebase mais avec une expérience développeur historiquement plus complexe, surtout côté iOS où le SDK Firebase est très mature.
+- **Supabase Auth** — open-source et auto-hébergeable, mais demande de gérer un PostgreSQL nous-mêmes et la doc iOS est moins fournie qu'Firebase.
+- **Auth0** — solide mais payant au-delà de 7 000 utilisateurs (tier gratuit limité).
+- **Apple Sign In + custom backend** — partiel : Apple Sign In ne couvre que les utilisateurs iCloud, il faudrait quand même une auth email/password pour les autres.
+
+## Liens
+
+- [Firebase Auth — Documentation](https://firebase.google.com/docs/auth)
+- [Firebase Admin SDK Go](https://firebase.google.com/docs/admin/setup)
+- [Issue #110 — Backend n'enforce pas la vérification email du token Firebase](https://github.com/ArboreTeam/Arbore/issues/110)
+- [Issue #137 — Backend POST /users silently fails on signup → orphan Firebase user](https://github.com/ArboreTeam/Arbore/issues/137)
+- ADR 0005 — Self-authz pattern (qui dépend de Firebase Admin)

--- a/docs/decisions/0005-self-authz-pattern.md
+++ b/docs/decisions/0005-self-authz-pattern.md
@@ -1,0 +1,75 @@
+# ADR 0005 — Self-authz via token uid (pas d'uid dans l'URL)
+
+- **Statut** : Accepted
+- **Date** : 2026-05-10
+- **Décideurs** : Équipe Arbore
+
+## Contexte
+
+Lorsqu'un utilisateur édite ses propres données (nom, photo, jardins, consentements), le backend doit garantir qu'il **n'agit que sur ses propres ressources**. Le risque à éviter : qu'un utilisateur authentifié A puisse modifier les données d'un utilisateur B en spécifiant l'`uid` de B dans la requête (par exemple via une URL `PATCH /users/{uid}` où l'`uid` serait un paramètre de chemin).
+
+Au moment de concevoir le nouvel endpoint `PATCH /users/me` (issue #138), deux options se présentaient :
+
+1. **`PATCH /users/{uid}`** — l'`uid` cible vient de l'URL. Le handler doit comparer cet `uid` au `tokenUID` extrait du middleware et renvoyer `403` si différent.
+2. **`PATCH /users/me`** — pas d'`uid` dans l'URL. Le handler utilise directement l'`uid` extrait du token. Toute requête est implicitement self-only.
+
+Le codebase héritait déjà d'endpoints en variante 1 (`POST /users/:uid/photo`, `GET /users/:uid/photo`), qui implémentent explicitement la vérification `tokenUID == uidParam` et renvoient `403 Forbidden` en cas de mismatch.
+
+## Décision
+
+**Tout nouvel endpoint sur les ressources de l'utilisateur courant doit utiliser le pattern `/users/me`**, **`/gardens`** (sans filtre d'`uid` dans l'URL), ou tout autre chemin qui ne **mentionne pas l'`uid`** dans l'URL.
+
+L'`uid` est systématiquement extrait du **token Firebase** par le middleware `FirebaseAuthMiddleware` et posé dans le contexte Gin via `c.Set("uid", ...)`. Les handlers lisent uniquement cette source.
+
+Les endpoints hérités qui acceptent un `uid` dans l'URL (`/users/:uid/photo`) restent en place pour ne pas casser les clients existants, mais ne sont **plus la cible** pour de nouvelles features. Leur consolidation (migration vers `/users/me/photo`) sera tracée dans une issue séparée si une refonte API est planifiée.
+
+L'`uid` envoyé dans le body d'une requête est **explicitement ignoré** et écrasé par le `tokenUID` (cf. `createUser` et `createGarden` dans `main.go`).
+
+## Conséquences
+
+### Positives
+
+- **Surface d'attaque réduite** : un utilisateur ne peut pas tenter d'agir au nom d'un autre, même s'il forge manuellement une requête HTTP. La cible de la requête est intrinsèquement self.
+- **Simplicité du handler** : pas de comparaison `tokenUID == uidParam`, pas de risque d'oublier la vérification dans un nouveau handler.
+- **Pattern cohérent** avec les conventions REST modernes (`/users/me` est l'idiome reconnu pour « l'utilisateur courant »).
+- **Lisibilité côté client** : les appels iOS deviennent `NetworkManager.shared.request(endpoint: "/users/me", method: .PATCH, body: ...)` sans avoir à concaténer l'`uid` dans l'URL.
+
+### Négatives
+
+- **Asymétrie temporaire** dans l'API : les endpoints hérités utilisent encore `/users/:uid/photo`, ce qui crée une incohérence visible pour un nouvel arrivant qui lit le code. Cette incohérence est tolérée le temps d'une refonte future.
+- **Impossibilité d'agir sur un autre utilisateur** sans introduire un endpoint admin dédié. Cela impose à l'avenir, si la feature de modération devient nécessaire, de créer une route séparée `/admin/users/:uid` avec une autorisation différente (rôle admin vérifié via une claim Firebase custom).
+
+### Neutres
+
+- Les **endpoints de lecture publique** (`GET /plants`, `GET /models/thumbnails/:filename`) ne sont pas concernés par ce pattern puisqu'ils ne portent pas d'`uid`. Ils restent en l'état.
+- Les **handlers en cascade** (par exemple `deleteUser` qui supprime gardens puis consents puis le user) bénéficient également du pattern : l'`uid` est lu une seule fois en tête du handler et tous les filtres `bson.M{"uid": uid}` en bénéficient.
+
+## Application concrète
+
+| Endpoint | Pattern | Notes |
+|---|---|---|
+| `PATCH /users/me` | ✅ self-authz | Introduit par #138. Modèle pour tout nouvel endpoint. |
+| `GET /users/:uid` | ⚠️ hérité | Vérifie `tokenUID == uidParam` puis renvoie 403 si différent. |
+| `POST /users/:uid/photo` | ⚠️ hérité | Idem. |
+| `GET /users/:uid/photo` | ⚠️ hérité | Idem. |
+| `POST /users` | ✅ self-authz | Le `uid` du body est ignoré, le `tokenUID` est utilisé. |
+| `DELETE /users` | ✅ self-authz | Pas d'`uid` dans l'URL. |
+| `GET /gardens` | ✅ self-authz | Filtre implicite `bson.M{"uid": tokenUID}`. |
+| `POST /gardens` | ✅ self-authz | `garden.UID = tokenUID` forcé. |
+| `PUT /gardens/:id` | ✅ self-authz | Filtre `bson.M{"_id": id, "uid": tokenUID}` garantit l'ownership. |
+| `DELETE /gardens/:id` | ✅ self-authz | Idem. |
+| `POST /consents` | ✅ self-authz | `consent.UID = tokenUID` forcé. |
+| `GET /consents` | ✅ self-authz | Filtre par `uid`. |
+
+## Alternatives considérées
+
+- **Header `X-User-Id` géré par le client** — écarté car équivalent à mettre l'`uid` dans l'URL : trivial à falsifier.
+- **Signed URL avec scope `users/{uid}`** — écarté car plus complexe à implémenter qu'un middleware token classique pour un gain de sécurité minime.
+- **Custom claims Firebase avec rôle** — pas nécessaire pour la self-authz, mais sera utile pour introduire un rôle admin si la modération devient un besoin.
+
+## Liens
+
+- [Issue #138 — PATCH /users/me](https://github.com/ArboreTeam/Arbore/issues/138)
+- [Issue #110 — Backend n'enforce pas la vérification email du token Firebase](https://github.com/ArboreTeam/Arbore/issues/110)
+- ADR 0004 — Firebase Auth (qui fournit le `uid` injecté dans le contexte)
+- [OWASP — Broken Object Level Authorization](https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/)

--- a/docs/decisions/_index.md
+++ b/docs/decisions/_index.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records (ADRs)
+
+Cette section regroupe les **décisions d'architecture** prises au fil du projet, au format **MADR** (Markdown Architectural Decision Records).
+
+## Format
+
+Chaque ADR suit la structure suivante :
+
+1. **Statut** — `Proposed`, `Accepted`, `Deprecated`, `Superseded by [n]`. La date d'acceptation est précisée.
+2. **Contexte** — le problème à résoudre et les contraintes qui pèsent sur la décision.
+3. **Décision** — le choix retenu, exprimé à la voix active.
+4. **Conséquences** — les effets positifs, négatifs et neutres du choix.
+5. **Alternatives considérées** — les options qui ont été évaluées et écartées, avec la raison de l'écart.
+
+Le format complet est documenté sur [adr.github.io/madr](https://adr.github.io/madr/).
+
+## Convention de nommage
+
+Les ADRs sont numérotés à partir de `0001` et nommés en `kebab-case` :
+
+```
+0001-mermaid-for-docs.md
+0002-scan-stacks.md
+0003-relocation-strategy.md
+...
+```
+
+## Immutabilité
+
+Une fois passé en statut `Accepted`, **un ADR n'est jamais modifié**. Si une décision évolue, un nouvel ADR est créé et il **supersede** explicitement l'ancien (le statut de l'ancien devient `Superseded by 0XXX`). Cette discipline garantit la traçabilité historique des choix.
+
+Cette règle s'applique également si l'on découvre une erreur factuelle dans un ADR existant : on crée un nouvel ADR de correction plutôt que d'éditer l'ancien.
+
+## Index
+
+| # | Titre | Statut | Sujet |
+|---|---|---|---|
+| [0001](0001-mermaid-for-docs.md) | Mermaid + sémantique C4 portée par flowchart | Accepted (2026-05-10) | Choix d'outillage documentaire |
+| [0002](0002-scan-stacks.md) | Stack de scan double : RoomPlan (LiDAR) + tracé périmètre (non-LiDAR) | Accepted (2026-04-15) | AR / capture spatiale |
+| [0003](0003-relocation-strategy.md) | Relocalisation ARWorldMap + fallback manual replace | Accepted (2026-04-29) | AR / persistance session |
+| [0004](0004-firebase-auth.md) | Firebase Auth comme provider d'authentification | Accepted (2026-01-20) | Authentification |
+| [0005](0005-self-authz-pattern.md) | Self-authz via token uid (pas d'uid dans l'URL) | Accepted (2026-05-10) | Sécurité backend |
+
+## Pourquoi des ADRs
+
+Les ADRs servent trois publics :
+
+- **Les nouveaux contributeurs** : comprendre les choix existants évite de les remettre en question sans raison ou, à l'inverse, de les contourner par méconnaissance.
+- **Les revues d'architecture** : un ADR documenté est plus rapide à challenger qu'une décision tacite.
+- **L'examinateur externe (jury Epitech)** : la présence d'ADRs démontre la maturité d'architecte et la capacité à expliciter les compromis.
+
+Tous les ADRs de ce dépôt sont volontairement courts (une page maximum) afin d'être effectivement lus et maintenus.


### PR DESCRIPTION
Phase 5 — la dernière du plan #141. Couvre la vue **historique** des décisions architecturales au format MADR (Markdown Architectural Decision Records).

## Contenu

- **`docs/decisions/_index.md`** : présentation du format MADR, convention de nommage (`NNNN-kebab-case.md`), règle d'immutabilité (jamais modifier après `Accepted`, créer un nouvel ADR qui supersede), tableau récapitulatif des cinq ADRs.

- **`0001-mermaid-for-docs.md`** *(2026-05-10)* — Mermaid + sémantique C4 portée par `flowchart` au lieu de `C4Context` experimental. Trace l'élimination de PlantUML (pas de rendu GitHub natif), Structurizr (outil build supplémentaire), Figma (non-versionné), et ELK (non supporté par GitHub).

- **`0002-scan-stacks.md`** *(2026-04-15)* — Double stack RoomPlan (LiDAR) + tracé périmètre (non-LiDAR), avec ObjectCapture iOS 17+ comme candidat futur via #140. Trade-off : tous les iPhones supportés vs duplication de code AR (#81).

- **`0003-relocation-strategy.md`** *(2026-04-29)* — Stratégie à trois étages : `ARWorldMap.relocalize` → manual replace avec morphing MVC → ICP scene-to-scene futur. Documente pourquoi on ne mise pas tout sur ARWorldMap (#96) ni sur GPS.

- **`0004-firebase-auth.md`** *(2026-01-20)* — Firebase Auth (email + Google Sign-In). Trade-offs assumés : vendor lock-in fort vs vitesse de delivery et coût zéro. Mentionne la discipline applicative pour éviter les comptes orphelins (#137).

- **`0005-self-authz-pattern.md`** *(2026-05-10)* — Pattern `/users/me` + filtre `bson` par `uid` du token, jamais `uid` de l'URL ou du body. Cible pour tout nouvel endpoint depuis #138. Liste les endpoints hérités à migrer.

## Format MADR

Tous les ADRs suivent la même structure :

1. **Statut + date**
2. **Contexte** (problème + contraintes)
3. **Décision** (à la voix active)
4. **Conséquences** (positives, négatives, neutres)
5. **Alternatives considérées** (avec raison d'écart)
6. **Liens** (issues GitHub, documentation externe)

Volontairement courts (1 page max) pour rester effectivement lus et maintenus.

## Plan #141 — complet après ce merge

| Phase | PR | Statut |
|---|---|---|
| Phase 1 — README + C4 Context/Container + Glossaire | #142 | ✅ mergée |
| Phase 2 — Composants iOS + Backend + Data model | #143 | ✅ mergée |
| Phase 3 — State machine + Flows | #145 | ✅ mergée |
| Phase 4 — Per-screen specs (3 hero screens) | #146 | ✅ mergée |
| **Phase 5 — ADRs rétro** | **#147** | 🟢 cette PR |

À traiter en parallèle : #144 (CI validation docs Mermaid + liens + drift), à activer après ce merge.

Closes #141 (après merge de cette PR).