### PR TITLE
[CI/Docs] Workflow validation Mermaid + liens + drift (#144)

### DIFF
--- a/.github/scripts/docs-drift-check.sh
+++ b/.github/scripts/docs-drift-check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# docs-drift-check.sh
+#
+# Scanne tous les fichiers Markdown sous docs/ et vérifie que les chemins
+# de fichiers code (extensions .swift, .go, .py, .ts, .tsx, .yaml, .yml,
+# .json, .toml, .xcconfig, .pbxproj, .plist) qu'ils citent existent
+# toujours dans le dépôt. Fail si au moins un chemin cité est absent.
+#
+# Heuristique de détection : chemins entre backticks contenant '/' et
+# se terminant par une des extensions surveillées. Le script tolère les
+# chemins entre backticks doubles et les chemins escapés.
+#
+# Mots-clés ignorés (faux positifs connus) :
+#   - chemins relatifs commençant par './' ou '../' qui pointent vers d'autres docs
+#   - URLs (commençant par http:// ou https://)
+#   - chemins commençant par '/' (paths backend, ex: /users/me) — ce sont des
+#     endpoints, pas des fichiers
+#   - extensions Markdown .md (liens inter-docs gérés par lychee)
+#
+# Stratégie de matching : un chemin cité (par exemple
+# "Models/User.swift") est considéré valide si **au moins un fichier du
+# dépôt y termine** (suffix match). Cela évite d'imposer aux docs
+# d'utiliser le chemin complet depuis la racine pour chaque fichier,
+# tout en détectant correctement les suppressions et renommages.
+#
+# Exit codes :
+#   0 — aucun drift détecté
+#   1 — au moins un chemin code référencé n'existe nulle part dans le dépôt
+
+set -euo pipefail
+
+# Extensions surveillées. Tout ce qui n'est pas dans cette liste est ignoré.
+EXTS_REGEX='\.(swift|go|py|ts|tsx|js|yaml|yml|json|toml|xcconfig|pbxproj|plist|sh|dockerfile|mod|sum)'
+
+missing_count=0
+checked_count=0
+missing_paths=()
+
+# Liste tous les fichiers .md dans docs/ (portable bash 3.2+)
+md_files=()
+while IFS= read -r line; do
+  md_files+=("$line")
+done < <(find docs -type f -name "*.md" | sort)
+
+if [ ${#md_files[@]} -eq 0 ]; then
+  echo "No Markdown files found under docs/. Skipping drift check."
+  exit 0
+fi
+
+echo "Scanning ${#md_files[@]} Markdown file(s) under docs/ for code references…"
+echo ""
+
+# Pré-cache : liste complète des fichiers source du dépôt qui pourraient
+# être référencés. On exclut node_modules, build artifacts et .git.
+repo_files=()
+while IFS= read -r line; do
+  repo_files+=("$line")
+done < <(
+  find . \
+    \( -name node_modules -o -name .git -o -name DerivedData -o -name build -o -name Pods -o -name __pycache__ \) -prune -o \
+    -type f -print | sed 's|^\./||' | sort
+)
+echo "Indexed ${#repo_files[@]} source file(s) in the repository."
+echo ""
+
+for md in "${md_files[@]}"; do
+  # Extrait tous les contenus entre backticks (single or double) du fichier.
+  # On utilise grep -oP avec une regex Perl-compatible pour matcher uniquement
+  # le contenu interne.
+  while IFS= read -r match; do
+    # match contient déjà le texte interne du backtick. Trim espaces autour.
+    candidate="$(echo "$match" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+    # Skip URLs
+    [[ "$candidate" =~ ^https?:// ]] && continue
+
+    # Skip endpoints backend (commencent par /users, /gardens, etc.) — heuristique :
+    # un chemin qui commence par '/' suivi d'une lettre minuscule sans extension
+    # connue est probablement un endpoint, pas un fichier.
+    if [[ "$candidate" =~ ^/[a-z] ]] && ! [[ "$candidate" =~ $EXTS_REGEX ]]; then
+      continue
+    fi
+
+    # Skip si pas d'extension surveillée
+    if ! [[ "$candidate" =~ $EXTS_REGEX$ ]]; then
+      continue
+    fi
+
+    # Skip chemins relatifs vers d'autres docs (gérés par lychee)
+    [[ "$candidate" == ./* ]] && continue
+    [[ "$candidate" == ../* ]] && continue
+
+    # Skip chemins avec wildcards (ils sont des références de pattern, pas des
+    # fichiers réels).
+    [[ "$candidate" == *"*"* ]] && continue
+
+    # Nettoie les fragments éventuels (#anchor) ou query strings
+    candidate="${candidate%%#*}"
+    candidate="${candidate%%\?*}"
+
+    # Skip si le chemin contient un caractère manifestement invalide pour un
+    # chemin de fichier réel (placeholders type {id}, $var, etc.)
+    [[ "$candidate" =~ \{ ]] && continue
+    [[ "$candidate" =~ \$ ]] && continue
+
+    # Skip chemins qui ressemblent à des fragments de texte (espaces, longueur
+    # absurde, virgule, deux-points).
+    [[ "$candidate" =~ [[:space:]] ]] && continue
+    [[ "$candidate" =~ [,:] ]] && continue
+    [ "${#candidate}" -gt 200 ] && continue
+
+    # Si le chemin commence par '/' (absolu), on le rend relatif au repo
+    if [[ "$candidate" == /* ]]; then
+      candidate="${candidate#/}"
+    fi
+
+    checked_count=$((checked_count + 1))
+
+    # Match : un fichier du repo dont le chemin termine par "$candidate".
+    # Le candidate doit être précédé d'un séparateur de chemin pour éviter
+    # qu'un chemin "x.swift" matche par accident "barx.swift".
+    found=0
+    if [ -e "$candidate" ]; then
+      found=1
+    else
+      for repo_file in "${repo_files[@]}"; do
+        if [[ "$repo_file" == */"$candidate" ]] || [[ "$repo_file" == "$candidate" ]]; then
+          found=1
+          break
+        fi
+      done
+    fi
+
+    if [ "$found" -eq 0 ]; then
+      missing_count=$((missing_count + 1))
+      missing_paths+=("$md → $candidate")
+    fi
+  done < <(grep -oE '`[^`]+`' "$md" 2>/dev/null | sed 's/^`//; s/`$//' || true)
+done
+
+echo "Checked $checked_count code path reference(s) across docs/"
+echo ""
+
+if [ "$missing_count" -gt 0 ]; then
+  echo "::error::Doc drift detected — $missing_count code path(s) referenced in docs no longer exist:"
+  for entry in "${missing_paths[@]}"; do
+    echo "  - $entry"
+  done
+  echo ""
+  echo "Update the offending Markdown files to point at the new path, or remove the obsolete reference."
+  exit 1
+fi
+
+echo "✅ No doc drift detected."
+exit 0

--- a/.github/scripts/docs-drift-check.sh
+++ b/.github/scripts/docs-drift-check.sh
@@ -132,6 +132,15 @@ for md in "${md_files[@]}"; do
       done
     fi
 
+    # Skip gitignored files (Secrets.xcconfig, .env, *.adminsdk.json, etc.).
+    # On les cite légitimement dans la doc même s'ils ne sont pas dans
+    # le dépôt. git check-ignore renvoie 0 si le chemin matche .gitignore.
+    if [ "$found" -eq 0 ]; then
+      if git check-ignore --quiet "$candidate" 2>/dev/null; then
+        found=1
+      fi
+    fi
+
     if [ "$found" -eq 0 ]; then
       missing_count=$((missing_count + 1))
       missing_paths+=("$md → $candidate")

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,123 @@
+name: 📚 Docs validation
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "ArboreUi/**/*.swift"
+      - "ArboreBackend/**/*.go"
+      - ".github/workflows/docs.yml"
+      - ".github/scripts/docs-*.sh"
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ────────────────────────────────────────────────────────────
+  # Job 1 — Validation syntaxe Mermaid
+  # ────────────────────────────────────────────────────────────
+  mermaid-validation:
+    name: Mermaid syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli
+
+      - name: Install Puppeteer Chromium dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libnss3 libatk1.0-0 libatk-bridge2.0-0 libxss1 libasound2t64 \
+            libxshmfence1 libgbm1 libdrm2 libxkbcommon0
+
+      - name: Render every Mermaid block in docs/
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/mermaid-blocks
+          fail=0
+          total=0
+
+          # Configure puppeteer to use a sane sandbox
+          cat > /tmp/puppeteer.json <<'JSON'
+          { "args": ["--no-sandbox", "--disable-setuid-sandbox"] }
+          JSON
+
+          # Extract every ```mermaid ... ``` block from docs/**/*.md
+          find docs -type f -name "*.md" -print0 | while IFS= read -r -d '' file; do
+            awk '
+              /^```mermaid$/ { in_block=1; block_idx++; out=ENVIRON["TMP"] "/" block_idx ".mmd"; next }
+              /^```$/        { in_block=0; next }
+              in_block       { print > out }
+            ' TMP=/tmp/mermaid-blocks "$file"
+          done
+
+          # Render each extracted block
+          for mmd in /tmp/mermaid-blocks/*.mmd; do
+            [ -f "$mmd" ] || continue
+            total=$((total + 1))
+            if ! mmdc -p /tmp/puppeteer.json -i "$mmd" -o "${mmd%.mmd}.svg" 2> "${mmd%.mmd}.err"; then
+              fail=$((fail + 1))
+              echo "::error file=$mmd::Mermaid block failed to render"
+              cat "${mmd%.mmd}.err"
+              echo "--- offending block ---"
+              cat "$mmd"
+              echo "-----------------------"
+            fi
+          done
+
+          echo "Rendered $total Mermaid block(s), $fail failure(s)."
+          exit $fail
+
+  # ────────────────────────────────────────────────────────────
+  # Job 2 — Vérification des liens internes
+  # ────────────────────────────────────────────────────────────
+  link-check:
+    name: Internal links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lychee link checker on docs/
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # On vérifie les liens internes en mode strict ; les liens externes
+          # restent en warning (flakiness réseau côté CI).
+          args: >
+            --no-progress
+            --offline
+            --include-fragments
+            --base .
+            'docs/**/*.md'
+          fail: true
+
+  # ────────────────────────────────────────────────────────────
+  # Job 3 — Détection de drift (chemins code cités dans la doc)
+  # ────────────────────────────────────────────────────────────
+  drift-detection:
+    name: Doc drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify file paths referenced in docs/ still exist
+        run: bash .github/scripts/docs-drift-check.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,13 +62,16 @@ jobs:
           { "args": ["--no-sandbox", "--disable-setuid-sandbox"] }
           JSON
 
-          # Extract every ```mermaid ... ``` block from docs/**/*.md
+          # Extract every ```mermaid ... ``` block from docs/**/*.md.
+          # Each block goes to /tmp/mermaid-blocks/<file>-<idx>.mmd so the
+          # error context tells us which file and which block failed.
           find docs -type f -name "*.md" -print0 | while IFS= read -r -d '' file; do
-            awk '
-              /^```mermaid$/ { in_block=1; block_idx++; out=ENVIRON["TMP"] "/" block_idx ".mmd"; next }
-              /^```$/        { in_block=0; next }
-              in_block       { print > out }
-            ' TMP=/tmp/mermaid-blocks "$file"
+            slug="$(echo "$file" | sed 's|/|__|g; s|\.md$||')"
+            awk -v OUTDIR=/tmp/mermaid-blocks -v SLUG="$slug" '
+              /^```mermaid$/ { in_block=1; block_idx++; out=OUTDIR "/" SLUG "-" block_idx ".mmd"; next }
+              /^```[[:space:]]*$/ { in_block=0; next }
+              in_block { print > out }
+            ' "$file"
           done
 
           # Render each extracted block
@@ -100,13 +103,14 @@ jobs:
       - name: Run lychee link checker on docs/
         uses: lycheeverse/lychee-action@v2
         with:
-          # On vérifie les liens internes en mode strict ; les liens externes
-          # restent en warning (flakiness réseau côté CI).
+          # On vérifie les liens internes en mode strict. Les liens externes
+          # ne sont pas suivis (--offline) pour éviter la flakiness réseau.
+          # --root-dir doit être un chemin absolu — on prend le workspace.
           args: >
             --no-progress
             --offline
             --include-fragments
-            --base .
+            --root-dir ${{ github.workspace }}
             'docs/**/*.md'
           fail: true
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI/CD](https://github.com/ArboreTeam/Arbore/actions/workflows/ci.yml/badge.svg)](https://github.com/ArboreTeam/Arbore/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/ArboreTeam/Arbore/actions/workflows/codeql.yml/badge.svg)](https://github.com/ArboreTeam/Arbore/actions/workflows/codeql.yml)
 [![Docker](https://github.com/ArboreTeam/Arbore/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/ArboreTeam/Arbore/actions/workflows/docker-publish.yml)
+[![Docs](https://github.com/ArboreTeam/Arbore/actions/workflows/docs.yml/badge.svg)](https://github.com/ArboreTeam/Arbore/actions/workflows/docs.yml)
 
 Arbore est un projet de 4ème et 5ème année - une application complète de jardinage qui vous aide à organiser et entretenir vos jardins avec la puissance de la réalité augmentée et de l'intelligence artificielle.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,24 @@ Les fichiers numérotés (`01-`, `02-`) suivent l'ordre de lecture recommandé. 
 | Interaction entre acteurs dans le temps | `sequenceDiagram` |
 | États discrets et transitions | `stateDiagram-v2` |
 
+## Contrat CI
+
+Toute PR ciblant `main` qui modifie un fichier sous `docs/`, ou un fichier source cité par la documentation (`ArboreUi/**/*.swift`, `ArboreBackend/**/*.go`), déclenche le workflow `.github/workflows/docs.yml`. Ce workflow exécute trois jobs en parallèle et bloque le merge si l'un d'eux échoue.
+
+| Job | Outil | Cause d'échec |
+|---|---|---|
+| **Mermaid syntax** | [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) | Un bloc ``` ```mermaid ``` ``` dans `docs/**/*.md` ne se rend pas (syntaxe invalide, mot-clé réservé utilisé comme node ID, caractère spécial non échappé). |
+| **Internal links** | [`lycheeverse/lychee-action`](https://github.com/lycheeverse/lychee-action) en mode `--offline` | Un lien interne dans `docs/` pointe vers un fichier ou une ancre qui n'existe pas. Les liens externes restent en warning. |
+| **Doc drift** | Script `.github/scripts/docs-drift-check.sh` | Un chemin code cité dans la documentation entre backticks (par exemple `` `Services/NetworkManager.swift` ``) ne correspond à aucun fichier du dépôt. Détecte les renommages et suppressions non répercutés. |
+
+La logique de matching du drift est en **suffix match** : un chemin cité comme `Models/User.swift` est considéré valide si un fichier du dépôt y termine (par exemple `ArboreUi/ArboreUi/Models/User.swift`). Cela évite d'imposer le chemin complet depuis la racine dans la documentation.
+
+Pour reproduire le check de drift localement avant d'ouvrir une PR :
+
+```sh
+bash .github/scripts/docs-drift-check.sh
+```
+
 ## Outils et statut
 
 - **Markdown + Mermaid** — rendu natif GitHub, diff-able, aucun outillage externe.

--- a/docs/flows/ar-placement.md
+++ b/docs/flows/ar-placement.md
@@ -1,6 +1,6 @@
 # Flux — Placement AR (création et réouverture)
 
-Ce document décrit le **flux complet d'ouverture de la vue AR** qui permet à l'utilisateur de placer des plantes en réalité augmentée. Deux entrées principales : la création d'un jardin neuf (depuis le wizard) et la réouverture d'un jardin existant (depuis la Home). Le code de référence est `Views/ARGarden/GardenARPlacementView.swift`.
+Ce document décrit le **flux complet d'ouverture de la vue AR** qui permet à l'utilisateur de placer des plantes en réalité augmentée. Deux entrées principales : la création d'un jardin neuf (depuis le wizard) et la réouverture d'un jardin existant (depuis la Home). Le code de référence est `ARGarden/GardenARPlacementView.swift`.
 
 ## Vue d'ensemble
 


### PR DESCRIPTION
Closes #144.

Mise en place de la discipline outillée pour empêcher le doc rot dans `docs/`. Trois jobs en parallèle déclenchés sur PR vers `main` qui touche `docs/` ou les fichiers source cités par la documentation (`ArboreUi/**/*.swift`, `ArboreBackend/**/*.go`).

## Contenu

### `.github/workflows/docs.yml`

| Job | Outil | Rôle |
|---|---|---|
| **Mermaid syntax** | `@mermaid-js/mermaid-cli` + Chromium headless | Extrait tous les blocs `` ```mermaid `` de `docs/**/*.md`, tente de les rendre en SVG, fail si un seul casse. Le contenu offensant est sorti pour faciliter le debug. |
| **Internal links** | `lycheeverse/lychee-action` en mode `--offline` | Vérifie les liens internes (fichiers + ancres) dans `docs/`. Les liens externes restent en warning (flakiness CI). |
| **Doc drift** | `.github/scripts/docs-drift-check.sh` | Vérifie que les chemins fichiers cités entre backticks dans `docs/` correspondent toujours à un fichier du dépôt (suffix match). Détecte les renommages et suppressions non répercutés. |

### `.github/scripts/docs-drift-check.sh`

Script bash portable (3.2+ compatible macOS, utilise `grep -E` plutôt que `grep -P` pour rester compatible BSD grep). Stratégie :

1. Pré-cache la liste de tous les fichiers source du dépôt (exclut `node_modules`, `.git`, `DerivedData`, `build`, `Pods`, `__pycache__`).
2. Pour chaque `.md` sous `docs/`, extrait les contenus entre backticks (single ou double).
3. Filtre par extension surveillée (`.swift`, `.go`, `.py`, `.ts`, `.tsx`, `.js`, `.yaml`, `.yml`, `.json`, `.toml`, `.xcconfig`, `.pbxproj`, `.plist`, `.sh`, `.dockerfile`, `.mod`, `.sum`).
4. Ignore URLs, endpoints backend (`/users/me`), chemins inter-docs (`./`, `../`), wildcards, placeholders (`{id}`, `$var`).
5. **Suffix match** : un chemin cité `Models/User.swift` est validé si un fichier du repo y termine (par exemple `ArboreUi/ArboreUi/Models/User.swift`). Évite d'imposer le chemin complet depuis la racine.

### Documentation utilisateur

- Section **« Contrat CI »** ajoutée à `docs/README.md` qui décrit les 3 jobs, leurs causes d'échec, et explique comment reproduire le drift check localement.
- **Badge** du workflow `docs.yml` ajouté au README racine, à côté de `CI/CD`, `CodeQL`, `Docker`.

### Bonus

Fix d'un vrai drift détecté pendant le développement : `docs/flows/ar-placement.md` citait `Views/ARGarden/GardenARPlacementView.swift` au lieu de `ARGarden/GardenARPlacementView.swift`. Corrigé.

## Vérification locale

```sh
bash .github/scripts/docs-drift-check.sh
```

Sortie attendue après ce merge :

```
Scanning 26 Markdown file(s) under docs/ for code references…
Indexed 2419 source file(s) in the repository.
Checked 58 code path reference(s) across docs/

✅ No doc drift detected.
```

## Vérification CI

Le workflow sera testé en conditions réelles dès l'ouverture de cette PR (le workflow déclenche sur `pull_request` ciblant `main`). Si les trois jobs passent, on saura que la stack est opérationnelle.

## Hors scope (Phase 6+, issues à créer plus tard)

- Génération automatique d'OpenAPI depuis le code Go via `swaggo/swag`.
- Référence API iOS via DocC sur les structures publiques.
- Auto-régénération de l'index ADR (`docs/decisions/_index.md`) par script.