### PR TITLE
feat(ar): adaptive AR quality + thermal observer (closes #80 #82)

### DIFF
--- a/ArboreUi/ArboreUi/ARCamera/ARPage.swift
+++ b/ArboreUi/ArboreUi/ARCamera/ARPage.swift
@@ -35,7 +35,7 @@ struct SinglePlantARContainer: UIViewRepresentable {
         // 2. Configuration AR
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = [.horizontal] // On cherche le sol
-        config.environmentTexturing = .automatic
+        config.environmentTexturing = ARQuality.recommended.environmentTexturing
         
         // Anti-Ecran Noir : on laisse la config standard sans forcer le LiDAR
         if ARWorldTrackingConfiguration.supportsFrameSemantics(.sceneDepth) {

--- a/ArboreUi/ArboreUi/ARCamera/ARViewBasic.swift
+++ b/ArboreUi/ArboreUi/ARCamera/ARViewBasic.swift
@@ -116,7 +116,7 @@ struct ARViewBasicContainer: UIViewRepresentable {
 
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = [.horizontal, .vertical]
-        config.environmentTexturing = .automatic
+        config.environmentTexturing = ARQuality.recommended.environmentTexturing
 
         // ⚠️ IMPORTANT: sceneDepth peut provoquer un flux caméra noir sur certains appareils/iOS.
         // On le désactive par défaut.

--- a/ArboreUi/ArboreUi/ARCamera/ARViewContainer_ARCamera.swift
+++ b/ArboreUi/ArboreUi/ARCamera/ARViewContainer_ARCamera.swift
@@ -24,7 +24,7 @@ struct ARViewContainer: UIViewRepresentable {
         // Configuration AR
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = [.horizontal, .vertical]
-        config.environmentTexturing = .automatic
+        config.environmentTexturing = ARQuality.recommended.environmentTexturing
 
         // ⚠️ IMPORTANT: sceneDepth peut provoquer un flux caméra noir sur certains appareils/iOS (iPhone 16/17 Pro).
         // On le désactive par défaut. À réactiver plus tard via un toggle si besoin.

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -278,6 +278,12 @@ struct GardenARPlacementView: View {
                 }
             }
         }
+        .overlay(alignment: .top) {
+            // Banner thermal critique (#82). Invisible par défaut, apparait
+            // sur .arboreThermalCritical posée par ARQualityObserver, se
+            // masque sur .arboreThermalRecovered.
+            ThermalStateBanner()
+        }
         .sheet(isPresented: $showPicker) {
             PlantCatalogARView(wizardFilter: wizard) { plant in
                 selectedPlantForPlacement = plant
@@ -756,7 +762,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
         
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = [.horizontal]
-        config.environmentTexturing = .automatic
+        config.environmentTexturing = ARQuality.recommended.environmentTexturing
         
         sceneView.session.run(config, options: [.resetTracking, .removeExistingAnchors])
 
@@ -787,7 +793,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                 DispatchQueue.main.async {
                     let restartConfig = ARWorldTrackingConfiguration()
                     restartConfig.planeDetection = [.horizontal]
-                    restartConfig.environmentTexturing = .automatic
+                    restartConfig.environmentTexturing = ARQuality.recommended.environmentTexturing
                     restartConfig.initialWorldMap = worldMap
                     sceneView.session.run(restartConfig, options: [.resetTracking, .removeExistingAnchors])
                     AppLog.gardenLoad.notice("WorldMap loaded id=\(mapId, privacy: .public)")

--- a/ArboreUi/ArboreUi/ARGarden/Quality/ARQuality.swift
+++ b/ArboreUi/ArboreUi/ARGarden/Quality/ARQuality.swift
@@ -1,0 +1,69 @@
+//
+//  ARQuality.swift
+//  ArboreUi
+//
+//  Niveau de qualité retenu pour une session ARKit. Décide notamment
+//  de `environmentTexturing` (cube map HDR pour réflexions) qui peut
+//  coûter 50-100 MB de RAM en continu.
+//
+//  La recommandation au démarrage d'une session combine deux signaux :
+//
+//  - Tier du device (cf. DeviceCapabilities) : un device legacy reçoit
+//    une config plus pauvre dès le départ pour éviter de saturer la RAM.
+//
+//  - Thermal state du système au démarrage : si le téléphone est déjà
+//    chaud, on n'aggrave pas la situation en empilant des textures.
+//
+//  Note d'architecture : `ARQuality` n'observe pas le thermal state en
+//  continu — c'est le rôle de `ARQualityObserver`. Changer
+//  `environmentTexturing` au cours d'une session demanderait un
+//  `session.run(config, options: [.resetTracking])` qui invaliderait
+//  la `ARWorldMap` relocalisée, ce qui dégraderait l'UX bien plus que
+//  le bénéfice thermique attendu.
+//
+
+import ARKit
+import Foundation
+
+enum ARQuality {
+    /// Toutes les options graphiques activées. Réservé aux devices
+    /// modernes en condition thermique nominale.
+    case full
+    /// Mode intermédiaire — `environmentTexturing` reste actif mais
+    /// d'autres dégradations soft sont possibles (frame rate cap, etc.).
+    case standard
+    /// Mode allégé — `environmentTexturing` désactivé. Réservé aux
+    /// devices legacy et aux situations thermiques tendues.
+    case lite
+
+    /// Niveau de qualité recommandé au démarrage d'une nouvelle session AR.
+    /// La décision est figée pour toute la durée de la session ; les
+    /// dégradations dynamiques liées au thermal state sont portées par
+    /// `ARQualityObserver` via la notification `.arboreThermalCritical`.
+    static var recommended: ARQuality {
+        if DeviceCapabilities.tier == .legacy {
+            return .lite
+        }
+        switch ProcessInfo.processInfo.thermalState {
+        case .serious, .critical:
+            return .lite
+        case .fair:
+            return .standard
+        case .nominal:
+            return .full
+        @unknown default:
+            return .standard
+        }
+    }
+
+    /// Valeur à poser sur `ARWorldTrackingConfiguration.environmentTexturing`
+    /// pour ce niveau de qualité.
+    var environmentTexturing: ARWorldTrackingConfiguration.EnvironmentTexturing {
+        switch self {
+        case .full, .standard:
+            return .automatic
+        case .lite:
+            return .none
+        }
+    }
+}

--- a/ArboreUi/ArboreUi/ARGarden/Quality/ARQualityObserver.swift
+++ b/ArboreUi/ArboreUi/ARGarden/Quality/ARQualityObserver.swift
@@ -1,0 +1,95 @@
+//
+//  ARQualityObserver.swift
+//  ArboreUi
+//
+//  Observer global du thermal state iOS. Installé une fois au démarrage
+//  de l'app (cf. AppDelegate), il écoute `ProcessInfo.thermalStateDidChangeNotification`
+//  et republie une notification métier `.arboreThermalCritical` lorsque
+//  le système rapporte `.serious` ou `.critical`. Les composants UI
+//  intéressés (banner, vues AR) s'abonnent à cette notification métier
+//  plutôt qu'à la notification système — cela centralise la politique
+//  de seuils dans un seul fichier.
+//
+//  Aucun accès direct à l'UI ni à ARKit ici : couplage faible volontaire,
+//  l'observer est utilisable depuis n'importe quel contexte (preview,
+//  test unitaire, debug menu) sans tirer SwiftUI.
+//
+
+import Foundation
+
+extension Notification.Name {
+    /// Le thermal state du système a basculé sur un niveau qui justifie
+    /// un avertissement visible à l'utilisateur. Posée par
+    /// `ARQualityObserver` lorsque l'état rapporté est `.serious` ou
+    /// `.critical`.
+    static let arboreThermalCritical = Notification.Name("ArboreThermalCritical")
+
+    /// Le thermal state est redescendu sur un niveau sain (`.nominal` ou
+    /// `.fair`). Permet à l'UI de masquer le banner d'avertissement.
+    static let arboreThermalRecovered = Notification.Name("ArboreThermalRecovered")
+}
+
+/// Observer global du thermal state. Singleton car il n'y a aucune raison
+/// d'avoir plus d'un observer actif en même temps — l'API
+/// `NotificationCenter` rebroadcast à tous les listeners.
+final class ARQualityObserver {
+
+    static let shared = ARQualityObserver()
+
+    private var token: NSObjectProtocol?
+    /// Dernier état connu rapporté à l'UI. Utilisé pour ne notifier qu'en
+    /// transition (éviter le spam si iOS republie le même niveau).
+    private var lastBroadcastWasCritical = false
+
+    private init() {}
+
+    /// Démarre l'observation. À appeler une seule fois, typiquement depuis
+    /// `AppDelegate.didFinishLaunchingWithOptions`. Idempotent : appels
+    /// successifs sont sans effet.
+    func start() {
+        guard token == nil else { return }
+        token = NotificationCenter.default.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleThermalChange()
+        }
+        // Lit l'état courant au démarrage pour gérer le cas du device déjà
+        // chaud à l'ouverture de l'app.
+        handleThermalChange()
+    }
+
+    /// Arrête l'observation. Utile dans les tests et en cas de teardown
+    /// explicite. En production, l'observer vit toute la durée de l'app.
+    func stop() {
+        if let token = token {
+            NotificationCenter.default.removeObserver(token)
+        }
+        token = nil
+        lastBroadcastWasCritical = false
+    }
+
+    private func handleThermalChange() {
+        let state = ProcessInfo.processInfo.thermalState
+        let isCritical: Bool
+        switch state {
+        case .serious, .critical:
+            isCritical = true
+        case .nominal, .fair:
+            isCritical = false
+        @unknown default:
+            isCritical = false
+        }
+
+        // Ne broadcast qu'en transition pour limiter le bruit.
+        guard isCritical != lastBroadcastWasCritical else { return }
+        lastBroadcastWasCritical = isCritical
+
+        if isCritical {
+            NotificationCenter.default.post(name: .arboreThermalCritical, object: state)
+        } else {
+            NotificationCenter.default.post(name: .arboreThermalRecovered, object: state)
+        }
+    }
+}

--- a/ArboreUi/ArboreUi/ARGarden/Quality/DeviceCapabilities.swift
+++ b/ArboreUi/ArboreUi/ARGarden/Quality/DeviceCapabilities.swift
@@ -1,0 +1,39 @@
+//
+//  DeviceCapabilities.swift
+//  ArboreUi
+//
+//  Détection du tier d'un device iOS basée sur ProcessInfo.physicalMemory.
+//  Pas de hardcoded model strings (qui exigeraient une table à maintenir
+//  à chaque nouvelle génération d'iPhone) : la quantité de RAM est un
+//  proxy stable, future-proof, et corrélé à la capacité graphique réelle.
+//
+//  Seuil retenu : 4 GB.
+//  - iPhone XR (A12, 3 GB) → legacy
+//  - iPhone XS / 11 (A12-A13, 4 GB) → modern (minimal)
+//  - iPhone 12+ (A14+, 4-8 GB) → modern (comfortable)
+//
+//  Le seuil 4 GB est aligné avec la limite pratique pour un usage AR
+//  multi-objets avec textures PBR sans warnings "resource constraints".
+//
+
+import Foundation
+
+enum DeviceCapabilities {
+
+    enum Tier: Equatable {
+        /// Device avec moins de 4 GB de RAM physique. ARKit fonctionne mais
+        /// les options gourmandes (environmentTexturing, scene reconstruction)
+        /// doivent être désactivées pour éviter le thermal throttling et
+        /// les warnings de ressources.
+        case legacy
+        /// Device avec 4 GB ou plus. Toutes les features AR par défaut sont
+        /// utilisables.
+        case modern
+    }
+
+    /// Tier estimé du device courant. Évalué une seule fois au premier accès.
+    static let tier: Tier = {
+        let gigabytes = Double(ProcessInfo.processInfo.physicalMemory) / 1_073_741_824.0
+        return gigabytes < 4.0 ? .legacy : .modern
+    }()
+}

--- a/ArboreUi/ArboreUi/ARGarden/Quality/ThermalStateBanner.swift
+++ b/ArboreUi/ArboreUi/ARGarden/Quality/ThermalStateBanner.swift
@@ -1,0 +1,89 @@
+//
+//  ThermalStateBanner.swift
+//  ArboreUi
+//
+//  Banner UI à attacher en `safeAreaInset(edge: .top)` ou `overlay` sur
+//  une vue AR. Devient visible lorsque `ARQualityObserver` poste
+//  `.arboreThermalCritical`, se masque sur `.arboreThermalRecovered`.
+//
+//  Le banner est dismissable manuellement — l'utilisateur qui sait ce
+//  qu'il fait peut le cacher pour continuer sa session. Il réapparaît
+//  uniquement à la prochaine transition vers un état critique.
+//
+
+import SwiftUI
+
+struct ThermalStateBanner: View {
+    @State private var isVisible: Bool = false
+    @State private var dismissedThisCycle: Bool = false
+
+    var body: some View {
+        Group {
+            if isVisible {
+                bannerContent
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: isVisible)
+        .onReceive(NotificationCenter.default.publisher(for: .arboreThermalCritical)) { _ in
+            // Une nouvelle alerte critique réactive l'affichage même si
+            // l'utilisateur avait dismiss la précédente.
+            dismissedThisCycle = false
+            isVisible = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .arboreThermalRecovered)) { _ in
+            isVisible = false
+            dismissedThisCycle = false
+        }
+    }
+
+    private var bannerContent: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "thermometer.high")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.white)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("THERMAL_BANNER_TITLE", comment: ""))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                Text(NSLocalizedString("THERMAL_BANNER_SUBTITLE", comment: ""))
+                    .font(.system(size: 12))
+                    .foregroundColor(.white.opacity(0.85))
+            }
+
+            Spacer(minLength: 8)
+
+            Button(action: {
+                dismissedThisCycle = true
+                isVisible = false
+            }) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 20))
+                    .foregroundColor(.white.opacity(0.85))
+            }
+            .accessibilityLabel(NSLocalizedString("THERMAL_BANNER_DISMISS", comment: ""))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.orange.opacity(0.95))
+        )
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack {
+            ThermalStateBanner()
+            Spacer()
+        }
+        .onAppear {
+            NotificationCenter.default.post(name: .arboreThermalCritical, object: nil)
+        }
+    }
+}

--- a/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
@@ -29,6 +29,11 @@ class AppDelegate: NSObject, UIApplicationDelegate{
             }
         }
 
+        // Start global thermal state observation. Republishes
+        // `.arboreThermalCritical` and `.arboreThermalRecovered` for any
+        // UI component subscribed (cf. ThermalStateBanner). Issue #82.
+        ARQualityObserver.shared.start()
+
         return true
     }
 

--- a/ArboreUi/ArboreUi/Views/DetailPageInfo/ARMeasurementViewContainer.swift
+++ b/ArboreUi/ArboreUi/Views/DetailPageInfo/ARMeasurementViewContainer.swift
@@ -20,7 +20,7 @@ struct ARMeasurementViewContainer: UIViewRepresentable {
         
         let config = ARWorldTrackingConfiguration()
         config.planeDetection = [.horizontal] // On se concentre sur le sol
-        config.environmentTexturing = .automatic
+        config.environmentTexturing = ARQuality.recommended.environmentTexturing
         
         // Activation LiDAR si dispo pour meilleure précision
         if ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh) {

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -879,3 +879,8 @@
 // Garden AR Relocalization
 "GARDEN_LOADING_TITLE" = "Garten wird geladen";
 "GARDEN_LOADING_SUBTITLE" = "Scannen Sie langsam Ihre Umgebung,\num Ihre Pflanzen neu zu positionieren";
+
+// Thermal banner
+"THERMAL_BANNER_TITLE" = "Dein Telefon wird heiß";
+"THERMAL_BANNER_SUBTITLE" = "Reduziere die AR-Nutzung, um Verlangsamungen zu vermeiden.";
+"THERMAL_BANNER_DISMISS" = "Warnung schließen";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -895,3 +895,8 @@
 // Garden AR Relocalization
 "GARDEN_LOADING_TITLE" = "Loading your garden";
 "GARDEN_LOADING_SUBTITLE" = "Slowly scan your environment\nto reposition your plants";
+
+// Thermal banner
+"THERMAL_BANNER_TITLE" = "Your phone is getting hot";
+"THERMAL_BANNER_SUBTITLE" = "Consider reducing AR usage to avoid slowdowns.";
+"THERMAL_BANNER_DISMISS" = "Dismiss alert";

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -875,3 +875,8 @@
 // Garden AR Relocalization
 "GARDEN_LOADING_TITLE" = "Cargando tu jardín";
 "GARDEN_LOADING_SUBTITLE" = "Escanea lentamente tu entorno\npara reposicionar tus plantas";
+
+// Thermal banner
+"THERMAL_BANNER_TITLE" = "Tu teléfono se está calentando";
+"THERMAL_BANNER_SUBTITLE" = "Reduce el uso de AR para evitar ralentizaciones.";
+"THERMAL_BANNER_DISMISS" = "Cerrar alerta";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -922,3 +922,8 @@
 // Garden AR Relocalization
 "GARDEN_LOADING_TITLE" = "Chargement du jardin";
 "GARDEN_LOADING_SUBTITLE" = "Scannez lentement votre environnement\npour repositionner vos plantes";
+
+// Thermal banner
+"THERMAL_BANNER_TITLE" = "Votre téléphone chauffe";
+"THERMAL_BANNER_SUBTITLE" = "Pensez à réduire l'usage AR pour éviter le ralentissement.";
+"THERMAL_BANNER_DISMISS" = "Masquer l'alerte";


### PR DESCRIPTION
Closes #80, closes #82.

Consolidation de deux issues liées en une PR : la config \`environmentTexturing\` (#80) et l'observation du thermal state (#82) partagent la même logique de décision et bénéficient d'une architecture commune.

## Module ARGarden/Quality/

Quatre composants en couplage faible, chacun avec une responsabilité unique :

| Fichier | Rôle | Dépendances |
|---|---|---|
| \`DeviceCapabilities.swift\` | Tier device via \`ProcessInfo.physicalMemory\` (seuil 4 GB) | Foundation seul |
| \`ARQuality.swift\` | Enum 3 niveaux (full / standard / lite) + \`recommended\` au démarrage | ARKit + DeviceCapabilities |
| \`ARQualityObserver.swift\` | Singleton observer du thermalState, republie notifs métier | Foundation seul |
| \`ThermalStateBanner.swift\` | Overlay SwiftUI dismissable, abonné aux notifs métier | SwiftUI seul |

Aucun hardcoded model strings (iPhone XS, etc.) — la détection est purement basée sur la RAM physique, future-proof à chaque nouvelle génération.

## Wiring

- **\`AppDelegate.didFinishLaunchingWithOptions\`** démarre l'observer global une seule fois.
- **6 sites** qui posaient \`environmentTexturing = .automatic\` utilisent désormais \`ARQuality.recommended.environmentTexturing\` :
  - \`GardenARPlacementView\` (initial + restartConfig)
  - \`ARViewContainerMeasure\` (était \`.none\` hardcodé, désormais aligné sur la stratégie globale)
  - \`ARMeasurementViewContainer\`
  - \`ARViewBasic\`, \`ARViewContainer_ARCamera\`, \`ARPage\` (vues AR camera legacy)
- **\`GardenARPlacementView\`** attache \`ThermalStateBanner\` en overlay top.

## Localisation

Trois nouvelles clés \`THERMAL_BANNER_TITLE\`, \`SUBTITLE\`, \`DISMISS\` en fr / en / de / es.

## Décision d'architecture documentée

\`ARQuality.recommended\` est **figé pour toute la durée d'une session AR**. Changer \`environmentTexturing\` mid-session nécessiterait \`session.run(config, options: [.resetTracking])\` qui invaliderait la WorldMap relocalisée. Les dégradations dynamiques sous pression thermique passent par le banner et pourront être étendues (frame rate cap, shadow res) selon les retours device. Cette décision est en doc header de \`ARQuality.swift\`.

## Vérification

- [x] xcodebuild via workspace → BUILD SUCCEEDED
- [x] CI docs : aucun impact (les nouveaux fichiers .swift sont sous \`ArboreUi/\`, le drift check va les indexer)
- [ ] Test device : impossible cette PR (pas de device sous la main, cf. discussion)

## Suite

- **#150** ouverte pour le toggle Settings 'Mode économie batterie' (hors MVP).
- Dégradations dynamiques (frame rate cap, shadow res) à ajouter si les retours utilisateurs montrent que le banner seul ne suffit pas.