### PR TITLE
chore(ci): commenter les triggers CodeQL (Advanced Security indispo)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,30 @@
 name: "🔒 CodeQL Security Analysis"
 
+# ─────────────────────────────────────────────────────────────────────
+# IMPORTANT — triggers automatiques temporairement commentés.
+#
+# CodeQL exige GitHub Advanced Security pour les dépôts privés. Notre
+# dépôt n'a pas cette licence (payante, Team / Enterprise) donc
+# l'analyse tourne nickel sur le runner mais le upload SARIF échoue
+# systématiquement avec :
+#
+#   Advanced Security must be enabled for this repository to use code scanning.
+#
+# Conséquence : la CI restait rouge en permanence sur main.
+#
+# À DÉCOMMENTER quand le dépôt sera rendu public — CodeQL est gratuit
+# pour les repos publics. Restaurer alors les blocs `push`, `pull_request`
+# et `schedule` ci-dessous.
+# ─────────────────────────────────────────────────────────────────────
+
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
-    - cron: '30 2 * * 1'  # Tous les lundis à 2h30
+  workflow_dispatch:  # Relance manuelle uniquement, à conserver dans tous les cas.
+  # push:
+  #   branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
+  # schedule:
+  #   - cron: '30 2 * * 1'  # Tous les lundis à 2h30
 
 jobs:
   analyze:


### PR DESCRIPTION
## Contexte

Le workflow \`codeql.yml\` échoue systématiquement à l'étape d'upload SARIF depuis que le dépôt est privé sans licence Advanced Security. Erreur :

\`\`\`
Advanced Security must be enabled for this repository to use code scanning.
\`\`\`

L'analyse CodeQL elle-même tourne sur le runner (extractor + queries OK), c'est uniquement le push des résultats vers l'UI Code Scanning de GitHub qui foire. Conséquence : la CI sur main est rouge en permanence sur ce workflow, ce qui parasite la lecture des autres checks.

## Fix

Les triggers \`push\`, \`pull_request\` et \`schedule\` sont **commentés** plutôt que supprimés. Le \`workflow_dispatch\` reste actif pour permettre une relance manuelle. Commentaire en tête du fichier qui explique la situation et indique précisément quoi décommenter quand le dépôt passe en public.

CodeQL est **gratuit pour les dépôts publics** — la réactivation se fera en deux gestes (décommenter trois blocs YAML) le jour où la décision de passer public sera prise.

Aucun autre fichier modifié :
- README badge CodeQL conservé (informatif même si le workflow est dormant pour l'instant)
- \`codeql-swift-optional.yml\` déjà sur \`workflow_dispatch\` uniquement, intact