### PR TITLE
fix(tests): DELETE /users sans uid + Bearer token pour le cleanup CI

### DIFF
--- a/ArboreUi/ArboreUiTests/NetworkManagerTests.swift
+++ b/ArboreUi/ArboreUiTests/NetworkManagerTests.swift
@@ -467,9 +467,9 @@ class NetworkManagerIntegrationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         // Supprimer le user du backend
-        if let uid = testUserUID {
+        if testUserUID != nil {
             let deleteExpectation = XCTestExpectation(description: "Delete user from backend")
-            deleteUserFromBackend(uid: uid) { _ in
+            deleteUserFromBackend { _ in
                 deleteExpectation.fulfill()
             }
             wait(for: [deleteExpectation], timeout: 5.0)
@@ -531,23 +531,35 @@ class NetworkManagerIntegrationTests: XCTestCase {
         }.resume()
     }
 
-    private func deleteUserFromBackend(uid: String, completion: @escaping (Bool) -> Void) {
-        guard let url = URL(string: "\(AppConfig.usersEndpoint)/\(uid)") else {
+    /// Le backend dérive l'uid du Bearer token Firebase (self-only authz,
+    /// cf. ADR 0005). Pas d'uid dans l'URL — on tape `DELETE /users` tout
+    /// court. Sans le Bearer token, le middleware Firebase renvoie 401
+    /// et le user reste orphan en base (issue identifiée pendant le
+    /// triage des dependabot bumps).
+    private func deleteUserFromBackend(completion: @escaping (Bool) -> Void) {
+        guard let currentUser = Auth.auth().currentUser else {
             completion(false)
             return
         }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue(AppConfig.apiKey, forHTTPHeaderField: "X-API-Key")
-
-        URLSession.shared.dataTask(with: request) { _, response, _ in
-            if let httpResponse = response as? HTTPURLResponse {
-                completion(httpResponse.statusCode == 200)
-            } else {
+        currentUser.getIDToken { token, _ in
+            guard let token = token,
+                  let url = URL(string: AppConfig.usersEndpoint) else {
                 completion(false)
+                return
             }
-        }.resume()
+            var request = URLRequest(url: url)
+            request.httpMethod = "DELETE"
+            request.setValue(AppConfig.apiKey, forHTTPHeaderField: "X-API-Key")
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+            URLSession.shared.dataTask(with: request) { _, response, _ in
+                if let httpResponse = response as? HTTPURLResponse {
+                    completion(httpResponse.statusCode == 200)
+                } else {
+                    completion(false)
+                }
+            }.resume()
+        }
     }
 
     // MARK: - Real Backend Tests

--- a/ArboreUi/ArboreUiTests/PrivacySettingsViewTests.swift
+++ b/ArboreUi/ArboreUiTests/PrivacySettingsViewTests.swift
@@ -494,7 +494,7 @@ class PrivacySettingsIntegrationTests: XCTestCase {
      2. MongoDB collection "users" (via POST /users)
 
      Et supprimé automatiquement de:
-     1. MongoDB (via DELETE /users/:uid)
+     1. MongoDB (via DELETE /users, self-authz par token Firebase)
      2. Firebase Authentication (via user.delete())
      */
 
@@ -599,10 +599,10 @@ class PrivacySettingsIntegrationTests: XCTestCase {
         clearUserDefaults()
 
         // Supprimer le user du backend (MongoDB)
-        if let uid = testUserUID {
+        if testUserUID != nil {
             let deleteBackendExpectation = XCTestExpectation(description: "Delete user from backend")
 
-            deleteUserFromBackend(uid: uid) { success in
+            deleteUserFromBackend { success in
                 if success {
                     NSLog("✅ Test user deleted from MongoDB")
                 } else {
@@ -677,29 +677,40 @@ class PrivacySettingsIntegrationTests: XCTestCase {
         }.resume()
     }
 
-    private func deleteUserFromBackend(uid: String, completion: @escaping (Bool) -> Void) {
-        guard let url = URL(string: "\(AppConfig.usersEndpoint)/\(uid)") else {
+    /// Le backend dérive l'uid du Bearer token Firebase (self-only authz,
+    /// cf. ADR 0005). Pas d'uid dans l'URL — on tape `DELETE /users` tout
+    /// court avec le Bearer token. La variante précédente `DELETE /users/:uid`
+    /// renvoyait 404 (route inexistante) et laissait les users de test orphans
+    /// en base.
+    private func deleteUserFromBackend(completion: @escaping (Bool) -> Void) {
+        guard let currentUser = Auth.auth().currentUser else {
             completion(false)
             return
         }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue(AppConfig.apiKey, forHTTPHeaderField: "X-API-Key")
-
-        URLSession.shared.dataTask(with: request) { _, response, error in
-            if let error = error {
-                NSLog("❌ Error deleting user from backend: \(error)")
+        currentUser.getIDToken { token, _ in
+            guard let token = token,
+                  let url = URL(string: AppConfig.usersEndpoint) else {
                 completion(false)
                 return
             }
+            var request = URLRequest(url: url)
+            request.httpMethod = "DELETE"
+            request.setValue(AppConfig.apiKey, forHTTPHeaderField: "X-API-Key")
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-            if let httpResponse = response as? HTTPURLResponse {
-                completion(httpResponse.statusCode == 200)
-            } else {
-                completion(false)
-            }
-        }.resume()
+            URLSession.shared.dataTask(with: request) { _, response, error in
+                if let error = error {
+                    NSLog("❌ Error deleting user from backend: \(error)")
+                    completion(false)
+                    return
+                }
+                if let httpResponse = response as? HTTPURLResponse {
+                    completion(httpResponse.statusCode == 200)
+                } else {
+                    completion(false)
+                }
+            }.resume()
+        }
     }
 
     private func clearUserDefaults() {


### PR DESCRIPTION
Fix des helpers `deleteUserFromBackend` dans les tests d'intégration. Identifié lors du triage des dependabot bumps (#126-#135) en lisant les logs prod : 243 req/24h depuis 3 IPs Azure GitHub Actions, avec un pattern systématique 404 sur `DELETE /users/:uid`.

## Cause

Les deux fichiers :

- `ArboreUi/ArboreUiTests/NetworkManagerTests.swift`
- `ArboreUi/ArboreUiTests/PrivacySettingsViewTests.swift`

avaient un helper `deleteUserFromBackend(uid:)` qui :

1. Tapait `DELETE /users/:uid` — **mais cette route n'existe pas** côté backend. Notre handler est `DELETE /users` self-only via le token Firebase (ADR 0005).
2. N'envoyait pas de Bearer token — le middleware Firebase aurait renvoyé 401 même sur la bonne route.

Résultat sur les logs Gin prod : `404 DELETE /users/IXp1J8...` à chaque run.

## Impact mesuré

- **Pollution Mongo** : ~1318 docs dans la collection `users` (vu lors du mongodump du jour), dont une grosse partie sont des `test-network-*@arbore.test` et `test.rgpd.*@arbore.test` accumulés sur tous les runs CI depuis l'introduction de ces tests
- **Pollution Firebase Auth** : même problème, mais le `currentUser.delete()` de Firebase, lui, marchait. Donc Firebase est probablement propre — c'est juste côté Mongo qu'on a des orphans

## Fix

Les deux helpers consomment maintenant le Bearer token via `Auth.auth().currentUser.getIDToken()` et tapent `DELETE /users` sans uid. Le backend dérive l'uid du token (pattern self-authz défendu dans l'ADR 0005).

```swift
private func deleteUserFromBackend(completion: @escaping (Bool) -> Void) {
    guard let currentUser = Auth.auth().currentUser else { ... }
    currentUser.getIDToken { token, _ in
        guard let token = token, let url = URL(string: AppConfig.usersEndpoint) else { ... }
        var request = URLRequest(url: url)
        request.httpMethod = "DELETE"
        request.setValue(AppConfig.apiKey, forHTTPHeaderField: "X-API-Key")
        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
        // ...
    }
}
```

Les call sites `tearDownWithError` ne passent plus l'uid (la signature change). Le test garde la séquence safe : `wait(for: deleteBackendExpectation)` bloque jusqu'à la fin du HTTP, puis seulement on appelle `currentUser.delete()` Firebase.

## Vérification

- [x] `xcodebuild` workspace → BUILD SUCCEEDED
- [ ] Smoke test sur un run CI : observer dans les logs Gin que `DELETE /users` renvoie 200 (au lieu de 404 sur `DELETE /users/:uid`)

## Suite

Deux issues complémentaires ouvertes après ce fix :

- **Mongo collection de test séparée** : pour que la CI ne tape plus la DB prod
- **Cleanup batch** : un script qui supprime les `*@arbore.test` accumulés en base

Le fix actuel adresse uniquement le `DELETE /users` qui ne marchait pas. Les deux issues ci-dessus traitent la pollution déjà présente et la prévention long-terme.