### PR TITLE
feat(backend): dual-DB routing prod/test par API key (closes #159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,12 +338,39 @@ jobs:
             ARBORE_BACKEND_HOST="${{ secrets.ARBORE_BACKEND_HOST }}" \
             | xcpretty
 
+      - name: 🧪 Switch to test API key (route to arbore_test DB)
+        # Si ARBORE_API_KEY_TEST est défini comme secret, on régénère
+        # Secrets.xcconfig avec cette clé avant les tests. Le backend
+        # détecte la clé test via APIKeyMiddleware et route les écritures
+        # vers la DB `arbore_test` au lieu de `arbore` (cf. issue #159 v2).
+        # Si le secret n'est pas défini, on reste sur la clé prod et les
+        # tests continuent de polluer `arbore` (état antérieur, à éviter).
+        if: env.ARBORE_API_KEY_TEST != ''
+        env:
+          ARBORE_API_KEY_TEST: ${{ secrets.ARBORE_API_KEY_TEST }}
+        run: |
+          echo "🔁 Réécriture Secrets.xcconfig avec ARBORE_API_KEY_TEST"
+          cat > Secrets.xcconfig << EOF
+          // Secrets.xcconfig - Test mode (CI only)
+          ARBORE_API_KEY = ${ARBORE_API_KEY_TEST}
+          ARBORE_BACKEND_PROTOCOL = ${{ secrets.ARBORE_BACKEND_PROTOCOL }}
+          ARBORE_BACKEND_HOST = ${{ secrets.ARBORE_BACKEND_HOST }}
+          EOF
+          echo "✅ Secrets.xcconfig (test) écrit"
+
       - name: 🧪 Run Unit Tests
         timeout-minutes: 20
+        env:
+          ARBORE_API_KEY_EFFECTIVE: ${{ secrets.ARBORE_API_KEY_TEST != '' && secrets.ARBORE_API_KEY_TEST || secrets.ARBORE_API_KEY }}
         run: |
           set -o pipefail
 
           echo "🧪 Running all tests (including integration tests with backend)"
+          if [ "${{ secrets.ARBORE_API_KEY_TEST != '' }}" = "true" ]; then
+            echo "ℹ️  Mode TEST actif : écritures dans arbore_test DB"
+          else
+            echo "⚠️  Mode PROD : tests polluent arbore DB (ajouter ARBORE_API_KEY_TEST secret)"
+          fi
 
           xcodebuild test \
             -workspace ArboreUi.xcworkspace \
@@ -358,7 +385,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             GCC_TREAT_WARNINGS_AS_ERRORS=NO \
             SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
-            ARBORE_API_KEY="${{ secrets.ARBORE_API_KEY }}" \
+            ARBORE_API_KEY="$ARBORE_API_KEY_EFFECTIVE" \
             ARBORE_BACKEND_PROTOCOL="${{ secrets.ARBORE_BACKEND_PROTOCOL }}" \
             ARBORE_BACKEND_HOST="${{ secrets.ARBORE_BACKEND_HOST }}" \
             2>&1 | tee build/test-output.log

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -26,7 +26,68 @@ import (
 	"ArboreBackend/middleware"
 )
 
-var client *mongo.Client
+// client est la connexion MongoDB de production (DB `arbore`).
+// testClient est la connexion utilisée pour le trafic de tests (DB
+// `arbore_test`) — initialisée uniquement si MONGODB_URI_TEST est défini.
+// Cf. issue #159 v2 pour le contexte du routing dual.
+var (
+	client     *mongo.Client
+	testClient *mongo.Client
+)
+
+const (
+	prodDBName = "arbore"
+	testDBName = "arbore_test"
+)
+
+// getDatabaseForRequest retourne la *mongo.Database à utiliser pour la
+// requête courante, en fonction du sélecteur posé par APIKeyMiddleware.
+// Tombe sur la DB prod si le sélecteur est absent (cas hors middleware
+// ou bug de routing — fail-safe vers prod).
+func getDatabaseForRequest(c *gin.Context) *mongo.Database {
+	if selector, ok := c.Get(middleware.DBSelectorKey); ok {
+		if selector == middleware.DBSelectorTest && testClient != nil {
+			return testClient.Database(testDBName)
+		}
+	}
+	return client.Database(prodDBName)
+}
+
+// getDatabaseByName retourne la *mongo.Database par nom logique
+// (`prod` ou `test`). Utilisé par les helpers qui ne reçoivent pas
+// directement un *gin.Context (par exemple checkUserBannedFromDB
+// appelé par le middleware Firebase).
+func getDatabaseByName(name string) *mongo.Database {
+	if name == middleware.DBSelectorTest && testClient != nil {
+		return testClient.Database(testDBName)
+	}
+	return client.Database(prodDBName)
+}
+
+// maybeLabelTestDoc enrichit un document inséré en mode test avec
+// `_test: true` et `_createdAtUTC` pour faciliter le tracking (qui a
+// été créé par les tests, à quand remonte le doc) et l'éventuel cleanup
+// par filtre plutôt que par drop complet de la DB. Pas d'effet en mode
+// prod : le doc est retourné tel quel. Si le marshal/unmarshal échoue
+// (cas pathologique), on retombe sur le doc original sans label —
+// l'écriture ne doit pas échouer à cause d'un problème de labelling.
+func maybeLabelTestDoc(dbSelector string, doc interface{}) interface{} {
+	if dbSelector != middleware.DBSelectorTest {
+		return doc
+	}
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		return doc
+	}
+	var m bson.M
+	if err := bson.Unmarshal(raw, &m); err != nil {
+		return doc
+	}
+	m["_test"] = true
+	m["_createdAtUTC"] = time.Now().UTC()
+	return m
+}
+
 var thumbnailPlantIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 type User struct {
@@ -179,9 +240,11 @@ type Garden struct {
 
 // ---------- HELPER FUNCTIONS ----------
 
-// checkUserBannedFromDB vérifie si l'utilisateur est banni dans MongoDB
-func checkUserBannedFromDB(uid string) (bool, error) {
-	collection := client.Database("arbore").Collection("users")
+// checkUserBannedFromDB vérifie si l'utilisateur est banni dans MongoDB.
+// Reçoit le contexte Gin pour router vers la bonne DB (prod ou test) selon
+// le sélecteur posé par APIKeyMiddleware.
+func checkUserBannedFromDB(c *gin.Context, uid string) (bool, error) {
+	collection := getDatabaseForRequest(c).Collection("users")
 
 	var user User
 	err := collection.FindOne(context.Background(), bson.M{"uid": uid}).Decode(&user)
@@ -212,7 +275,7 @@ func exportUserData(c *gin.Context) {
 
 	// 1. Récupérer les données utilisateur
 	var user User
-	userCollection := client.Database("arbore").Collection("users")
+	userCollection := getDatabaseForRequest(c).Collection("users")
 	err := userCollection.FindOne(ctx, bson.M{"uid": uid}).Decode(&user)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
@@ -225,7 +288,7 @@ func exportUserData(c *gin.Context) {
 
 	// 2. Récupérer tous les gardens
 	var gardens []Garden
-	gardensCollection := client.Database("arbore").Collection("gardens")
+	gardensCollection := getDatabaseForRequest(c).Collection("gardens")
 	gardensCursor, err := gardensCollection.Find(ctx, bson.M{"uid": uid})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de la récupération des gardens"})
@@ -244,7 +307,7 @@ func exportUserData(c *gin.Context) {
 
 	// 3. Récupérer tous les consentements
 	var consents []ConsentRecord
-	consentsCollection := client.Database("arbore").Collection("consents")
+	consentsCollection := getDatabaseForRequest(c).Collection("consents")
 	consentsCursor, err := consentsCollection.Find(ctx, bson.M{"uid": uid})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de la récupération des consentements"})
@@ -300,8 +363,8 @@ func createUser(c *gin.Context) {
 
 	fmt.Printf("✅ Donnée reçue dans createUser : %+v\n", user)
 
-	collection := client.Database("arbore").Collection("users")
-	_, err := collection.InsertOne(context.Background(), user)
+	collection := getDatabaseForRequest(c).Collection("users")
+	_, err := collection.InsertOne(context.Background(), maybeLabelTestDoc(c.GetString(middleware.DBSelectorKey), user))
 	if err != nil {
 		log.Println("❌ Erreur lors de l'insertion dans MongoDB :", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de l'insertion dans MongoDB"})
@@ -345,7 +408,7 @@ func updateUserSelf(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("users")
+	collection := getDatabaseForRequest(c).Collection("users")
 	res, err := collection.UpdateOne(
 		context.Background(),
 		bson.M{"uid": uid},
@@ -378,7 +441,7 @@ func deleteUser(c *gin.Context) {
 
 	uid := authenticatedUID.(string)
 	ctx := context.Background()
-	db := client.Database("arbore")
+	db := getDatabaseForRequest(c)
 
 	// 1. Supprimer tous les gardens de l'utilisateur
 	gardensCollection := db.Collection("gardens")
@@ -459,8 +522,8 @@ func recordConsent(c *gin.Context) {
 		consent.UserAgent = c.GetHeader("User-Agent")
 	}
 
-	collection := client.Database("arbore").Collection("consents")
-	_, err := collection.InsertOne(context.Background(), consent)
+	collection := getDatabaseForRequest(c).Collection("consents")
+	_, err := collection.InsertOne(context.Background(), maybeLabelTestDoc(c.GetString(middleware.DBSelectorKey), consent))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de l'enregistrement du consentement"})
 		return
@@ -478,7 +541,7 @@ func getUserConsents(c *gin.Context) {
 
 	uid := authenticatedUID.(string)
 
-	collection := client.Database("arbore").Collection("consents")
+	collection := getDatabaseForRequest(c).Collection("consents")
 
 	findOptions := options.Find().SetSort(bson.D{{Key: "timestamp", Value: -1}})
 
@@ -519,7 +582,7 @@ func getLatestUserConsents(c *gin.Context) {
 
 	uid := authenticatedUID.(string)
 
-	collection := client.Database("arbore").Collection("consents")
+	collection := getDatabaseForRequest(c).Collection("consents")
 
 	findOptions := options.Find().SetSort(bson.D{{Key: "timestamp", Value: -1}})
 	cursor, err := collection.Find(
@@ -571,10 +634,10 @@ func createPlant(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("plants")
+	collection := getDatabaseForRequest(c).Collection("plants")
 	plant.ID = primitive.NewObjectID()
 
-	_, err := collection.InsertOne(context.Background(), plant)
+	_, err := collection.InsertOne(context.Background(), maybeLabelTestDoc(c.GetString(middleware.DBSelectorKey), plant))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de l'insertion de la plante"})
 		return
@@ -584,7 +647,7 @@ func createPlant(c *gin.Context) {
 }
 
 func getPlants(c *gin.Context) {
-	collection := client.Database("arbore").Collection("plants")
+	collection := getDatabaseForRequest(c).Collection("plants")
 
 	cursor, err := collection.Find(context.Background(), bson.M{})
 	if err != nil {
@@ -615,7 +678,7 @@ func getPlantByID(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("plants")
+	collection := getDatabaseForRequest(c).Collection("plants")
 
 	var plant Plant
 	err = collection.FindOne(context.TODO(), bson.M{"_id": objectID}).Decode(&plant)
@@ -634,10 +697,12 @@ func getPlantByID(c *gin.Context) {
 // ---------- AI GENERATION (logique commune) ----------
 
 // Génère une plante avec l'IA + Unsplash + insertion Mongo
-// - name: nom de la plante
+// - name : nom de la plante
+// - dbSelector : sélecteur de DB ("prod" ou "test") — propagé depuis le
+//   gin.Context du handler appelant pour respecter le routing par API key
 // Retourne: (plant, alreadyExists, error)
-func generateAndInsertPlant(ctx context.Context, name string) (Plant, bool, error) {
-	collection := client.Database("arbore").Collection("plants")
+func generateAndInsertPlant(ctx context.Context, name string, dbSelector string) (Plant, bool, error) {
+	collection := getDatabaseByName(dbSelector).Collection("plants")
 
 	// Vérifie si la plante existe déjà (insensible à la casse)
 	filter := bson.M{
@@ -704,7 +769,7 @@ func generateAndInsertPlant(ctx context.Context, name string) (Plant, bool, erro
 		},
 	}
 
-	_, err = collection.InsertOne(ctx, plant)
+	_, err = collection.InsertOne(ctx, maybeLabelTestDoc(dbSelector, plant))
 	if err != nil {
 		log.Println("❌ Erreur lors de l'insertion MongoDB :", err)
 		return Plant{}, false, err
@@ -755,7 +820,7 @@ func generatePlantWithAI(c *gin.Context) {
 		return
 	}
 
-	plant, exists, err := generateAndInsertPlant(context.Background(), req.Name)
+	plant, exists, err := generateAndInsertPlant(context.Background(), req.Name, c.GetString(middleware.DBSelectorKey))
 	if err != nil {
 		log.Println("❌ Erreur lors de la génération de la plante :", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de la génération de la plante"})
@@ -794,7 +859,7 @@ func generateMultiplePlantsHandler(c *gin.Context) {
 			continue
 		}
 
-		plant, exists, err := generateAndInsertPlant(context.Background(), name)
+		plant, exists, err := generateAndInsertPlant(context.Background(), name, c.GetString(middleware.DBSelectorKey))
 		if err != nil {
 			log.Println("❌ Erreur lors de la génération pour", name, ":", err)
 			skipped = append(skipped, name)
@@ -855,7 +920,7 @@ func uploadUserPhoto(c *gin.Context) {
 		contentType = http.DetectContentType(imageBytes)
 	}
 
-	collection := client.Database("arbore").Collection("users")
+	collection := getDatabaseForRequest(c).Collection("users")
 	filter := bson.M{"uid": uidParam}
 	update := bson.M{"$set": bson.M{
 		"photoData":        encoded,
@@ -880,7 +945,7 @@ func getUserPhoto(c *gin.Context) {
 		return
 	}
 	uid := uidParam
-	collection := client.Database("arbore").Collection("users")
+	collection := getDatabaseForRequest(c).Collection("users")
 
 	var user User
 	err := collection.FindOne(context.Background(), bson.M{"uid": uid}).Decode(&user)
@@ -1026,8 +1091,8 @@ func createGarden(c *gin.Context) {
 	garden.CreatedAt = now
 	garden.UpdatedAt = now
 
-	collection := client.Database("arbore").Collection("gardens")
-	_, err := collection.InsertOne(context.Background(), garden)
+	collection := getDatabaseForRequest(c).Collection("gardens")
+	_, err := collection.InsertOne(context.Background(), maybeLabelTestDoc(c.GetString(middleware.DBSelectorKey), garden))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur insertion garden"})
 		return
@@ -1043,7 +1108,7 @@ func listGardens(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("gardens")
+	collection := getDatabaseForRequest(c).Collection("gardens")
 	opts := options.Find().SetSort(bson.M{"updatedAt": -1})
 
 	cursor, err := collection.Find(context.Background(), bson.M{"uid": uid}, opts)
@@ -1075,7 +1140,7 @@ func getGardenByID(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("gardens")
+	collection := getDatabaseForRequest(c).Collection("gardens")
 	var garden Garden
 
 	err = collection.FindOne(context.Background(), bson.M{"_id": objectID}).Decode(&garden)
@@ -1131,7 +1196,7 @@ func updateGarden(c *gin.Context) {
 		set["thumbnailKey"] = *payload.ThumbnailKey
 	}
 
-	collection := client.Database("arbore").Collection("gardens")
+	collection := getDatabaseForRequest(c).Collection("gardens")
 	res, err := collection.UpdateOne(context.Background(), bson.M{"_id": objectID, "uid": uid}, bson.M{"$set": set})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur update garden"})
@@ -1159,7 +1224,7 @@ func deleteGarden(c *gin.Context) {
 		return
 	}
 
-	collection := client.Database("arbore").Collection("gardens")
+	collection := getDatabaseForRequest(c).Collection("gardens")
 	res, err := collection.DeleteOne(context.Background(), bson.M{"_id": objectID, "uid": uid})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur delete garden"})
@@ -1171,6 +1236,56 @@ func deleteGarden(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Garden supprimé"})
+}
+
+// seedTestDBPlantsIfEmpty copie le catalogue de plantes depuis la DB prod
+// vers la DB test si celle-ci est vide. Appelée une seule fois au démarrage
+// du backend si MONGODB_URI_TEST est défini. Permet aux tests d'avoir un
+// catalogue cohérent avec prod sans script de seed manuel, et permet au
+// cleanup nocturne (cf. cron VPS) de droper la DB test sans craindre de
+// perdre le seed — il sera reposé au prochain démarrage.
+func seedTestDBPlantsIfEmpty() {
+	if testClient == nil {
+		return
+	}
+	testPlants := testClient.Database(testDBName).Collection("plants")
+	count, err := testPlants.CountDocuments(context.Background(), bson.M{})
+	if err != nil {
+		log.Printf("⚠️  Test DB plants count failed: %v — seed sauté", err)
+		return
+	}
+	if count > 0 {
+		fmt.Printf("ℹ️ Test DB plants déjà peuplée (%d entrées), pas de seed.\n", count)
+		return
+	}
+
+	prodPlants := client.Database(prodDBName).Collection("plants")
+	cursor, err := prodPlants.Find(context.Background(), bson.M{})
+	if err != nil {
+		log.Printf("⚠️  Lecture plants prod pour seed échouée : %v", err)
+		return
+	}
+	defer func() { _ = cursor.Close(context.Background()) }()
+
+	var docs []interface{}
+	for cursor.Next(context.Background()) {
+		var p Plant
+		if err := cursor.Decode(&p); err != nil {
+			continue
+		}
+		// Note : on conserve l'ObjectID prod pour que les références
+		// PlacedPlant.plantId restent valides côté gardens créés en test.
+		docs = append(docs, p)
+	}
+	if len(docs) == 0 {
+		log.Println("⚠️  Aucune plante en prod à seed vers test.")
+		return
+	}
+	if _, err := testPlants.InsertMany(context.Background(), docs); err != nil {
+		log.Printf("⚠️  Seed test DB plants échoué : %v", err)
+		return
+	}
+	fmt.Printf("🌱 Seed test DB : %d plantes copiées depuis prod.\n", len(docs))
 }
 
 // ---------- LOAD ENV ----------
@@ -1239,7 +1354,31 @@ func main() {
 	if err != nil {
 		log.Fatal("❌ Erreur lors de la vérification de la connexion à MongoDB :", err)
 	}
-	fmt.Println("✅ Connecté à MongoDB!")
+	fmt.Println("✅ Connecté à MongoDB (prod, DB " + prodDBName + ") !")
+
+	// Connexion optionnelle pour la DB de test. Permet aux runs CI d'écrire
+	// dans `arbore_test` sans polluer la prod, via une seconde API key
+	// reconnue par APIKeyMiddleware (cf. issue #159 v2). Si MONGODB_URI_TEST
+	// n'est pas défini, le mode test est désactivé et toute requête avec
+	// ARBORE_API_KEY_TEST sera rejetée par le middleware.
+	if testURI := os.Getenv("MONGODB_URI_TEST"); testURI != "" {
+		testClientOptions := options.Client().ApplyURI(testURI)
+		testClient, err = mongo.Connect(context.Background(), testClientOptions)
+		if err != nil {
+			log.Fatal("❌ Connexion test MongoDB échouée :", err)
+		}
+		if err := testClient.Ping(context.Background(), nil); err != nil {
+			log.Fatal("❌ Ping test MongoDB échoué :", err)
+		}
+		fmt.Println("✅ Connecté à MongoDB (test, DB " + testDBName + ") !")
+
+		// Auto-seed des plantes dans la DB test si elle est vide. Évite
+		// d'avoir à exécuter un script de seed manuel après chaque cleanup
+		// nocturne. Copie le catalogue depuis la DB prod.
+		seedTestDBPlantsIfEmpty()
+	} else {
+		fmt.Println("ℹ️ MONGODB_URI_TEST non défini, mode test désactivé.")
+	}
 
 	// Initialiser Firebase Admin SDK.
 	// En release mode, toute erreur est fatale : le backend refuse de démarrer
@@ -1325,7 +1464,7 @@ func main() {
 			}
 
 			var user User
-			collection := client.Database("arbore").Collection("users")
+			collection := getDatabaseForRequest(c).Collection("users")
 			err := collection.FindOne(context.Background(), bson.M{"uid": uidParam}).Decode(&user)
 			if err != nil {
 				if err == mongo.ErrNoDocuments {

--- a/ArboreBackend/middleware/api_key.go
+++ b/ArboreBackend/middleware/api_key.go
@@ -8,13 +8,32 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// APIKeyMiddleware validates the X-API-Key header against the ARBORE_API_KEY environment variable
+// DBSelectorKey is the gin.Context key under which APIKeyMiddleware stores
+// the logical database target ("prod" or "test"). Handlers read this value
+// to pick the right mongo.Database via the helper in main.go.
+const DBSelectorKey = "arboreDB"
+
+// Logical database selectors written to the gin.Context.
+const (
+	DBSelectorProd = "prod"
+	DBSelectorTest = "test"
+)
+
+// APIKeyMiddleware validates the X-API-Key header against either:
+//
+//   - ARBORE_API_KEY      → context value DBSelectorKey = DBSelectorProd
+//   - ARBORE_API_KEY_TEST → context value DBSelectorKey = DBSelectorTest
+//
+// Tests in the iOS target inject the test key during CI runs (cf. #159 v2),
+// so the same backend process handles both prod traffic and the integration
+// test suite without mutating prod data. ARBORE_API_KEY_TEST is optional —
+// if unset, only the prod key is accepted.
 func APIKeyMiddleware() gin.HandlerFunc {
 	expectedKey := os.Getenv("ARBORE_API_KEY")
-
 	if expectedKey == "" {
 		panic("ARBORE_API_KEY environment variable not set")
 	}
+	testKey := os.Getenv("ARBORE_API_KEY_TEST")
 
 	return func(c *gin.Context) {
 		apiKey := c.GetHeader("X-API-Key")
@@ -28,15 +47,22 @@ func APIKeyMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		if subtle.ConstantTimeCompare([]byte(apiKey), []byte(expectedKey)) != 1 {
-			c.JSON(401, gin.H{
-				"error": "Invalid API key",
-				"code":  "INVALID_API_KEY",
-			})
-			c.Abort()
+		if subtle.ConstantTimeCompare([]byte(apiKey), []byte(expectedKey)) == 1 {
+			c.Set(DBSelectorKey, DBSelectorProd)
+			c.Next()
 			return
 		}
 
-		c.Next()
+		if testKey != "" && subtle.ConstantTimeCompare([]byte(apiKey), []byte(testKey)) == 1 {
+			c.Set(DBSelectorKey, DBSelectorTest)
+			c.Next()
+			return
+		}
+
+		c.JSON(401, gin.H{
+			"error": "Invalid API key",
+			"code":  "INVALID_API_KEY",
+		})
+		c.Abort()
 	}
 }

--- a/ArboreBackend/middleware/firebase_auth.go
+++ b/ArboreBackend/middleware/firebase_auth.go
@@ -15,8 +15,10 @@ import (
 
 var firebaseAuth *auth.Client
 
-// CheckUserBannedFunc is a function to check if a user is banned in the database
-var CheckUserBannedFunc func(string) (bool, error)
+// CheckUserBannedFunc is a function to check if a user is banned in the database.
+// It receives the gin.Context so the implementation can read DBSelectorKey
+// and route to the appropriate database (prod vs test).
+var CheckUserBannedFunc func(c *gin.Context, uid string) (bool, error)
 
 // isReleaseMode reports whether the server runs in production.
 // In release mode Firebase auth is REQUIRED — any missing credential must fail fast.
@@ -139,7 +141,7 @@ func FirebaseAuthMiddleware() gin.HandlerFunc {
 		uid := token.UID
 
 		if CheckUserBannedFunc != nil {
-			banned, err := CheckUserBannedFunc(uid)
+			banned, err := CheckUserBannedFunc(c, uid)
 			if err != nil {
 				log.Printf("❌ Error checking ban status: %v", err)
 				c.JSON(500, gin.H{

--- a/docs/architecture/03-components-backend.md
+++ b/docs/architecture/03-components-backend.md
@@ -129,7 +129,9 @@ Les handlers sont regroupés thématiquement dans `main.go` et exposés sous le 
 | Variable | Rôle | Sensibilité |
 |---|---|---|
 | `MONGODB_URI` | URI de connexion Mongo Atlas | 🔒 **secret** |
-| `ARBORE_API_KEY` | Clé applicative attendue dans `X-API-Key` | 🔒 **secret** |
+| `ARBORE_API_KEY` | Clé applicative attendue dans `X-API-Key` pour le trafic prod | 🔒 **secret** |
+| `ARBORE_API_KEY_TEST` | Clé applicative alternative qui route vers la DB `arbore_test`. Optionnelle ; si absente, le mode test est désactivé. | 🔒 **secret** |
+| `MONGODB_URI_TEST` | URI Mongo pour la DB `arbore_test` (utilisée uniquement quand `ARBORE_API_KEY_TEST` est validée). Optionnelle. | 🔒 **secret** |
 | `FIREBASE_SERVICE_ACCOUNT_PATH` | Chemin vers le JSON du service account Firebase | 🔒 **secret** |
 | `OPENAI_API_KEY` | Forwardée à l'AI Generator | 🔒 **secret** |
 | `UNSPLASH_ACCESS_KEY` | Clé API Unsplash | 🔒 **secret** |

--- a/scripts/cleanup-test-db.sh
+++ b/scripts/cleanup-test-db.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# cleanup-test-db.sh — Nettoie la DB Mongo de test (`arbore_test`).
+#
+# À exécuter via cron sur le VPS, idéalement à un horaire de faible
+# activité CI (04:00 UTC = 05:00/06:00 Paris). Le script vérifie qu'aucun
+# workflow GitHub Actions n'est en cours avant de droper la DB, pour ne
+# pas casser un run d'intégration en vol.
+#
+# La DB test est seedée à nouveau au prochain démarrage du backend grâce
+# à seedTestDBPlantsIfEmpty() — pas besoin d'intervention manuelle pour
+# retrouver le catalogue plantes.
+#
+# Variables d'environnement attendues :
+#   MONGODB_URI_TEST       URI de connexion vers la DB test (`.env`)
+#   GH_REPO                Slug du dépôt (default ArboreTeam/Arbore)
+#   GH_TOKEN               Personal Access Token avec `repo` scope.
+#                          Lecture via `gh api` si gh CLI installé.
+#
+# Codes de sortie :
+#   0   succès (drop OK ou skip légitime)
+#   1   prérequis manquant
+#   2   appel API GitHub a échoué (CI status inconnu, on n'ose pas drop)
+#   3   drop Mongo a échoué
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+GH_REPO="${GH_REPO:-ArboreTeam/Arbore}"
+
+log() { printf '%s [cleanup-test-db] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"; }
+
+# ── 1. Prérequis ──────────────────────────────────────────────────
+if ! command -v mongosh >/dev/null 2>&1; then
+    log "ERROR mongosh introuvable — installer mongodb-mongosh"
+    exit 1
+fi
+if [ ! -f "$ENV_FILE" ]; then
+    log "ERROR $ENV_FILE manquant"
+    exit 1
+fi
+
+MONGODB_URI_TEST="$(grep '^MONGODB_URI_TEST=' "$ENV_FILE" | sed 's/^MONGODB_URI_TEST=//' || true)"
+if [ -z "$MONGODB_URI_TEST" ]; then
+    log "INFO MONGODB_URI_TEST non défini dans .env — rien à nettoyer, exit 0"
+    exit 0
+fi
+
+# ── 2. Garde-fou : skip si une CI tourne ──────────────────────────
+#
+# Sans gh CLI, on essaie d'appeler l'API REST directement avec curl +
+# token. Si on ne peut pas vérifier (ni gh ni curl+token), on refuse
+# de drop pour éviter de casser une CI en vol.
+
+count_in_progress=""
+
+if command -v gh >/dev/null 2>&1; then
+    if count_in_progress=$(gh api "repos/$GH_REPO/actions/runs?status=in_progress" --jq '.total_count' 2>/dev/null); then
+        log "INFO via gh CLI : $count_in_progress CI run(s) en cours"
+    else
+        count_in_progress=""
+    fi
+fi
+
+if [ -z "$count_in_progress" ] && command -v curl >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+    response=$(curl -fsS \
+        -H "Authorization: Bearer $GH_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/$GH_REPO/actions/runs?status=in_progress" 2>/dev/null) || response=""
+    if [ -n "$response" ]; then
+        count_in_progress=$(echo "$response" | grep -oE '"total_count":[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$' || echo "")
+        if [ -n "$count_in_progress" ]; then
+            log "INFO via REST : $count_in_progress CI run(s) en cours"
+        fi
+    fi
+fi
+
+if [ -z "$count_in_progress" ]; then
+    log "ERROR impossible de vérifier le statut CI (ni gh ni curl+GH_TOKEN), abort par sécurité"
+    exit 2
+fi
+
+if [ "$count_in_progress" -gt 0 ]; then
+    log "INFO $count_in_progress CI run(s) en cours, skip du cleanup"
+    exit 0
+fi
+
+# ── 3. Drop arbore_test ───────────────────────────────────────────
+log "INFO Drop de la DB arbore_test..."
+if mongosh "$MONGODB_URI_TEST" --quiet --eval 'db.dropDatabase()'; then
+    log "INFO Drop OK — la DB sera reseedée au prochain démarrage du backend"
+else
+    log "ERROR drop a échoué"
+    exit 3
+fi


### PR DESCRIPTION
Closes #159.

Sépare le trafic CI du trafic prod sans créer un second backend ni un cluster Atlas dédié : **une seconde API key route les requêtes vers la DB Mongo `arbore_test` au lieu de `arbore`**.

Le seul backend tourne. Le middleware `APIKeyMiddleware` détecte si la requête arrive avec `ARBORE_API_KEY` (prod) ou `ARBORE_API_KEY_TEST` (test) et pose un sélecteur dans le contexte Gin. Les 22 handlers utilisent désormais un helper `getDatabaseForRequest(c)` qui choisit la bonne `*mongo.Database`.

## Diff résumé

| Fichier | Changement |
|---|---|
| `middleware/api_key.go` | 2 keys acceptées, sélecteur dans le context (`DBSelectorProd` / `DBSelectorTest`) |
| `middleware/firebase_auth.go` | `CheckUserBannedFunc` reçoit le `*gin.Context` pour propager le sélecteur |
| `main.go` | 2 `*mongo.Client` (prod + test), helpers `getDatabaseForRequest` / `getDatabaseByName`, label `_test: true` sur les inserts test via `maybeLabelTestDoc`, seed auto des plantes au démarrage si DB test vide |
| `.github/workflows/ci.yml` | Step "Switch to test API key" qui réécrit `Secrets.xcconfig` avec `ARBORE_API_KEY_TEST` avant le test step ; fallback safe vers prod si le secret n'existe pas |
| `scripts/cleanup-test-db.sh` | Drop `arbore_test` à condition qu'aucun workflow GH Actions ne tourne. Reseedé au prochain démarrage. À installer en cron VPS 04:00 UTC. |
| `docs/architecture/03-components-backend.md` | Doc des nouvelles env vars |

## Comportement

| Requête | API key | Effet |
|---|---|---|
| iOS app prod | `ARBORE_API_KEY` | Écrit dans `arbore` (DB prod, inchangé) |
| CI integration tests | `ARBORE_API_KEY_TEST` | Écrit dans `arbore_test` avec `_test: true` |
| Si `ARBORE_API_KEY_TEST` non défini côté backend | Tout `ARBORE_API_KEY_TEST` arrivant rejeté en 401 | Sécurité par défaut |

## Atlas

Déjà fait par Antonin avant le code : Database User `arbore_test_user` créé avec `readWriteAnyDatabase@admin`. URI stockée dans `MONGODB_URI_TEST` sur le VPS `.env`.

⚠️ Le rôle est volontairement large (`readWriteAnyDatabase`). À tightener en `readWrite@arbore_test` uniquement quand on aura un meilleur séparateur (cf. follow-up).

## À faire après merge (par toi)

1. **GitHub** : Settings → Secrets and variables → Actions → ajouter `ARBORE_API_KEY_TEST` (générer une chaîne aléatoire 32+ chars, exemple : `openssl rand -base64 32`).
2. **VPS** : ajouter la **même valeur** dans `/home/fedora/Arbore/.env` :
   ```
   ARBORE_API_KEY_TEST=<même_clé>
   ```
3. **VPS** : `cd /home/fedora/Arbore && ./deploy.sh` (redémarre le backend avec les nouvelles env vars, déclenche le seed initial des plantes vers `arbore_test`).
4. **VPS** : installer le cron de cleanup :
   ```
   crontab -e
   0 4 * * * /home/fedora/Arbore/scripts/cleanup-test-db.sh >> /home/fedora/Arbore/logs/cleanup.log 2>&1
   ```
   Variable `GH_TOKEN` à exporter pour que le script puisse vérifier le statut CI.

## Vérification

- [x] `go build ./...` sur le backend → OK
- [x] `go test ./...` → 2 packages OK
- [ ] xcodebuild iOS (touche uniquement `.github/workflows/ci.yml`, pas le code Swift)
- [ ] Test end-to-end : déploiement VPS + run CI avec `ARBORE_API_KEY_TEST` → vérifier que les `test-network-*@arbore.test` arrivent dans `arbore_test.users` et pas dans `arbore.users`

## Suite

Après ce merge :
- **#160** Cleanup batch des users `*@arbore.test` déjà accumulés dans `arbore` (la migration vers test stoppe le flux mais ne purge pas le passif)
- Suivi : tightener les privilèges `arbore_test_user` (cf. note Atlas ci-dessus)