### PR TITLE
fix(ci): stop dumping Secrets.xcconfig to Actions logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,9 +297,10 @@ jobs:
           // Backend host (IP:port or domain:port)
           ARBORE_BACKEND_HOST = ${{ secrets.ARBORE_BACKEND_HOST }}
           EOF
-          echo "✅ Secrets.xcconfig created"
-          echo "📝 Content:"
-          cat Secrets.xcconfig
+          # NE PAS dumper Secrets.xcconfig dans les logs : ARBORE_API_KEY
+          # serait imprimée en clair et les Actions logs des repos publics
+          # sont consultables par tous (issue #120).
+          echo "✅ Secrets.xcconfig created ($(wc -l < Secrets.xcconfig) lines, $(wc -c < Secrets.xcconfig) bytes)"
 
       - name: 🔑 Setup Keychain for CI
         run: |


### PR DESCRIPTION
## Summary

Close #120.

- Le step \`📝 Create Secrets.xcconfig file\` faisait \`cat Secrets.xcconfig\` après génération
- Les Actions logs des repos publics étant consultables par tous, \`ARBORE_API_KEY\` fuitait en clair à chaque run CI
- Remplacé par un résumé taille (lignes/bytes) — suffit à confirmer la génération sans révéler le contenu

## Test plan

- [ ] Vérifier sur le prochain run CI que le step ne dumpe plus le contenu
- [ ] Confirmer que le step suivant (Keychain setup + xcodebuild) lit toujours bien le fichier