### PR TITLE
chore(scripts): cleanup-test-db fallback to unauth GitHub API

### DIFF
--- a/scripts/cleanup-test-db.sh
+++ b/scripts/cleanup-test-db.sh
@@ -100,8 +100,32 @@ fi
 # ── 3. Drop arbore_test ───────────────────────────────────────────
 log "INFO Drop de la DB arbore_test..."
 if mongosh "$MONGODB_URI_TEST" --quiet --eval 'db.dropDatabase()'; then
-    log "INFO Drop OK — la DB sera reseedée au prochain démarrage du backend"
+    log "INFO Drop OK"
 else
     log "ERROR drop a échoué"
     exit 3
+fi
+
+# ── 4. Restart backend pour réamorcer le catalogue plantes ────────
+#
+# seedTestDBPlantsIfEmpty() ne tourne qu'au démarrage du backend. Sans
+# restart, les CI runs entre le drop et le prochain redémarrage
+# trouveront plants vide → tests cassés. Restart pour réamorcer.
+#
+# Le container est piloté par docker-compose ; un simple restart suffit.
+# Variable BACKEND_CONTAINER overridable si le nom change (default
+# arbore-backend, défini dans docker-compose.yml).
+
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-arbore-backend}"
+
+if command -v docker >/dev/null 2>&1 && sudo -n docker ps >/dev/null 2>&1; then
+    if sudo -n docker restart "$BACKEND_CONTAINER" >/dev/null 2>&1; then
+        log "INFO Backend container '$BACKEND_CONTAINER' restarted — seed plants amorcé"
+    else
+        log "WARN restart docker a échoué — la DB est dropée mais plants restera vide"
+        log "WARN jusqu'au prochain restart manuel du backend"
+    fi
+else
+    log "WARN docker indisponible ou sans accès sudo, skip du restart"
+    log "WARN la DB est dropée mais plants restera vide jusqu'au prochain restart du backend"
 fi

--- a/scripts/cleanup-test-db.sh
+++ b/scripts/cleanup-test-db.sh
@@ -51,13 +51,18 @@ fi
 
 # ── 2. Garde-fou : skip si une CI tourne ──────────────────────────
 #
-# Sans gh CLI, on essaie d'appeler l'API REST directement avec curl +
-# token. Si on ne peut pas vérifier (ni gh ni curl+token), on refuse
-# de drop pour éviter de casser une CI en vol.
+# On essaie dans l'ordre :
+#   1. gh CLI (si installé ET authentifié)
+#   2. curl + GH_TOKEN (si défini)
+#   3. curl sans auth (le dépôt est public, l'API Actions est lisible
+#      sans token — rate-limit 60 req/h largement suffisant pour un
+#      cron quotidien)
+# Si aucune option ne renvoie de réponse, on refuse de drop pour ne
+# pas casser une CI en vol.
 
 count_in_progress=""
 
-if command -v gh >/dev/null 2>&1; then
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     if count_in_progress=$(gh api "repos/$GH_REPO/actions/runs?status=in_progress" --jq '.total_count' 2>/dev/null); then
         log "INFO via gh CLI : $count_in_progress CI run(s) en cours"
     else
@@ -65,21 +70,25 @@ if command -v gh >/dev/null 2>&1; then
     fi
 fi
 
-if [ -z "$count_in_progress" ] && command -v curl >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
-    response=$(curl -fsS \
-        -H "Authorization: Bearer $GH_TOKEN" \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/$GH_REPO/actions/runs?status=in_progress" 2>/dev/null) || response=""
+if [ -z "$count_in_progress" ] && command -v curl >/dev/null 2>&1; then
+    curl_args=(-fsS -H "Accept: application/vnd.github+json")
+    if [ -n "${GH_TOKEN:-}" ]; then
+        curl_args+=(-H "Authorization: Bearer $GH_TOKEN")
+        via="REST (authenticated)"
+    else
+        via="REST (anonymous — repo public)"
+    fi
+    response=$(curl "${curl_args[@]}" "https://api.github.com/repos/$GH_REPO/actions/runs?status=in_progress" 2>/dev/null) || response=""
     if [ -n "$response" ]; then
         count_in_progress=$(echo "$response" | grep -oE '"total_count":[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$' || echo "")
         if [ -n "$count_in_progress" ]; then
-            log "INFO via REST : $count_in_progress CI run(s) en cours"
+            log "INFO via $via : $count_in_progress CI run(s) en cours"
         fi
     fi
 fi
 
 if [ -z "$count_in_progress" ]; then
-    log "ERROR impossible de vérifier le statut CI (ni gh ni curl+GH_TOKEN), abort par sécurité"
+    log "ERROR impossible de vérifier le statut CI (gh + curl ont tous deux échoué), abort par sécurité"
     exit 2
 fi
 


### PR DESCRIPTION
## Summary

Deux ajustements au script de cleanup nocturne de la DB de test :

### 1. Fallback API GitHub sans auth (repo passé public)

Le dépôt étant public depuis le 2026-05-13, l'API Actions est lisible sans token (rate-limit 60 req/h, largement suffisant pour un cron quotidien) :

- Permet au script de fonctionner sur le VPS sans avoir à maintenir un PAT
- Le check \`gh auth status\` évite qu'un \`gh\` CLI installé mais non auth empêche le fallback curl

Ordre de fallback :
1. \`gh\` CLI (si installé **et** authentifié)
2. \`curl + GH_TOKEN\` (si défini)
3. \`curl\` sans auth (nouveau)

### 2. Restart backend après drop pour re-seed plants

\`seedTestDBPlantsIfEmpty()\` ne tourne qu'au démarrage du backend. Sans restart après drop, le catalogue \`plants\` reste vide jusqu'au prochain restart manuel → CI matinaux cassés.

- Ajoute \`sudo -n docker restart \$BACKEND_CONTAINER\` après drop réussi
- Variable \`BACKEND_CONTAINER\` overridable (default \`arbore-backend\`)
- Non-bloquant : si docker indisponible ou sudo refusé, warn dans les logs mais drop reste valide

## Test plan

- [x] Script validé sur VPS : skip CI in progress détecté correctement (anonymous REST)
- [x] mongosh connecte à \`arbore_test\` (4 collections)
- [x] \`sudo -n docker ps\` fonctionne sur VPS (fedora a sudo NOPASSWD)
- [ ] Vérifier au premier run cron (04:00 UTC) que drop + restart se passent OK
- [ ] Vérifier que le backend re-seed les plants dans la foulée

## Cron déjà installé sur le VPS

\`\`\`
0 4 * * * /home/fedora/Arbore/scripts/cleanup-test-db.sh >> /home/fedora/Arbore/logs/cleanup-test-db.log 2>&1
\`\`\`

Prochain run : 04:00 UTC. \`mongosh\` + \`cronie\` installés via \`dnf\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)