### PR TITLE
fix(ci): docs-drift skip absolute system paths

### DIFF
--- a/.github/scripts/docs-drift-check.sh
+++ b/.github/scripts/docs-drift-check.sh
@@ -82,6 +82,16 @@ for md in "${md_files[@]}"; do
       continue
     fi
 
+    # Skip chemins absolus système (container ou VPS) : la doc d'opérations
+    # cite légitimement /root/firebase-adminsdk.json (intra-container),
+    # /home/fedora/Arbore/... (VPS), /etc/nginx/conf.d/... etc. Ces
+    # chemins n'ont pas de correspondance dans le dépôt et ne doivent
+    # pas faire échouer le drift check.
+    case "$candidate" in
+      /root/*|/home/*|/etc/*|/usr/*|/var/*|/opt/*|/tmp/*|/proc/*|/sys/*)
+        continue ;;
+    esac
+
     # Skip si pas d'extension surveillée
     if ! [[ "$candidate" =~ $EXTS_REGEX$ ]]; then
       continue


### PR DESCRIPTION
## Summary

La doc d'opérations (\`docs/operations/vps-bootstrap.md\` ajoutée par #165) cite légitimement des chemins absolus système :
- \`/root/firebase-adminsdk.json\` (intra-container)
- \`/home/fedora/Arbore/...\` (VPS)
- \`/etc/nginx/conf.d/...\` etc.

Le script \`docs-drift-check.sh\` les interprétait comme repo-relatifs après strip du leading \`/\`, faisant échouer la CI.

## Fix

Ajoute une garde explicite : tout chemin commençant par \`/root\`, \`/home\`, \`/etc\`, \`/usr\`, \`/var\`, \`/opt\`, \`/tmp\`, \`/proc\` ou \`/sys\` est skippé.

Le check reste actif pour tous les chemins repo-relatifs (la vaste majorité des références code dans la doc).

## Validation locale

Sur la branche \`docs/vps-bootstrap\` avec ce patch appliqué :
\`\`\`
Indexed 2428 source file(s) in the repository.
Checked 77 code path reference(s) across docs/
✅ No doc drift detected.
\`\`\`

## Impact

Une fois mergée, #165 (VPS bootstrap doc) passera la CI après rebase.