### PR TITLE
feat(ci): fastlane TestFlight auto-deploy (closes #156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,19 @@ arbore-firebase-adminsdk.json
 *.p12
 *.mobileprovision
 *.certSigningRequest
+*.p8
+
+# Fastlane — never commit the App Store Connect API key or any local
+# fastlane state (only the Fastfile + Appfile + READMEs are tracked).
+fastlane/AuthKey.json
+fastlane/AuthKey*.json
+fastlane/AuthKey*.p8
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/.env
+fastlane/.env.local
 
 # Deepl translations
 .deepl_api.backups/

--- a/.gitignore
+++ b/.gitignore
@@ -178,8 +178,14 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+fastlane/builds
 fastlane/.env
 fastlane/.env.local
+
+# Bundler — gems sont installés en local au projet (vendor/bundle,
+# déjà couvert par `vendor/` plus haut). `.bundle/` contient la config
+# locale `bundle config set --local path 'vendor/bundle'`.
+.bundle/
 
 # Deepl translations
 .deepl_api.backups/

--- a/ArboreUi/ArboreUi/Info.plist
+++ b/ArboreUi/ArboreUi/Info.plist
@@ -41,6 +41,16 @@
 	<true/>
 	<key>GIDClientID</key>
 	<string>66927287937-72cn4i6cjliekvs01mr0i0ac3tdm7fsp.apps.googleusercontent.com</string>
+	<!--
+		Export-compliance declaration : Arbore n'utilise que du chiffrement
+		« exempté » au sens d'Apple (HTTPS standard, auth Firebase, etc.) — pas
+		de crypto custom. Évite la modale "Missing Compliance" sur chaque
+		upload TestFlight. Si on ajoute un jour du chiffrement non-exempt
+		(E2E messaging, crypto wallet, etc.), repasser à `true` ET soumettre
+		une déclaration ERN annuelle au Bureau of Industry and Security US.
+	-->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# Fastlane pour l'automatisation TestFlight (cf. fastlane/Fastfile).
+gem "fastlane", "~> 2.226"
+
+plugins_path = File.join(File.dirname(__FILE__), "fastlane", "Pluginfile")
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/docs/operations/testflight-deploy.md
+++ b/docs/operations/testflight-deploy.md
@@ -64,17 +64,29 @@ git check-ignore -v fastlane/AuthKey.json
 
 ### 4. Installer fastlane sur la machine qui déploie
 
+Sur macOS avec Ruby installé via Homebrew, le dossier système des gems
+n'est pas writable par défaut. Toujours installer les gems en local au
+projet :
+
 ```bash
+bundle config set --local path 'vendor/bundle'   # one-shot — écrit .bundle/config
 bundle install
 ```
 
-Cela installe la version pinnée dans `Gemfile`. Vérifier ensuite :
+Cela installe la version pinnée dans `Gemfile` dans `vendor/bundle/`
+(gitignored). Vérifier ensuite :
 
 ```bash
 bundle exec fastlane --version
 ```
 
-> Alternative sans bundler : `brew install fastlane`. Plus simple mais sans pin de version — risque de dériver entre machines.
+> Si `bundle install` échoue avec `Bundler::PermissionError` sur
+> `/opt/homebrew/lib/ruby/...`, c'est que le `bundle config set` n'a pas
+> été fait. La config est par-projet (dans `.bundle/config`), pas
+> globale — chaque clone du repo doit la repasser.
+
+> Alternative sans bundler : `brew install fastlane`. Plus simple mais
+> sans pin de version — risque de dériver entre machines.
 
 ### 5. Vérifier le code signing Xcode
 

--- a/docs/operations/testflight-deploy.md
+++ b/docs/operations/testflight-deploy.md
@@ -1,0 +1,159 @@
+# TestFlight Deploy — Fastlane
+
+Procédure pour déposer une nouvelle build de l'app iOS sur TestFlight et la
+distribuer automatiquement au groupe interne « Internal QA ». Lane
+principale : `bundle exec fastlane beta`.
+
+Le pipeline en une commande :
+
+1. Bump `CFBundleVersion` à `latest_testflight + 1`
+2. `xcodebuild archive` (export `app-store`)
+3. Upload sur App Store Connect via l'API Key
+4. Attend la fin du processing Apple (5-30 min)
+5. Distribue au groupe « Internal QA » (pas de Beta App Review)
+
+---
+
+## Setup initial (one-shot)
+
+### 1. Créer l'App Store Connect API Key
+
+Rôle requis : **Admin** sur ArboreTeam dans App Store Connect.
+
+1. Aller sur [App Store Connect → Users and Access → Integrations → App Store Connect API](https://appstoreconnect.apple.com/access/integrations/api).
+2. Cliquer sur **« + »** pour générer une nouvelle clé.
+3. Nom : `arbore-fastlane-beta`. Access : **App Manager** (suffisant pour upload TestFlight, pas besoin d'Admin).
+4. Télécharger le fichier `.p8` (téléchargeable **une seule fois** — perdu = recommencer).
+5. Noter le **Key ID** (visible sur la ligne de la clé après création) et l'**Issuer ID** (en haut de la page).
+
+> **Pourquoi cette clé** : elle remplace l'authentification interactive Apple ID + 2FA. Sans elle, fastlane échoue dans 80 % des cas à cause des codes 2FA reçus sur un device tiers.
+
+### 2. Poser `fastlane/AuthKey.json`
+
+Reformater le contenu du `.p8` en JSON :
+
+```bash
+cat > fastlane/AuthKey.json << EOF
+{
+  "key_id": "<Key ID>",
+  "issuer_id": "<Issuer ID>",
+  "key": "$(cat ~/Downloads/AuthKey_<KeyID>.p8 | awk '{printf "%s\\n", $0}')",
+  "in_house": false
+}
+EOF
+chmod 600 fastlane/AuthKey.json
+```
+
+Vérifier que le fichier est bien gitignored :
+
+```bash
+git check-ignore -v fastlane/AuthKey.json
+# → .gitignore:172:fastlane/AuthKey.json   fastlane/AuthKey.json
+```
+
+> ⚠️ Si `git check-ignore` ne retourne rien, ne PAS continuer — `AuthKey.json` serait commit au prochain `git add .`. Le pre-commit hook gitleaks devrait aussi rattraper, mais ne pas s'en remettre.
+
+### 3. Créer le groupe « Internal QA » sur App Store Connect
+
+1. App Store Connect → ArboreUi → **TestFlight → Internal Testing → « + »**.
+2. Group Name : `Internal QA`.
+3. Cocher **« Enable automatic distribution »** — chaque nouvelle build leur sera poussée sans configuration côté Fastfile.
+4. Ajouter les membres : Antonin, Hugo M., Hugo R., Isaac, Tanssime + l'adresse de review interne si applicable.
+
+> Le nom **doit** matcher la constante `INTERNAL_GROUP` dans `fastlane/Fastfile`. S'il change, modifier le Fastfile en conséquence.
+
+### 4. Installer fastlane sur la machine qui déploie
+
+```bash
+bundle install
+```
+
+Cela installe la version pinnée dans `Gemfile`. Vérifier ensuite :
+
+```bash
+bundle exec fastlane --version
+```
+
+> Alternative sans bundler : `brew install fastlane`. Plus simple mais sans pin de version — risque de dériver entre machines.
+
+### 5. Vérifier le code signing Xcode
+
+Ouvrir `ArboreUi.xcworkspace` dans Xcode :
+
+- Target `ArboreUi` → onglet **Signing & Capabilities**
+- **Automatically manage signing** activé
+- Team : `ArboreTeam (582QH9652J)` (enforced par `.githooks/pre-commit`)
+
+Si « Automatically manage signing » est désactivé, fastlane échouera sur l'étape `build_app` faute de provisioning profile à jour.
+
+---
+
+## Usage courant
+
+### Déposer une nouvelle build interne
+
+```bash
+bundle exec fastlane beta
+```
+
+La commande :
+
+- Échoue immédiatement si `fastlane/AuthKey.json` est absent.
+- Récupère le dernier `build_number` sur TestFlight.
+- Incrémente de 1 et l'écrit dans `ArboreUi.xcodeproj`.
+- Archive l'app (~ 3-5 min sur M2/M3).
+- Upload sur App Store Connect (~ 30-60 s).
+- Attend la fin du processing Apple (5-30 min, peut être plus long si Apple charge la queue).
+- Distribue automatiquement au groupe « Internal QA ».
+
+Total : 10-40 min selon le processing Apple.
+
+### Vérifier le dernier build sur TestFlight
+
+```bash
+bundle exec fastlane current_build
+```
+
+Utile pour confirmer que l'upload précédent a bien été enregistré côté ASC avant d'en lancer un autre.
+
+### Annuler un build en cours
+
+`Ctrl-C` pendant `build_app` : l'archive locale est jetée, rien n'est uploadé. Pendant `upload_to_testflight` : l'upload est interrompu, ASC peut ou non avoir enregistré la build (vérifier dans l'UI ASC). Si une build orpheline traîne dans TestFlight, la supprimer via l'UI ASC.
+
+---
+
+## Dépannage
+
+| Symptôme | Cause probable | Fix |
+|---|---|---|
+| `Fastlane API key missing` au lancement | `fastlane/AuthKey.json` absent ou mal lu | Repasser sur l'étape 2 du setup |
+| `Couldn't find bundle identifier` | `fastlane/Appfile` désynchronisé du projet Xcode | Vérifier `PRODUCT_BUNDLE_IDENTIFIER` dans `ArboreUi.xcodeproj/project.pbxproj` |
+| `No provisioning profile found` | Automatic signing désactivé ou Team différent | Réactiver Automatic signing avec `ArboreTeam (582QH9652J)` |
+| `Build number 42 already exists` | Race condition avec un autre upload en cours | Attendre la fin du processing, vérifier `current_build`, relancer |
+| `App Store Connect timeout` | Processing Apple anormalement long | Vérifier le statut sur [Apple System Status](https://www.apple.com/support/systemstatus/), relancer plus tard |
+| `Code signing entitlements` divergent | Capabilities Xcode modifiées sans MAJ ASC | Activer/désactiver la capability dans Xcode, builder à nouveau |
+
+### Logs détaillés
+
+```bash
+bundle exec fastlane beta --verbose
+```
+
+Les rapports Junit sont écrits dans `fastlane/report.xml` (gitignored).
+
+---
+
+## Hors scope (issues séparées si besoin)
+
+- **CI macOS GitHub Actions** qui lance `fastlane beta` sur push de tag : faisable mais demande des minutes Actions macOS (10× plus chères qu'Ubuntu) + un secret pour l'API key. Pas urgent tant que le deploy interne reste manuel.
+- **match (fastlane)** pour le code signing multi-machines : nécessite un repo privé séparé pour les certificats chiffrés. À considérer si plusieurs personnes uploadent.
+- **Lane `release`** vers les testeurs externes : demande Beta App Review Apple à chaque submission. Sprint 4.
+
+---
+
+## Références
+
+- Issue de mise en place : [#156](https://github.com/ArboreTeam/Arbore/issues/156)
+- [Apple — App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi)
+- [Fastlane — `upload_to_testflight`](https://docs.fastlane.tools/actions/upload_to_testflight/)
+- [Fastlane — `app_store_connect_api_key`](https://docs.fastlane.tools/actions/app_store_connect_api_key/)

--- a/docs/operations/testflight-deploy.md
+++ b/docs/operations/testflight-deploy.md
@@ -51,7 +51,7 @@ git check-ignore -v fastlane/AuthKey.json
 # → .gitignore:172:fastlane/AuthKey.json   fastlane/AuthKey.json
 ```
 
-> ⚠️ Si `git check-ignore` ne retourne rien, ne PAS continuer — `AuthKey.json` serait commit au prochain `git add .`. Le pre-commit hook gitleaks devrait aussi rattraper, mais ne pas s'en remettre.
+> ⚠️ Si `git check-ignore` ne retourne rien, ne PAS continuer — le fichier serait commit au prochain `git add .`. Le pre-commit hook gitleaks devrait aussi rattraper, mais ne pas s'en remettre.
 
 ### 3. Créer le groupe « Internal QA » sur App Store Connect
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier "com.arboreteam.arbore"  # Bundle identifier de l'app iOS (cf. ArboreUi.xcodeproj)
+team_id "582QH9652J"                     # ArboreTeam Apple Developer — enforced par .githooks/pre-commit

--- a/fastlane/AuthKey.json.example
+++ b/fastlane/AuthKey.json.example
@@ -1,0 +1,6 @@
+{
+  "key_id": "ABCD123456",
+  "issuer_id": "12345678-1234-1234-1234-123456789012",
+  "key": "-----BEGIN PRIVATE KEY-----\nREMPLACER_ICI_LE_CONTENU_DU_FICHIER_P8\n-----END PRIVATE KEY-----",
+  "in_house": false
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,18 +44,20 @@ platform :ios do
 
   desc "Build + upload TestFlight + distribute à « Internal QA »."
   lane :beta do
-    api_key = app_store_connect_api_key(
-      key_filepath: AUTH_KEY,
-      duration: 1200,
-      in_house: false
-    )
+    # On passe `api_key_path` directement aux actions plutôt que de
+    # construire un hash via `app_store_connect_api_key` — ce helper
+    # attend un `.p8` brut, alors que nous stockons les credentials
+    # dans un JSON déjà au bon format pour `api_key_path` (cf doc
+    # operations/testflight-deploy.md). C'est aussi ce que fait la
+    # lane `current_build` (qui passe le smoke-test).
 
     # Bump build_number = latest_testflight + 1. Échoue volontairement si
     # ASC ne répond pas, plutôt que de pousser une build avec un numéro
     # qui collisionne et fera échouer l'upload après 15 min de processing.
+    version = get_version_number(xcodeproj: "ArboreUi/ArboreUi.xcodeproj")
     latest = latest_testflight_build_number(
-      api_key: api_key,
-      version: get_version_number(xcodeproj: "ArboreUi/ArboreUi.xcodeproj")
+      api_key_path: AUTH_KEY,
+      version: version
     )
     increment_build_number(
       xcodeproj: "ArboreUi/ArboreUi.xcodeproj",
@@ -74,7 +76,7 @@ platform :ios do
     )
 
     upload_to_testflight(
-      api_key: api_key,
+      api_key_path: AUTH_KEY,
       ipa: "./fastlane/builds/Arbore.ipa",
       distribute_external: false,
       groups: [INTERNAL_GROUP],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,11 @@
 
 WORKSPACE = "ArboreUi/ArboreUi.xcworkspace"
 SCHEME    = "ArboreUi"
-AUTH_KEY  = "./fastlane/AuthKey.json"
+# Path absolu vers AuthKey.json — `__dir__` est le dossier du Fastfile,
+# robuste quelle que soit la cwd au moment de l'invocation (fastlane chdir
+# dans `fastlane/` au démarrage, donc un `./fastlane/AuthKey.json`
+# relatif chercherait `fastlane/fastlane/AuthKey.json`).
+AUTH_KEY  = File.expand_path("AuthKey.json", __dir__)
 INTERNAL_GROUP = "Internal QA"
 
 default_platform(:ios)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,88 @@
+# Fastfile — automatisation TestFlight pour Arbore iOS
+#
+# Lane principale : `fastlane beta`
+#   Bump le build number à `latest_testflight + 1`, archive et upload sur
+#   TestFlight, distribue automatiquement au groupe interne « Internal QA ».
+#
+# Prérequis (one-shot, cf. docs/operations/testflight-deploy.md) :
+#   1. App Store Connect API Key (rôle App Manager) → fichier `.p8`
+#   2. fastlane/AuthKey.json renseigné (gitignored)
+#   3. Groupe « Internal QA » créé dans ASC avec auto-distribution
+#   4. Xcode automatic signing activé sur la machine qui déploie
+#
+# Usage :
+#   bundle exec fastlane beta            # déploie une nouvelle build interne
+#   bundle exec fastlane current_build   # affiche le dernier build_number sur TestFlight
+
+WORKSPACE = "ArboreUi/ArboreUi.xcworkspace"
+SCHEME    = "ArboreUi"
+AUTH_KEY  = "./fastlane/AuthKey.json"
+INTERNAL_GROUP = "Internal QA"
+
+default_platform(:ios)
+
+platform :ios do
+  before_all do
+    # Garde-fou : refuser de tourner si la clé API n'est pas posée.
+    unless File.exist?(AUTH_KEY)
+      UI.user_error!(
+        "Fastlane API key missing: #{AUTH_KEY}\n" \
+        "Suivre docs/operations/testflight-deploy.md (section « Setup initial »)."
+      )
+    end
+  end
+
+  desc "Affiche le dernier build_number actuellement sur TestFlight."
+  lane :current_build do
+    n = latest_testflight_build_number(api_key_path: AUTH_KEY)
+    UI.success("Dernier build sur TestFlight: #{n}")
+  end
+
+  desc "Build + upload TestFlight + distribute à « Internal QA »."
+  lane :beta do
+    api_key = app_store_connect_api_key(
+      key_filepath: AUTH_KEY,
+      duration: 1200,
+      in_house: false
+    )
+
+    # Bump build_number = latest_testflight + 1. Échoue volontairement si
+    # ASC ne répond pas, plutôt que de pousser une build avec un numéro
+    # qui collisionne et fera échouer l'upload après 15 min de processing.
+    latest = latest_testflight_build_number(
+      api_key: api_key,
+      version: get_version_number(xcodeproj: "ArboreUi/ArboreUi.xcodeproj")
+    )
+    increment_build_number(
+      xcodeproj: "ArboreUi/ArboreUi.xcodeproj",
+      build_number: latest + 1
+    )
+
+    build_app(
+      workspace: WORKSPACE,
+      scheme: SCHEME,
+      export_method: "app-store",
+      clean: true,
+      output_directory: "./fastlane/builds",
+      output_name: "Arbore.ipa",
+      include_symbols: true,
+      include_bitcode: false
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: "./fastlane/builds/Arbore.ipa",
+      distribute_external: false,
+      groups: [INTERNAL_GROUP],
+      skip_waiting_for_build_processing: false,
+      notify_external_testers: false,
+      changelog: "Build interne automatique (lane: beta)."
+    )
+
+    UI.success("✅ Build #{latest + 1} déployée sur TestFlight → groupe #{INTERNAL_GROUP}")
+  end
+
+  error do |lane, exception|
+    UI.error("❌ Lane #{lane} a échoué: #{exception}")
+  end
+end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,0 +1,5 @@
+# Plugins fastlane (vide pour l'instant — la lane beta n'a besoin
+# que des actions standard `build_app` et `upload_to_testflight`).
+#
+# Pour ajouter un plugin :
+#   bundle exec fastlane add_plugin <nom>


### PR DESCRIPTION
Closes #156.

Met en place l'infrastructure Fastlane pour automatiser le dépôt d'une nouvelle build sur TestFlight et sa distribution au groupe interne « Internal QA ». Une seule commande après setup :

\`\`\`
bundle exec fastlane beta
\`\`\`

## Pipeline

1. Bump \`CFBundleVersion\` à \`latest_testflight + 1\` (récupéré via l'API ASC, pas d'oubli)
2. \`xcodebuild archive\` (export \`app-store\`, ~3-5 min)
3. Upload sur App Store Connect via API Key (~30-60 s)
4. Attente du processing Apple (5-30 min)
5. Distribution automatique au groupe « Internal QA » (pas de Beta App Review nécessaire pour les testeurs internes ≤ 100 personnes)

Temps total : 10-40 min, **0 clic** dans Xcode ou ASC.

## Fichiers ajoutés

- \`Gemfile\` — pin de \`fastlane ~> 2.226\` (reproductibilité inter-machines)
- \`fastlane/Fastfile\` — lanes \`beta\` + \`current_build\`. Garde-fou \`before_all\` qui refuse de tourner si la clé API n'est pas posée
- \`fastlane/Appfile\` — bundle ID \`com.arboreteam.arbore\` + team \`582QH9652J\` (cohérent avec ce qu'enforce déjà \`.githooks/pre-commit\`)
- \`fastlane/Pluginfile\` — vide, scaffolding only
- \`fastlane/AuthKey.json.example\` — template explicite avec placeholders
- \`docs/operations/testflight-deploy.md\` — runbook complet (setup ASC API key, groupe Internal QA, code signing, dépannage)
- \`.gitignore\` — ajoute \`fastlane/AuthKey.json\` + variantes, \`*.p8\`, artefacts locaux

## Actions manuelles restantes (côté humain)

Documentées en détail dans \`docs/operations/testflight-deploy.md\` :

- [ ] Créer l'API Key ASC (rôle App Manager) — **requiert le rôle Admin sur ArboreTeam dans ASC**
- [ ] Télécharger le \`.p8\` et reformater en \`fastlane/AuthKey.json\` (gitignored)
- [ ] Créer le groupe « Internal QA » dans ASC avec **« Enable automatic distribution »** activé
- [ ] Ajouter les testeurs au groupe (Antonin, Hugo M., Hugo R., Isaac, Tanssime + adresse de review)
- [ ] \`bundle install\` sur la machine qui déploie
- [ ] Premier essai : \`bundle exec fastlane beta\`

## Test plan

- [ ] \`bundle exec fastlane current_build\` retourne le dernier build_number (smoke-test de l'API key)
- [ ] \`bundle exec fastlane beta\` complète sans erreur
- [ ] Vérifier l'arrivée de la build dans TestFlight → onglet Builds avec le bon numéro
- [ ] Vérifier la distribution automatique : les testeurs du groupe « Internal QA » reçoivent la notif TestFlight
- [ ] Vérifier que \`fastlane/AuthKey.json\` reste gitignored (\`git check-ignore -v fastlane/AuthKey.json\`)

## Hors scope (issues séparées si besoin)

- GitHub Actions macOS runner pour lancer \`fastlane beta\` sur tag push (chères en minutes Actions macOS)
- \`match\` setup pour code signing multi-machines (nécessite repo privé chiffré)
- Lane \`release\` vers testeurs externes (demande Beta App Review Apple)