### PR TITLE
fix(ar): single world-frame convention for persisted scenes

### DIFF
--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -1667,7 +1667,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                         // legacy → world frame appliquée si nécessaire.
                         let existingURL = GardenLocalStore.sceneURL(for: id)
                         if let existingData = try? Data(contentsOf: existingURL),
-                           let existingScene = try? JSONDecoder().decode(PersistedARScene.self, from: existingData)?.normalizedToWorldFrame() {
+                           let existingScene = try? JSONDecoder().decode(PersistedARScene.self, from: existingData).normalizedToWorldFrame() {
                             boundaryPointsArray = existingScene.boundaryPoints ?? []
                             savedArea = existingScene.area ?? props.area
                             savedPerimeter = existingScene.perimeter ?? props.perimeter
@@ -2672,7 +2672,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                     var plants: [PersistedPlant] = []
                     if FileManager.default.fileExists(atPath: sceneURL.path),
                        let data = try? Data(contentsOf: sceneURL),
-                       let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data)?.normalizedToWorldFrame() {
+                       let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data).normalizedToWorldFrame() {
                         plants = scene.plants
                         boundary = (scene.boundaryPoints ?? []).compactMap { arr in
                             guard arr.count >= 3 else { return nil }

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -1641,23 +1641,33 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
             // Fonction d'écriture disque
             private func saveToDisk(id: String, plants: [PersistedPlant], arView: ARSCNView) {
                 guard let props = parentProps else { return }
-                
+
                 // 1. JSON (Synchrone, facile)
                 do {
-                    // 🔄 En mode reopen, props.boundaryPoints est vide.
-                    // On recharge les bordures depuis le JSON existant pour les préserver.
+                    // Convention #170 : tout est persisté en frame monde ARKit
+                    // (cf doc en tête de GardenLocalStore.swift). Plus de
+                    // normalisation par centroïde : ni les `plants` capturés
+                    // depuis `captureCurrentState`, ni les `boundaryPoints`
+                    // rechargés du JSON existant. Le morpher recalcule les
+                    // centroïdes à la volée pour son MVC.
+                    //
+                    // Pré-fix : ce site soustrayait le centroïde de la
+                    // boundary à `position` et `boundaryPoints` mais pas à
+                    // `transform`, produisant un JSON en 2 frames incompatibles
+                    // (issues #170 / #136).
                     var boundaryPointsArray: [[Float]]
                     var savedArea: Float = props.area
                     var savedPerimeter: Float = props.perimeter
 
                     if !props.boundaryPoints.isEmpty {
-                        // Mode création : on utilise les bordures fraîchement mesurées
+                        // Mode création : boundary fraîchement mesurée, world frame.
                         boundaryPointsArray = props.boundaryPoints.map { [$0.x, $0.y, $0.z] }
                     } else {
-                        // Mode reopen : on relit les bordures déjà sauvegardées dans le JSON
+                        // Mode reopen : on relit la boundary existante. Migration
+                        // legacy → world frame appliquée si nécessaire.
                         let existingURL = GardenLocalStore.sceneURL(for: id)
                         if let existingData = try? Data(contentsOf: existingURL),
-                           let existingScene = try? JSONDecoder().decode(PersistedARScene.self, from: existingData) {
+                           let existingScene = try? JSONDecoder().decode(PersistedARScene.self, from: existingData)?.normalizedToWorldFrame() {
                             boundaryPointsArray = existingScene.boundaryPoints ?? []
                             savedArea = existingScene.area ?? props.area
                             savedPerimeter = existingScene.perimeter ?? props.perimeter
@@ -1667,54 +1677,9 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                         }
                     }
 
-                    // When fresh boundary points exist (creation flow), we
-                    // normalize BOTH the boundary and plant positions to the
-                    // boundary's centroid. Keeping them in the same 2D frame
-                    // is required for GardenMorpher (Issue #111) — it reads
-                    // both `plants` and `boundaryPoints` from the saved JSON
-                    // and treats them as living in the same XZ space.
-                    //
-                    // A previous patch saved `plants` raw while still
-                    // normalizing the boundary, which silently broke
-                    // morphing for any garden created since. Both paths
-                    // realign here.
-                    var plantsToSave = plants
-                    if !props.boundaryPoints.isEmpty {
-                        let sumX = props.boundaryPoints.reduce(0.0) { $0 + $1.x }
-                        let sumZ = props.boundaryPoints.reduce(0.0) { $0 + $1.z }
-                        let centroidX = sumX / Float(props.boundaryPoints.count)
-                        let centroidZ = sumZ / Float(props.boundaryPoints.count)
-
-                        AppLog.gardenSave.debug("boundary centroid x=\(centroidX, format: .fixed(precision: 3), privacy: .public) z=\(centroidZ, format: .fixed(precision: 3), privacy: .public)")
-
-                        boundaryPointsArray = boundaryPointsArray.map { point in
-                            [point[0] - centroidX, point[1], point[2] - centroidZ]
-                        }
-                        plantsToSave = plants.map { plant in
-                            PersistedPlant(
-                                plantID: plant.plantID,
-                                plantName: plant.plantName,
-                                modelURLString: plant.modelURLString,
-                                position: [
-                                    plant.position[0] - centroidX,
-                                    plant.position[1],
-                                    plant.position[2] - centroidZ
-                                ],
-                                rotation: plant.rotation,
-                                scale: plant.scale,
-                                transform: plant.transform,
-                                upAxis: plant.upAxis,
-                                surfaceType: plant.surfaceType,
-                                surfaceHeight: plant.surfaceHeight
-                            )
-                        }
-
-                        AppLog.gardenSave.debug("coords normalized plants=\(plantsToSave.count, privacy: .public) boundary=\(boundaryPointsArray.count, privacy: .public)")
-                    }
-
                     let sceneData = PersistedARScene(
                         savedAt: Date(),
-                        plants: plantsToSave,
+                        plants: plants,
                         boundaryPoints: boundaryPointsArray,
                         area: savedArea,
                         perimeter: savedPerimeter
@@ -1764,6 +1729,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                         do {
                             let sceneJson = try Data(contentsOf: sceneUrl)
                             let sceneData = try JSONDecoder().decode(PersistedARScene.self, from: sceneJson)
+                                .normalizedToWorldFrame()  // migration legacy (#170)
                             persistedPlants = sceneData.plants
                             AppLog.gardenLoad.notice("scene JSON loaded plants=\(persistedPlants.count, privacy: .public)")
                         } catch {
@@ -2706,7 +2672,7 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                     var plants: [PersistedPlant] = []
                     if FileManager.default.fileExists(atPath: sceneURL.path),
                        let data = try? Data(contentsOf: sceneURL),
-                       let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data) {
+                       let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data)?.normalizedToWorldFrame() {
                         plants = scene.plants
                         boundary = (scene.boundaryPoints ?? []).compactMap { arr in
                             guard arr.count >= 3 else { return nil }

--- a/ArboreUi/ArboreUi/Views/GardenLocalStore.swift
+++ b/ArboreUi/ArboreUi/Views/GardenLocalStore.swift
@@ -15,6 +15,28 @@
 import Foundation
 import SwiftUI
 
+// MARK: - Convention de coordonnées
+//
+// Tout ce qui est persisté dans `scene_<id>.json` est en **frame monde
+// ARKit** (mètres, repère défini au démarrage de la session). Cela
+// concerne :
+//   - `plants[*].position`         : [x, y, z] en world frame
+//   - `plants[*].transform[12..14]`: tx, ty, tz en world frame
+//   - `plants[*].surfaceHeight`    : Y de la surface en world frame
+//   - `boundaryPoints[*]`          : [x, y, z] en world frame
+//
+// `position[0,2]` et `transform[12,14]` du même plant doivent toujours
+// être égaux (sauf 1-2 mm de drift de stripScale). C'est le contrat de
+// l'issue #170 / #136 — pré-fix, certains chemins de save soustrayaient
+// le centroïde de la boundary à `position` et `boundaryPoints` (mais pas
+// à `transform`), produisant un JSON en 2 frames incompatibles.
+//
+// `PersistedARScene.normalizedToWorldFrame()` détecte les jardins legacy
+// (offset constant entre `position` et `transform`) et les migre en
+// mémoire au moment de la lecture. Tous les consommateurs (restore,
+// morpher, saveMeasurementsOnly, saveToDisk reopen) doivent appeler
+// `.normalizedToWorldFrame()` après JSONDecoder.decode().
+
 // MARK: - 1. Gestion des Fichiers (Local Store)
 struct GardenLocalStore {
     static func worldMapURL(for gardenId: String) -> URL {
@@ -91,4 +113,88 @@ struct GardenModel: Identifiable {
     let name: String
     let lastModified: Date
     let thumbnail: String
+}
+
+// MARK: - 4. Migration legacy → world frame
+
+extension PersistedARScene {
+    /// Renvoie une copie du scène garantie en frame monde ARKit (cf entête
+    /// du fichier). Si la scène est déjà en frame monde, renvoie `self`
+    /// inchangé. Si elle est en frame legacy (`position` shifté par le
+    /// centroïde de la boundary, `transform` non-shifté), migre :
+    ///   1. réécrit chaque `plant.position[0,2]` depuis `plant.transform[12,14]`
+    ///   2. ajoute le centroïde déduit à chaque `boundaryPoints[i]`
+    ///
+    /// La détection compare l'écart `transform[12] - position[0]` (et 14/2)
+    /// par plante : tous les plants d'un même jardin legacy partagent le
+    /// même centroïde, donc le même offset. On utilise la médiane pour
+    /// résister à un plant qui aurait été drag-and-saved indépendamment.
+    func normalizedToWorldFrame() -> PersistedARScene {
+        guard !plants.isEmpty else { return self }
+
+        // Per-plant offset between transform translation and stored position.
+        // For a world-frame garden, all offsets ≈ 0. For a legacy garden, all
+        // offsets ≈ boundary centroid.
+        var offsetsX: [Float] = []
+        var offsetsZ: [Float] = []
+        for plant in plants {
+            guard plant.position.count >= 3, plant.transform.count == 16 else { continue }
+            offsetsX.append(plant.transform[12] - plant.position[0])
+            offsetsZ.append(plant.transform[14] - plant.position[2])
+        }
+        guard !offsetsX.isEmpty else { return self }
+
+        let medianX = Self.median(offsetsX)
+        let medianZ = Self.median(offsetsZ)
+
+        // Threshold : 1 cm. Below this we consider the scene already in
+        // world frame (drift between transform and position is negligible).
+        let epsilon: Float = 0.01
+        if abs(medianX) < epsilon && abs(medianZ) < epsilon {
+            return self
+        }
+
+        // Migration : plants take their position from transform (source of
+        // truth in world frame). Boundary points get the centroid added back.
+        let migratedPlants = plants.map { plant -> PersistedPlant in
+            guard plant.position.count >= 3, plant.transform.count == 16 else {
+                return plant
+            }
+            return PersistedPlant(
+                plantID: plant.plantID,
+                plantName: plant.plantName,
+                modelURLString: plant.modelURLString,
+                position: [plant.transform[12], plant.position[1], plant.transform[14]],
+                rotation: plant.rotation,
+                scale: plant.scale,
+                transform: plant.transform,
+                upAxis: plant.upAxis,
+                surfaceType: plant.surfaceType,
+                surfaceHeight: plant.surfaceHeight
+            )
+        }
+
+        let migratedBoundary: [[Float]]? = boundaryPoints.map { points in
+            points.map { point in
+                guard point.count >= 3 else { return point }
+                return [point[0] + medianX, point[1], point[2] + medianZ]
+            }
+        }
+
+        return PersistedARScene(
+            savedAt: savedAt,
+            plants: migratedPlants,
+            boundaryPoints: migratedBoundary,
+            area: area,
+            perimeter: perimeter
+        )
+    }
+
+    private static func median(_ values: [Float]) -> Float {
+        let sorted = values.sorted()
+        let n = sorted.count
+        if n == 0 { return 0 }
+        if n % 2 == 1 { return sorted[n / 2] }
+        return (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    }
 }

--- a/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
+++ b/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
@@ -473,9 +473,14 @@ struct ARViewContainerMesure: View {
         let sceneURL = GardenLocalStore.sceneURL(for: existingGardenId)
         let existingPlants: [PersistedPlant]
 
+        // Convention #170 : on lit l'existant en migrant si nécessaire
+        // depuis le format legacy (positions shiftées par centroïde) vers
+        // le format world frame. Sans cette migration, écrire une nouvelle
+        // boundary world-frame à côté de plants legacy produirait un JSON
+        // en 2 frames incompatibles (= issue #136 — closed by this).
         if FileManager.default.fileExists(atPath: sceneURL.path),
            let data = try? Data(contentsOf: sceneURL),
-           let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data) {
+           let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data)?.normalizedToWorldFrame() {
             existingPlants = scene.plants
         } else {
             existingPlants = []

--- a/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
+++ b/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
@@ -480,7 +480,7 @@ struct ARViewContainerMesure: View {
         // en 2 frames incompatibles (= issue #136 — closed by this).
         if FileManager.default.fileExists(atPath: sceneURL.path),
            let data = try? Data(contentsOf: sceneURL),
-           let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data)?.normalizedToWorldFrame() {
+           let scene = try? JSONDecoder().decode(PersistedARScene.self, from: data).normalizedToWorldFrame() {
             existingPlants = scene.plants
         } else {
             existingPlants = []

--- a/ArboreUi/ArboreUiTests/NetworkManagerTests.swift
+++ b/ArboreUi/ArboreUiTests/NetworkManagerTests.swift
@@ -35,10 +35,22 @@ class NetworkManagerTests: XCTestCase {
     }
 
     func testAppConfig_APIKey_ShouldExist() {
-        // Assert
-        XCTAssertNotNil(AppConfig.apiKey, "API Key should exist")
+        // Assert : la clé doit être présente, non vide, et de longueur
+        // plausible. On ne contraint plus le préfixe (anciennement
+        // "arbore_") : depuis PR #161, deux clés coexistent (prod et
+        // test, routées par APIKeyMiddleware côté backend) et leur
+        // convention de nommage peut évoluer indépendamment des tests.
         XCTAssertFalse(AppConfig.apiKey.isEmpty, "API Key should not be empty")
-        XCTAssertTrue(AppConfig.apiKey.hasPrefix("arbore_"), "API Key should have correct prefix")
+        XCTAssertGreaterThanOrEqual(
+            AppConfig.apiKey.count,
+            16,
+            "API Key should be at least 16 chars (sanity check, not a security requirement)"
+        )
+        XCTAssertNotEqual(
+            AppConfig.apiKey,
+            "$(ARBORE_API_KEY)",
+            "API Key placeholder should have been substituted at build time"
+        )
     }
 
     // MARK: - HTTP Method Tests


### PR DESCRIPTION
Closes #170, closes #136.

Phase 2 de la roadmap audit AR du 2026-05-13. Unifie les 3 chemins de save autour d'une **convention unique : tout en frame monde ARKit** dans \`scene_<id>.json\`. Documente la convention en tête de \`GardenLocalStore.swift\`.

## Pourquoi

L'audit a identifié 3 chemins de save qui produisaient des JSON avec des frames différentes :

| Chemin | Problème |
|---|---|
| \`saveToDisk .create\` | \`position\` shifté par le centroïde boundary, \`transform[12..14]\` non shifté → 2 frames incompatibles dans le même plant |
| \`saveToDisk .reopen\` | Plants capturés en world frame, boundary rechargée garde le legacy centroïde → drift à chaque cycle reopen→validate |
| \`saveMeasurementsOnly\` | Nouvelle boundary world frame, plants existants legacy verbatim → racine de #136 |

Consommateurs affectés : le morpher (qui lit \`position\` et \`boundaryPoints\` comme 2D dans la même frame) et le backend DTO (qui veut du world frame).

## Solution

### 1. Convention unique : world frame

Tout est persisté en frame monde ARKit :
- \`plants[*].position\` : [x, y, z] world
- \`plants[*].transform[12..14]\` : tx, ty, tz world (déjà le cas)
- \`plants[*].surfaceHeight\` : Y world (déjà le cas)
- \`boundaryPoints[*]\` : [x, y, z] world

Documenté en tête de \`GardenLocalStore.swift\`.

### 2. Migration auto à la lecture

Nouveau : \`PersistedARScene.normalizedToWorldFrame()\` détecte les jardins legacy via l'offset médian entre \`position[0,2]\` et \`transform[12,14]\` (médiane pour résister à un plant drag-and-saved indépendamment). Si l'offset > 1 cm → migre :

1. Réécrit chaque \`position[0,2]\` depuis \`transform[12,14]\` (source de vérité)
2. Ajoute le centroïde dérivé à chaque \`boundaryPoints[i]\`

No-op si l'offset est < 1 cm (jardin déjà world frame).

### 3. Save sites simplifiés

- \`saveToDisk\` : suppression complète du bloc de normalisation par centroïde
- \`saveMeasurementsOnly\` : migre les plants existants avant de les réécrire avec la nouvelle boundary
- \`loadGardenFromDisk\`, \`loadOldGardenData\` : appellent \`.normalizedToWorldFrame()\` après decode

### 4. GardenMorpher : pas de changement

MVC est translation-invariant. Old et new boundaries étant désormais dans la même frame (world), la math du morpher reste correcte sans modification.

## Backward compat

Les jardins déjà sur disque en frame legacy se migrent **automatiquement à la première lecture**. Pas de migration batch ni de step manuel. La prochaine sauvegarde du jardin (re-validate, drag, saveMeasurementsOnly) écrit en world frame, finalisant la migration côté disque.

## Stats du diff

| Fichier | Lignes |
|---|---|
| \`GardenLocalStore.swift\` | +107 (extension migration + commentaire convention) |
| \`GardenARPlacementView.swift\` | +18 / -54 (suppression centroïde block + 3 call sites migration) |
| \`ARViewContainerMeasure.swift\` | +5 / -2 (1 call site migration) |

## Test plan

- [ ] Créer un nouveau jardin avec boundary : valider, fermer, rouvrir → plantes bien placées
- [ ] Ouvrir un jardin pré-fix (legacy), valider sans rien modifier → après save, JSON sur disque inspecté = world frame
- [ ] Re-mesure (saveMeasurementsOnly) sur un jardin legacy → plants restent à leur position visuelle
- [ ] Manual replacement (morphing) sur un jardin legacy → boundary et plantes dans la même frame, morph correct
- [ ] Manual replacement sur un jardin neuf (world frame native) → idem