### PR TITLE
fix(fastlane): skip_submission for internal-only beta (no Beta App Review)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,13 +75,19 @@ platform :ios do
       include_bitcode: false
     )
 
+    # Internal-only deploy : on ne soumet PAS pour Beta App Review et on
+    # ne passe pas de `groups` (qui pousserait fastlane à appeler
+    # post_beta_app_review_submission, qui exige une "Beta App Description"
+    # qu'on n'a pas renseignée pour Arbore — réservée à la distribution
+    # externe). Le groupe « Internal QA » avec « Enable automatic
+    # distribution » coché côté ASC récupère la build automatiquement
+    # une fois le processing terminé.
     upload_to_testflight(
       api_key_path: AUTH_KEY,
       ipa: "./fastlane/builds/Arbore.ipa",
       distribute_external: false,
-      groups: [INTERNAL_GROUP],
+      skip_submission: true,
       skip_waiting_for_build_processing: false,
-      notify_external_testers: false,
       changelog: "Build interne automatique (lane: beta)."
     )
 


### PR DESCRIPTION
Build 4 a bien été **uploadée + processée** sur TestFlight côté ASC (cf logs locaux 2026-05-13 20:08), mais l'étape distribution a planté avec :

> \`Beta App Description is missing. - Beta App Description is required to submit a build for external testing.\`

## Cause

Passer \`groups: [INTERNAL_GROUP]\` à \`upload_to_testflight\` pousse fastlane à appeler \`post_beta_app_review_submission\` (= soumettre pour review Apple). Cette API exige une "Beta App Description" qu'on n'a pas renseignée — et qu'**on n'a pas besoin** de renseigner pour la distribution **interne**.

## Fix

- \`skip_submission: true\` → pas de submission Beta App Review
- Retire \`groups:\` → la distribution au groupe "Internal QA" se fait **automatiquement côté ASC** grâce au flag "Enable automatic distribution" coché à la création du groupe
- Retire \`notify_external_testers\` → inutile en internal-only

## Effet immédiat

La build 4 est déjà visible côté TestFlight pour les testeurs ajoutés au groupe "Internal QA" — l'auto-distribution a fonctionné côté ASC dès la fin du processing Apple (20:08:03 dans les logs). L'erreur fastlane est cosmétique sur ce build : le binaire est bien là, les testeurs y ont accès. Cette PR évite juste que le lane sorte en exit code 1 sur le prochain run.

## Test plan

- [ ] Re-run \`bundle exec fastlane beta\` → la lane termine en exit 0
- [ ] Vérifier que la build apparaît bien dans TestFlight pour les testeurs du groupe Internal QA (devrait déjà être le cas grâce à l'auto-distribution ASC)