### PR TITLE
fix(ar): two-tier raycast for drag, tap-teleport, boundary trace

### DIFF
--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -1394,6 +1394,35 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
             /// Used to classify a plant as `floor` vs `elevated` independently
             /// of the session's Y=0 origin (which depends on where the user
             /// held the phone at session start, not on the actual floor).
+            /// Two-tier raycast that prefers a real detected plane
+            /// (.existingPlaneGeometry — surveyed surface, reliable) over
+            /// ARKit's feature-point guess (.estimatedPlane). When the
+            /// estimated fallback fires, we lock Y to detectedFloorY() because
+            /// the estimated Y can drift 10-30 cm in low-texture / low-light
+            /// areas (cf audit AR finding Y-4). XZ from the estimate is kept
+            /// since the user's intent is captured by the screen position.
+            ///
+            /// Returns nil if no surface at all is detected — callers should
+            /// refuse the action (drag, tap-teleport, boundary point) rather
+            /// than fall back to a stale value.
+            @MainActor
+            private func resolvedFloorRaycast(at point: CGPoint) -> simd_float3? {
+                guard let arView = arView else { return nil }
+
+                if let q = arView.raycastQuery(from: point, allowing: .existingPlaneGeometry, alignment: .horizontal),
+                   let r = arView.session.raycast(q).first {
+                    let c = r.worldTransform.columns.3
+                    return SIMD3<Float>(c.x, c.y, c.z)
+                }
+                if let q = arView.raycastQuery(from: point, allowing: .estimatedPlane, alignment: .horizontal),
+                   let r = arView.session.raycast(q).first,
+                   let floorY = detectedFloorY() {
+                    let c = r.worldTransform.columns.3
+                    return SIMD3<Float>(c.x, floorY, c.z)
+                }
+                return nil
+            }
+
             @MainActor
             private func detectedFloorY() -> Float? {
                 guard let frame = arView?.session.currentFrame else { return nil }
@@ -2085,11 +2114,19 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                         return
                     }
                     // No plant under the reticle — teleport the selected one
-                    // to the reticle's last surface raycast (lastReticleTransform).
-                    if let node = selectedNode, let transform = lastReticleTransform {
+                    // to a fresh surface raycast under the reticle. Going via
+                    // resolvedFloorRaycast (instead of reusing lastReticleTransform)
+                    // ensures the teleport-Y benefits from the floor-locked
+                    // fallback when the reticle was on a low-texture area
+                    // (cf audit AR finding Y-5 / issue #171).
+                    if let node = selectedNode,
+                       let p = resolvedFloorRaycast(at: center) {
                         saveStateForUndo()
-                        let p = transform.columns.3
-                        node.simdWorldPosition = simd_float3(p.x, p.y, p.z)
+                        node.simdWorldPosition = p
+                        // Pivot can become stale after teleport if the plant
+                        // was previously scaled and the new surface is at a
+                        // different height — recompute it.
+                        refreshPivotForScale(node: node)
                         recordDraggedTransform(for: node)
                         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                         deselectAll()
@@ -2139,11 +2176,12 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                 // Update the visual position only when the raycast hits a
                 // surface. If it misses (finger over a textureless or non-floor
                 // area), keep the last visual position — don't snap back.
+                // Uses resolvedFloorRaycast which prefers real planes and
+                // locks Y to detectedFloorY() when falling back to estimated
+                // (cf audit AR finding Y-4 / issue #171).
                 let location = gesture.location(in: arView)
-                if let query = arView.raycastQuery(from: location, allowing: .estimatedPlane, alignment: .horizontal),
-                   let result = arView.session.raycast(query).first {
-                    let p = result.worldTransform.columns.3
-                    node.simdWorldPosition = simd_float3(p.x, p.y, p.z)
+                if let p = resolvedFloorRaycast(at: location) {
+                    node.simdWorldPosition = p
                 }
 
                 // Persist final position on .ended regardless of last raycast.
@@ -2155,6 +2193,9 @@ fileprivate struct GardenARPlacementContainerView: UIViewRepresentable {
                 // halos (which used to disappear with the destroyed node).
                 if gesture.state == .ended || gesture.state == .cancelled {
                     recordDraggedTransform(for: node)
+                    // Re-apply pivot offset in case the plant has been scaled
+                    // and the new surface differs in height (Y-5 in audit).
+                    refreshPivotForScale(node: node)
                 }
             }
 

--- a/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
+++ b/ArboreUi/ArboreUi/measure app/ARViewContainerMeasure.swift
@@ -182,12 +182,27 @@ struct ARViewContainerGarden: UIViewRepresentable {
         @objc func handleTap(_ sender: UITapGestureRecognizer) {
             guard let arView = self.arView else { return }
             let location = sender.location(in: arView)
-            
-            // Raycast version SceneKit
-            guard let query = arView.raycastQuery(from: location, allowing: .estimatedPlane, alignment: .horizontal) else { return }
-            let results = arView.session.raycast(query)
-            
-            if let firstResult = results.first {
+
+            // Two-tier raycast (cf audit AR finding Y-10 / issue #171) :
+            // prefer .existingPlaneGeometry (real detected plane) over
+            // .estimatedPlane (ARKit's best-guess from feature points,
+            // ±10-30 cm en zone faible texture). Le Y de la boundary sert
+            // ensuite de référence dans GardenMorpher.morph(floorY:), donc
+            // une erreur de quelques cm propagée à tous les points de la
+            // boundary contamine durablement les futurs morphs.
+            let result: ARRaycastResult? = {
+                if let q = arView.raycastQuery(from: location, allowing: .existingPlaneGeometry, alignment: .horizontal),
+                   let r = arView.session.raycast(q).first {
+                    return r
+                }
+                if let q = arView.raycastQuery(from: location, allowing: .estimatedPlane, alignment: .horizontal),
+                   let r = arView.session.raycast(q).first {
+                    return r
+                }
+                return nil
+            }()
+
+            if let firstResult = result {
                 // 1. Création visuelle (Sphère verte) en SceneKit
                 let sphereGeometry = SCNSphere(radius: 0.05)
                 sphereGeometry.firstMaterial?.diffuse.contents = UIColor.green


### PR DESCRIPTION
Closes #171.

Phase 3 de la roadmap audit AR du 2026-05-13. Adresse les findings **Y-4, Y-5, Y-10** : les 4 sites où l'utilisateur place ou déplace une plante utilisaient uniquement \`.estimatedPlane\`, qui peut être à **±10-30 cm du vrai sol** en zone faible texture / faible lumière → plantes sous le sol ou flottantes persistées en dur.

## Convention adoptée

Helper \`resolvedFloorRaycast(at:)\` dans \`GardenARPlacementView\` :

1. Essaie \`.existingPlaneGeometry\` d'abord (plane réellement détectée par ARKit — fiable au cm près)
2. Fallback sur \`.estimatedPlane\` **mais verrouille Y sur \`detectedFloorY()\`** pour éviter qu'une estimation foireuse propage l'erreur dans \`pendingDragTransform\` / \`scene_<id>.json\`
3. Renvoie \`nil\` si aucune surface n'est détectée — caller refuse l'action plutôt que se rabattre sur une valeur stale

## Sites modifiés

| Site | Avant | Après |
|---|---|---|
| \`handlePan\` (drag) | \`.estimatedPlane\` only | Helper + \`refreshPivotForScale\` à drag-end |
| \`handleTapToPlace\` (.adjusting) | \`lastReticleTransform\` (qui peut venir d'un \`.estimatedPlane\` stale) | Raycast frais via helper + \`refreshPivotForScale\` |
| \`ARViewContainerMeasure.handleTap\` (boundary trace) | \`.estimatedPlane\` only | Pattern à deux niveaux (sans Y-locking — la boundary EST la référence du sol) |

## Pourquoi pas le helper aussi pour la boundary trace

Le helper utilise \`detectedFloorY()\` qui suppose qu'au moins une plane est déjà détectée. Au moment du tracé de boundary (début de création de jardin), on est en train de DÉFINIR le sol — pas de référence pré-existante. On accepte donc le fallback estimé sans Y-locking, en comptant sur le feedback visuel du réticule pour que l'user re-tape proprement si la qualité de tracking est mauvaise.

## Validation locale

\`** BUILD SUCCEEDED **\` côté xcodebuild simulator.

## Test plan

- [ ] Dans une pièce avec textures variées : drag une plante vers un mur uni → la plante reste à la bonne Y (le helper refuse le raycast si pas de plane sous le doigt) au lieu de descendre/monter
- [ ] Tap-teleport en .adjusting depuis le sol vers une table → snap-to-plane correct (\`.existingPlaneGeometry\` sur la table)
- [ ] Tracé de boundary alternant zones texturées et lisses → tous les points à la même Y au cm près
- [ ] Aucune régression sur les flows .create / .reopen