### PR TITLE
fix(ar): MVC math hardening + unit tests

### DIFF
--- a/ArboreUi/ArboreUi/ARGarden/ManualReplacement/GardenMorpher.swift
+++ b/ArboreUi/ArboreUi/ARGarden/ManualReplacement/GardenMorpher.swift
@@ -37,11 +37,24 @@ enum GardenMorpher {
         guard !oldPlants.isEmpty else { return MorphResult(morphedPlants: []) }
 
         let oldPolygon2D = oldBoundary.map { SIMD2<Float>($0.x, $0.z) }
-        let newPolygon2D = newBoundary.map { SIMD2<Float>($0.x, $0.z) }
+        var newPolygon2D = newBoundary.map { SIMD2<Float>($0.x, $0.z) }
+        var newBoundary3D = newBoundary
 
         // Sanity check: same vertex count required for MVC re-application.
         guard oldPolygon2D.count == newPolygon2D.count, oldPolygon2D.count >= 3 else {
             return fallbackToCenter(plants: oldPlants, newBoundary: newBoundary, floorY: floorY)
+        }
+
+        // Winding normalization (cf audit AR F-4) : si l'utilisateur a tracé
+        // la nouvelle boundary en sens opposé de l'ancienne (CW vs CCW), les
+        // index polygon[i] ne correspondent plus aux mêmes coins logiques, et
+        // MVC.apply produit une position miroir. On retourne la nouvelle
+        // boundary pour rétablir la correspondance index-à-index.
+        let oldSignedArea = MeanValueCoordinates.signedArea(oldPolygon2D)
+        let newSignedArea = MeanValueCoordinates.signedArea(newPolygon2D)
+        if oldSignedArea * newSignedArea < 0 {
+            newPolygon2D.reverse()
+            newBoundary3D.reverse()
         }
 
         let oldCentroid2D = centroid(of: oldPolygon2D)
@@ -53,7 +66,7 @@ enum GardenMorpher {
         // saved at oldFloorY + 0.6 ends up at newFloorY + 0.6, regardless of
         // session-Y origin differences.
         let oldFloorY = oldBoundary.reduce(Float(0)) { $0 + $1.y } / Float(oldBoundary.count)
-        let newFloorY = floorY ?? (newBoundary.reduce(Float(0)) { $0 + $1.y } / Float(newBoundary.count))
+        let newFloorY = floorY ?? (newBoundary3D.reduce(Float(0)) { $0 + $1.y } / Float(newBoundary3D.count))
         let floorDelta = newFloorY - oldFloorY
 
         let morphed: [MorphedPlant] = oldPlants.map { plant in

--- a/ArboreUi/ArboreUi/ARGarden/ManualReplacement/MeanValueCoordinates.swift
+++ b/ArboreUi/ArboreUi/ARGarden/ManualReplacement/MeanValueCoordinates.swift
@@ -10,8 +10,10 @@ enum MeanValueCoordinates {
     /// The returned weights sum to 1 and can be used to express the point as a
     /// weighted combination of polygon vertices.
     ///
-    /// Special case: if the point lies exactly on a vertex, that vertex gets weight 1.
-    /// If it lies on an edge, the two endpoints share the weight linearly.
+    /// Special cases (all return early with stable values) :
+    ///   - point ≈ vertex          → that vertex gets weight 1 (canonical basis)
+    ///   - point on edge interior  → linear blend between the two endpoints
+    ///   - degenerate polygon      → uniform weights (apply() returns the centroid)
     static func weights(point p: SIMD2<Float>, polygon: [SIMD2<Float>]) -> [Float] {
         let n = polygon.count
         guard n >= 3 else { return Array(repeating: 1.0 / Float(max(n, 1)), count: n) }
@@ -34,26 +36,27 @@ enum MeanValueCoordinates {
             unit[i] = d / len
         }
 
-        // tan(theta_i / 2) = (1 - cos(theta_i)) / sin(theta_i)
-        // where theta_i is the angle between (vertex_i, vertex_{i+1}) seen from p.
+        // Half-angle tangent of each angle (vertex_i, p, vertex_{i+1}) computed
+        // via atan2(sin, cos) → tan(theta/2). atan2 is numerically stable across
+        // all four quadrants, including near 0 and near ±π, which avoids the
+        // (1 - cos)/sin divergence when |sin| is small (cf audit AR F-3).
         var halfTan = [Float](repeating: 0, count: n)
         for i in 0..<n {
             let next = (i + 1) % n
-            let dot = simd_clamp(simd_dot(unit[i], unit[next]), -1.0, 1.0)
-            // Cross product (2D) for sign of sin.
-            let cross = unit[i].x * unit[next].y - unit[i].y * unit[next].x
-            let sin = cross
-            let cos = dot
-            // Edge case: point on edge between i and next (theta ~ pi).
+            let cos = simd_clamp(simd_dot(unit[i], unit[next]), -1.0, 1.0)
+            // 2D cross product (signed magnitude in the implicit Z axis).
+            let sin = unit[i].x * unit[next].y - unit[i].y * unit[next].x
+            // Edge case: point on edge between i and next (theta ≈ ±π) →
+            // return a linear blend along the edge. Done explicitly because
+            // atan2 + tan(π/2) is undefined (infinity).
             if abs(sin) < 1e-6 && cos < 0 {
-                // Linear blend along the edge — assign and return.
                 let t = dists[next] / (dists[i] + dists[next])
                 weights[i] = t
                 weights[next] = 1 - t
                 return weights
             }
-            // tan(half-angle) via stable formula.
-            halfTan[i] = (1 - cos) / sin
+            let theta = atan2(sin, cos)
+            halfTan[i] = tan(theta / 2)
         }
 
         var totalWeight: Float = 0
@@ -64,11 +67,18 @@ enum MeanValueCoordinates {
             totalWeight += w
         }
 
+        // Degenerate fallback (cf audit AR F-5) : if the total weight is zero
+        // or non-finite (collinear polygon, NaN propagation from a corner
+        // case), return uniform weights so that `apply()` produces the new
+        // polygon's centroid instead of (0, 0). Avoids silently teleporting
+        // every plant to the session origin.
+        guard totalWeight.isFinite, abs(totalWeight) > 1e-6 else {
+            return Array(repeating: 1.0 / Float(n), count: n)
+        }
+
         // Normalize.
-        if totalWeight != 0 {
-            for i in 0..<n {
-                weights[i] /= totalWeight
-            }
+        for i in 0..<n {
+            weights[i] /= totalWeight
         }
 
         return weights
@@ -85,5 +95,18 @@ enum MeanValueCoordinates {
             result += weights[i] * polygon[i]
         }
         return result
+    }
+
+    /// Signed Shoelace area. Positive = counter-clockwise winding,
+    /// negative = clockwise. Used by callers to normalize old/new polygon
+    /// winding before computing weights (cf audit AR F-4).
+    static func signedArea(_ polygon: [SIMD2<Float>]) -> Float {
+        guard polygon.count >= 3 else { return 0 }
+        var sum: Float = 0
+        for i in 0..<polygon.count {
+            let j = (i + 1) % polygon.count
+            sum += polygon[i].x * polygon[j].y - polygon[j].x * polygon[i].y
+        }
+        return sum / 2
     }
 }

--- a/ArboreUi/ArboreUiTests/DistortionAnalyzerTests.swift
+++ b/ArboreUi/ArboreUiTests/DistortionAnalyzerTests.swift
@@ -1,0 +1,136 @@
+//
+//  DistortionAnalyzerTests.swift
+//  ArboreUiTests
+//
+//  Couvre le scoring de distorsion utilisé pour signaler à l'utilisateur
+//  quelles plantes risquent de se retrouver à une mauvaise position après
+//  morphing (issue #173).
+//
+
+import XCTest
+import simd
+@testable import ArboreUi
+
+final class DistortionAnalyzerTests: XCTestCase {
+
+    private let unitSquare: [SIMD2<Float>] = [
+        SIMD2(-1, -1),
+        SIMD2( 1, -1),
+        SIMD2( 1,  1),
+        SIMD2(-1,  1),
+    ]
+
+    private let eps: Float = 1e-4
+
+    // MARK: - Identity
+
+    func test_score_identicalBoundaries_returnsOne() {
+        let p = SIMD2<Float>(0.3, 0.4)
+        let score = DistortionAnalyzer.score(
+            oldPosition: p,
+            newPosition: p,
+            oldBoundary: unitSquare,
+            newBoundary: unitSquare
+        )
+        XCTAssertEqual(score, 1.0, accuracy: eps)
+    }
+
+    // MARK: - Scale equivariance
+
+    func test_score_uniformScaling_preserved() {
+        let p = SIMD2<Float>(0.3, 0.4)
+        let scaledSquare = unitSquare.map { $0 * 3 }
+        let scaledP = p * 3
+
+        let score = DistortionAnalyzer.score(
+            oldPosition: p,
+            newPosition: scaledP,
+            oldBoundary: unitSquare,
+            newBoundary: scaledSquare
+        )
+        // Le scoring est scale-invariant car newAvg = 3 * oldAvg, ratio = 3.
+        // max(3, 1/3) = 3 → la distorsion s'exprime bien comme un facteur.
+        XCTAssertEqual(score, 3.0, accuracy: eps)
+    }
+
+    // MARK: - Severity buckets
+
+    func test_severity_thresholds() {
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 1.0),  .ok)
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 1.19), .ok)
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 1.2),  .moderate)
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 1.7),  .moderate)
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 1.8),  .severe)
+        XCTAssertEqual(DistortionAnalyzer.severity(for: 5.0),  .severe)
+    }
+
+    // MARK: - Compression vs expansion symmetry
+
+    func test_score_compressionAndExpansion_returnSameScore() {
+        let p = SIMD2<Float>(0.5, 0)
+        let big = unitSquare.map { $0 * 2 }
+        let small = unitSquare.map { $0 * 0.5 }
+
+        // Both: boundary 2× then 0.5×. Position keeps the same relative.
+        let scoreUp = DistortionAnalyzer.score(
+            oldPosition: p,
+            newPosition: p * 2,
+            oldBoundary: unitSquare,
+            newBoundary: big
+        )
+        let scoreDown = DistortionAnalyzer.score(
+            oldPosition: p,
+            newPosition: p * 0.5,
+            oldBoundary: unitSquare,
+            newBoundary: small
+        )
+        // Le ratio est différent (2× vs 0.5×) mais le symmetric max(r, 1/r)
+        // renvoie 2.0 dans les deux cas.
+        XCTAssertEqual(scoreUp, scoreDown, accuracy: eps)
+        XCTAssertEqual(scoreUp, 2.0, accuracy: eps)
+    }
+
+    // MARK: - cardinalZone
+
+    func test_cardinalZone_centre() {
+        let zone = DistortionAnalyzer.cardinalZone(
+            of: SIMD2<Float>(0.05, 0.05),
+            centroid: SIMD2<Float>(0, 0)
+        )
+        XCTAssertEqual(zone, "CENTRE")
+    }
+
+    func test_cardinalZone_northEast() {
+        let zone = DistortionAnalyzer.cardinalZone(
+            of: SIMD2<Float>(0.5, -0.5),
+            centroid: SIMD2<Float>(0, 0)
+        )
+        XCTAssertEqual(zone, "NORD-EST")
+    }
+
+    func test_cardinalZone_pureSouth() {
+        let zone = DistortionAnalyzer.cardinalZone(
+            of: SIMD2<Float>(0.05, 0.5),  // x dans la zone CENTRE, z au sud
+            centroid: SIMD2<Float>(0, 0)
+        )
+        XCTAssertEqual(zone, "SUD")
+    }
+
+    // MARK: - Defensive cases
+
+    func test_score_mismatchedBoundaryCount_returnsOne() {
+        let p = SIMD2<Float>(0, 0)
+        let asymmetric: [SIMD2<Float>] = [
+            SIMD2(-1, -1),
+            SIMD2( 1, -1),
+            SIMD2( 0,  1),
+        ]
+        let score = DistortionAnalyzer.score(
+            oldPosition: p,
+            newPosition: p,
+            oldBoundary: unitSquare,
+            newBoundary: asymmetric
+        )
+        XCTAssertEqual(score, 1.0, "mismatched boundaries should not crash, must return 1")
+    }
+}

--- a/ArboreUi/ArboreUiTests/GardenMorpherTests.swift
+++ b/ArboreUi/ArboreUiTests/GardenMorpherTests.swift
@@ -1,0 +1,244 @@
+//
+//  GardenMorpherTests.swift
+//  ArboreUiTests
+//
+//  Couvre l'orchestration math du moteur de morphing (issue #173).
+//  Math pure — n'instancie aucun nœud SceneKit, ne dépend pas d'ARKit.
+//
+
+import XCTest
+import simd
+@testable import ArboreUi
+
+final class GardenMorpherTests: XCTestCase {
+
+    private let eps: Float = 1e-3
+
+    // MARK: - Helpers
+
+    private func makePlant(x: Float, y: Float, z: Float) -> PersistedPlant {
+        // Transform et position pointent vers le même point monde (convention
+        // world-frame de l'issue #170). rotation/scale: identité.
+        let identityScale: [Float] = [1, 1, 1]
+        let identityRot:   [Float] = [0, 0, 0]
+        let transform: [Float] = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            x, y, z, 1,
+        ]
+        return PersistedPlant(
+            plantID: "plant-\(x)-\(z)",
+            plantName: "Test Plant",
+            modelURLString: "test.usdz",
+            position: [x, y, z],
+            rotation: identityRot,
+            scale: identityScale,
+            transform: transform,
+            upAxis: nil,
+            surfaceType: "floor",
+            surfaceHeight: y
+        )
+    }
+
+    private func square(scale: Float = 1, center: SIMD3<Float> = .zero, y: Float = 0) -> [SIMD3<Float>] {
+        return [
+            center + SIMD3(-scale, y, -scale),
+            center + SIMD3( scale, y, -scale),
+            center + SIMD3( scale, y,  scale),
+            center + SIMD3(-scale, y,  scale),
+        ]
+    }
+
+    private func translation(of result: MorphedPlant) -> SIMD3<Float> {
+        // Column 3 du transform = (tx, ty, tz, 1).
+        return SIMD3(
+            result.newTransform.columns.3.x,
+            result.newTransform.columns.3.y,
+            result.newTransform.columns.3.z
+        )
+    }
+
+    // MARK: - Identity
+
+    func test_morph_squareToSquare_positionsUnchanged() {
+        let plants = [
+            makePlant(x: 0.3, y: 0, z: -0.2),
+            makePlant(x: -0.5, y: 0, z: 0.4),
+        ]
+        let boundary = square()
+        let result = GardenMorpher.morph(
+            oldPlants: plants,
+            oldBoundary: boundary,
+            newBoundary: boundary
+        )
+        XCTAssertEqual(result.morphedPlants.count, 2)
+        for (mp, original) in zip(result.morphedPlants, plants) {
+            let t = translation(of: mp)
+            XCTAssertEqual(t.x, original.position[0], accuracy: eps)
+            XCTAssertEqual(t.z, original.position[2], accuracy: eps)
+        }
+    }
+
+    // MARK: - Scale-up
+
+    func test_morph_squareToBiggerSquare_positionsScale() {
+        let plant = makePlant(x: 0.4, y: 0, z: -0.3)
+        let old = square(scale: 1)
+        let new = square(scale: 3)  // × 3 around origin
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: old,
+            newBoundary: new
+        )
+        let t = translation(of: result.morphedPlants[0])
+        XCTAssertEqual(t.x, plant.position[0] * 3, accuracy: eps)
+        XCTAssertEqual(t.z, plant.position[2] * 3, accuracy: eps)
+    }
+
+    // MARK: - Translation only
+
+    func test_morph_squareToTranslatedSquare_positionsTranslated() {
+        let plant = makePlant(x: 0.2, y: 0, z: 0.1)
+        let old = square()
+        let offset = SIMD3<Float>(5, 0, -2)
+        let new = square().map { $0 + offset }
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: old,
+            newBoundary: new
+        )
+        let t = translation(of: result.morphedPlants[0])
+        XCTAssertEqual(t.x, plant.position[0] + offset.x, accuracy: eps)
+        XCTAssertEqual(t.z, plant.position[2] + offset.z, accuracy: eps)
+    }
+
+    // MARK: - Floor delta (Y handling)
+
+    func test_morph_newBoundaryHigherFloor_plantsLiftedByDelta() {
+        let plant = makePlant(x: 0, y: 0, z: 0)
+        let old = square(y: 0)
+        let new = square(y: 0.5)  // floor moved up 50 cm
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: old,
+            newBoundary: new
+        )
+        let t = translation(of: result.morphedPlants[0])
+        XCTAssertEqual(t.y, 0.5, accuracy: eps)
+    }
+
+    func test_morph_floorYParameterOverridesAverage() {
+        let plant = makePlant(x: 0, y: 0, z: 0)
+        let old = square(y: 0)
+        let new = square(y: 0.5)
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: old,
+            newBoundary: new,
+            floorY: 0.2
+        )
+        let t = translation(of: result.morphedPlants[0])
+        // floorDelta = 0.2 - 0 = 0.2 → newY = oldY + 0.2 = 0.2
+        XCTAssertEqual(t.y, 0.2, accuracy: eps)
+    }
+
+    // MARK: - Winding sign normalization (F-4)
+
+    func test_morph_oppositeWinding_pointsStayInPlace() {
+        let plant = makePlant(x: 0.5, y: 0, z: 0)
+        let oldCCW = square()
+        let newCW = Array(oldCCW.reversed())  // exact same shape, reverse order
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: oldCCW,
+            newBoundary: newCW
+        )
+        let t = translation(of: result.morphedPlants[0])
+        // Le shape est identique en géométrie, seul le winding change. Après
+        // normalisation, la plante doit retomber sur sa position d'origine.
+        XCTAssertEqual(t.x, plant.position[0], accuracy: eps)
+        XCTAssertEqual(t.z, plant.position[2], accuracy: eps)
+    }
+
+    // MARK: - Out-of-polygon snap
+
+    func test_morph_outsideOfNewPolygon_snappedToBoundary() {
+        // Old polygon contains a point near edge ; new polygon is shrunk such
+        // that the morphed point falls outside. The morpher must snap to the
+        // closest edge instead of placing the plant in a void.
+        let plant = makePlant(x: 0.9, y: 0, z: 0)
+        let oldBig = square(scale: 1)
+        let newSmall = square(scale: 0.3)  // shrunk → 0.9 maps outside
+
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: oldBig,
+            newBoundary: newSmall
+        )
+        let t = translation(of: result.morphedPlants[0])
+        // Le point doit être sur ou à l'intérieur du nouveau carré (±eps).
+        let inside = abs(t.x) <= 0.3 + eps && abs(t.z) <= 0.3 + eps
+        XCTAssertTrue(inside, "morphed point must be inside the new polygon, got (\(t.x), \(t.z))")
+    }
+
+    // MARK: - Fallback path (mismatched vertex counts)
+
+    func test_morph_mismatchedVertexCount_fallbackProducesResult() {
+        let plant = makePlant(x: 0.2, y: 0, z: 0.2)
+        let oldSquare = square()
+        let newTriangle: [SIMD3<Float>] = [
+            SIMD3(-1, 0, -1),
+            SIMD3( 1, 0, -1),
+            SIMD3( 0, 0,  1),
+        ]
+        let result = GardenMorpher.morph(
+            oldPlants: [plant],
+            oldBoundary: oldSquare,
+            newBoundary: newTriangle
+        )
+        // Fallback : la plante doit avoir un placement (pas vide) et un warning.
+        XCTAssertEqual(result.morphedPlants.count, 1)
+        XCTAssertNotNil(result.morphedPlants[0].warning)
+        XCTAssertEqual(result.morphedPlants[0].warning?.severity, .severe)
+    }
+
+    // MARK: - Empty inputs
+
+    func test_morph_noPlants_returnsEmpty() {
+        let result = GardenMorpher.morph(
+            oldPlants: [],
+            oldBoundary: square(),
+            newBoundary: square()
+        )
+        XCTAssertTrue(result.morphedPlants.isEmpty)
+        XCTAssertTrue(result.warnings.isEmpty)
+    }
+
+    // MARK: - Performance smoke
+
+    func test_morph_141plants_under1000ms() {
+        // Sanity perf : 141 plantes (taille max plausible d'un gros jardin)
+        // morphées sous le seuil de 1 seconde sur Mac (10× la cible iPhone).
+        // Empêche une régression algo type O(n²) qui rendrait l'opération
+        // visiblement lente à l'écran.
+        var plants: [PersistedPlant] = []
+        plants.reserveCapacity(141)
+        for i in 0..<141 {
+            let angle = Float(i) / 141 * 2 * .pi
+            plants.append(makePlant(x: 0.5 * cos(angle), y: 0, z: 0.5 * sin(angle)))
+        }
+        measure {
+            _ = GardenMorpher.morph(
+                oldPlants: plants,
+                oldBoundary: square(),
+                newBoundary: square(scale: 2)
+            )
+        }
+    }
+}

--- a/ArboreUi/ArboreUiTests/MeanValueCoordinatesTests.swift
+++ b/ArboreUi/ArboreUiTests/MeanValueCoordinatesTests.swift
@@ -1,0 +1,165 @@
+//
+//  MeanValueCoordinatesTests.swift
+//  ArboreUiTests
+//
+//  Couvre la math MVC qui sert au morphing de jardin (issue #173).
+//
+
+import XCTest
+import simd
+@testable import ArboreUi
+
+final class MeanValueCoordinatesTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Carré unité CCW (counter-clockwise) centré sur l'origine.
+    private let unitSquareCCW: [SIMD2<Float>] = [
+        SIMD2(-1, -1),  // bottom-left
+        SIMD2( 1, -1),  // bottom-right
+        SIMD2( 1,  1),  // top-right
+        SIMD2(-1,  1),  // top-left
+    ]
+
+    /// Tolérance pour les comparaisons float — large car les calculs MVC
+    /// passent par atan2/tan/division et accumulent du bruit numérique.
+    private let eps: Float = 1e-4
+
+    // MARK: - Sum-to-one invariant
+
+    func test_weights_pointInside_normalizedToOne() {
+        let p = SIMD2<Float>(0.2, 0.3)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        let sum = weights.reduce(0, +)
+        XCTAssertEqual(sum, 1.0, accuracy: eps, "MVC weights must sum to 1")
+        XCTAssertEqual(weights.count, unitSquareCCW.count)
+    }
+
+    func test_weights_pointAtCenter_uniformWeights() {
+        let p = SIMD2<Float>(0, 0)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        // Centre du carré → poids égaux 0.25 chacun.
+        for w in weights {
+            XCTAssertEqual(w, 0.25, accuracy: eps)
+        }
+    }
+
+    // MARK: - Vertex / edge clamps
+
+    func test_weights_pointAtVertex_oneHot() {
+        let p = unitSquareCCW[2]  // top-right
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        // weight[2] must be 1, others 0.
+        XCTAssertEqual(weights[0], 0, accuracy: eps)
+        XCTAssertEqual(weights[1], 0, accuracy: eps)
+        XCTAssertEqual(weights[2], 1, accuracy: eps)
+        XCTAssertEqual(weights[3], 0, accuracy: eps)
+    }
+
+    func test_weights_pointOnEdgeMidpoint_linearBlend() {
+        // Mid-point of bottom edge (between vertices 0 and 1) → 0.5/0.5.
+        let p = SIMD2<Float>(0, -1)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        XCTAssertEqual(weights[0], 0.5, accuracy: eps)
+        XCTAssertEqual(weights[1], 0.5, accuracy: eps)
+        XCTAssertEqual(weights[2], 0, accuracy: eps)
+        XCTAssertEqual(weights[3], 0, accuracy: eps)
+    }
+
+    func test_weights_pointOnEdgeOffCenter_proportionalBlend() {
+        // 1/4 from vertex 0, 3/4 from vertex 1.
+        let p = SIMD2<Float>(-0.5, -1)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        XCTAssertEqual(weights[0], 0.75, accuracy: eps)
+        XCTAssertEqual(weights[1], 0.25, accuracy: eps)
+    }
+
+    // MARK: - Numerical stability near a vertex (F-3)
+
+    func test_weights_pointNearVertex_stableFinite() {
+        // Very close to a vertex but NOT exactly on it — exercise the
+        // formerly-buggy code path where (1 - cos)/sin diverges. After the
+        // atan2-based fix all weights remain finite and sum to 1.
+        let p = unitSquareCCW[0] + SIMD2<Float>(1e-4, 1e-4)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        for w in weights {
+            XCTAssertTrue(w.isFinite, "weight should be finite near a vertex")
+        }
+        let sum = weights.reduce(0, +)
+        XCTAssertEqual(sum, 1.0, accuracy: eps)
+    }
+
+    // MARK: - Degenerate polygon fallback (F-5)
+
+    func test_weights_collinearPolygon_uniformFallback() {
+        // All vertices on the same line → totalWeight degenerates. The fix
+        // returns uniform weights (1/n each) so apply() produces the
+        // centroid, instead of an all-zeros vector that maps to (0, 0).
+        let collinear: [SIMD2<Float>] = [
+            SIMD2(0, 0),
+            SIMD2(1, 0),
+            SIMD2(2, 0),
+            SIMD2(3, 0),
+        ]
+        let p = SIMD2<Float>(1.5, 1)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: collinear)
+        let sum = weights.reduce(0, +)
+        XCTAssertEqual(sum, 1.0, accuracy: eps, "fallback must still sum to 1")
+        for w in weights {
+            XCTAssertTrue(w.isFinite)
+            XCTAssertGreaterThanOrEqual(w, 0)
+        }
+    }
+
+    // MARK: - apply()
+
+    func test_apply_identicalPolygon_returnsOriginalPoint() {
+        let p = SIMD2<Float>(0.3, 0.7)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+        let recovered = MeanValueCoordinates.apply(weights: weights, to: unitSquareCCW)
+        XCTAssertEqual(recovered.x, p.x, accuracy: eps)
+        XCTAssertEqual(recovered.y, p.y, accuracy: eps)
+    }
+
+    func test_apply_scaledPolygon_scaledPoint() {
+        let p = SIMD2<Float>(0.3, 0.5)
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+
+        let scaledSquare = unitSquareCCW.map { $0 * 2 }
+        let morphed = MeanValueCoordinates.apply(weights: weights, to: scaledSquare)
+
+        XCTAssertEqual(morphed.x, p.x * 2, accuracy: eps)
+        XCTAssertEqual(morphed.y, p.y * 2, accuracy: eps)
+    }
+
+    func test_apply_translatedPolygon_translatedPoint() {
+        let p = SIMD2<Float>(0.0, 0.0)  // centre
+        let weights = MeanValueCoordinates.weights(point: p, polygon: unitSquareCCW)
+
+        let translatedSquare = unitSquareCCW.map { $0 + SIMD2<Float>(10, -5) }
+        let morphed = MeanValueCoordinates.apply(weights: weights, to: translatedSquare)
+
+        XCTAssertEqual(morphed.x, 10, accuracy: eps)
+        XCTAssertEqual(morphed.y, -5, accuracy: eps)
+    }
+
+    // MARK: - Signed area (F-4 building block)
+
+    func test_signedArea_ccwSquare_positive() {
+        let area = MeanValueCoordinates.signedArea(unitSquareCCW)
+        XCTAssertGreaterThan(area, 0, "CCW polygon must have positive signed area")
+        XCTAssertEqual(area, 4, accuracy: eps, "unit square (-1..1)² has area 4")
+    }
+
+    func test_signedArea_cwSquare_negative() {
+        let cw = Array(unitSquareCCW.reversed())
+        let area = MeanValueCoordinates.signedArea(cw)
+        XCTAssertLessThan(area, 0, "CW polygon must have negative signed area")
+        XCTAssertEqual(abs(area), 4, accuracy: eps)
+    }
+
+    func test_signedArea_degeneratePolygon_zero() {
+        let collinear: [SIMD2<Float>] = [SIMD2(0, 0), SIMD2(1, 0), SIMD2(2, 0)]
+        XCTAssertEqual(MeanValueCoordinates.signedArea(collinear), 0, accuracy: eps)
+    }
+}


### PR DESCRIPTION
Closes #172, closes #173.

Phases 4 + 5 de la roadmap audit AR. Bundled en une PR car les tests valident directement les fixes.

## Phase 4 — Math hardening

### F-3 : half-angle tangent via \`atan2(sin, cos) → tan(theta/2)\`

L'ancienne formule \`(1 - cos) / sin\` divergeait pour \`|sin| → 0\` avec \`cos > 0\` (point proche d'un sommet sans coïncidence exacte). \`atan2\` est numériquement stable sur les quatre quadrants — la garde explicite ne sert plus que pour le cas point-sur-arête (\`theta ≈ ±π\` où \`tan(π/2) = ∞\`).

### F-4 : winding sign normalization avant \`apply\`

Le morpher appliquait \`MeanValueCoordinates.apply(weights:to:)\` directement sur la nouvelle boundary. Si l'user a tracé old en CCW et new en CW (ou inverse), les index \`polygon[i]\` ne correspondent plus aux mêmes coins logiques → résultat miroir.

Fix dans \`GardenMorpher.morph\` :
\`\`\`swift
let oldSignedArea = MeanValueCoordinates.signedArea(oldPolygon2D)
let newSignedArea = MeanValueCoordinates.signedArea(newPolygon2D)
if oldSignedArea * newSignedArea < 0 {
    newPolygon2D.reverse()
    newBoundary3D.reverse()
}
\`\`\`

Le \`newBoundary3D\` suit pour que \`floorDelta\` (qui moyenne les Y de la new boundary) reste cohérent.

### F-5 : degenerate polygon fallback

Si \`totalWeight == 0\` ou NaN (polygone collinéaire), la fonction retournait un array de zéros → \`apply\` produisait \`(0, 0)\` → toutes les plantes téléportées à l'origine de session, sans warning. Désormais : \`guard isFinite && |total| > 1e-6\`, sinon fallback à des poids uniformes (\`apply\` renvoie le centroïde — plausible et explicite).

## Phase 5 — Unit tests

3 fichiers dans \`ArboreUiTests/\`, auto-ajoutés au target via Xcode 16 \`PBXFileSystemSynchronizedRootGroup\`. \`build-for-testing\` local : ✅.

| Fichier | Couvre | Nb cas |
|---|---|---|
| \`MeanValueCoordinatesTests.swift\` | sum-to-one, vertex/edge clamp, near-vertex stability (F-3), degenerate fallback (F-5), identity/scale/translation invariants, signedArea CCW/CW/degenerate | 13 |
| \`DistortionAnalyzerTests.swift\` | identity, scale equivariance, severity thresholds, symmetry, cardinalZone, defensive | 8 |
| \`GardenMorpherTests.swift\` | identity, scale, translation, floorY, opposite winding (F-4), out-of-polygon snap, fallback, empty, perf 141 plants | 9 |

Math pure — n'instancie aucun nœud SceneKit, pas de dep ARKit. Tourne en quelques ms par cas. La CI iOS exécute désormais ces tests à chaque PR.

## Roadmap audit AR — état post-merge

| Phase | Issue | État |
|---|---|---|
| 1 | #168 + #169 | ✅ |
| 2 | #170 + #136 | ✅ |
| 3 | #171 | ✅ (PR #179 — vient d'être mergée) |
| **4** | **#172** | **cette PR** |
| **5** | **#173** | **cette PR** |

Toute la roadmap audit AR sera shipped après ce merge.

## Test plan

- [ ] CI verte sur les nouveaux tests (3 fichiers, 30 cas au total)
- [ ] Pas de régression sur les tests existants (NetworkManager, ModelCache, etc.)
- [ ] Test manuel : tracer une boundary en CW dans le morpher, puis re-tracer la nouvelle en CCW → les plantes restent à leur position logique (pas inversées en miroir)