### PR TITLE
fix(ar): show coaching banner while AI auto-placement waits for floor

### DIFF
--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -102,6 +102,13 @@ struct GardenARPlacementView: View {
     // 🤖 AI Auto-placement
     @State private var isAutoPlacing = false
     @State private var autoPlaceToast: String? = nil
+    /// Issue #169 — set true the first time AI auto-placement actually
+    /// triggers (i.e. the reticle reached the floor + stability). Used
+    /// to hide the "Pointez vers le sol" coaching banner once the user
+    /// successfully fired the batch. Stays true for the rest of the
+    /// session ; placement won't re-trigger anyway (Coordinator gates
+    /// it with `didAutoPlace`).
+    @State private var hasTriggeredAutoPlace = false
     
     // 💡 Lux widget
     @State private var currentLux: Int = 0
@@ -292,6 +299,21 @@ struct GardenARPlacementView: View {
                         .padding(.top, 6)
                 }
 
+                // Issue #169 — AI placement coaching. Visible whenever
+                // the user lands on the AR screen with AI plants queued
+                // but hasn't yet pointed at the floor long enough to
+                // trigger the batch. Disappears as soon as auto-place
+                // fires (the autoPlacingOverlay + toast take over).
+                if mode == .create,
+                   !selectedPlants.isEmpty,
+                   !isAutoPlacing,
+                   !hasTriggeredAutoPlace {
+                    awaitingFloorPointBanner
+                        .padding(.horizontal, 16)
+                        .padding(.top, 6)
+                        .transition(.opacity)
+                }
+
                 Spacer()
 
                 // 🤖 Auto-place toast
@@ -408,6 +430,12 @@ struct GardenARPlacementView: View {
         .onChange(of: capturedShareImage) { _, image in
             guard image != nil else { return }
             showSharePreview = true
+        }
+        .onChange(of: isAutoPlacing) { _, new in
+            // Issue #169 — latch the "auto-place fired at least once"
+            // flag so the coaching banner doesn't re-appear after the
+            // batch finishes (isAutoPlacing flips back to false).
+            if new { hasTriggeredAutoPlace = true }
         }
         .fullScreenCover(isPresented: $showSharePreview) {
             if let capturedShareImage {
@@ -732,6 +760,43 @@ struct GardenARPlacementView: View {
     }
 
     // MARK: - 🤖 Auto-Placement Overlay
+
+    /// Issue #169 — coaching banner. The Coordinator only triggers the
+    /// AI batch when the reticle sits within ±20 cm of `detectedFloorY()` ;
+    /// without this banner, the user just sees nothing happen if they
+    /// hold the phone naturally pointing at a desk. Self-contained — no
+    /// binding bubbled from the Coordinator, since the prompt is
+    /// applicable for the whole pre-trigger window regardless of the
+    /// exact reticle Y.
+    private var awaitingFloorPointBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.down")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(Color(hex: "#2BEE79"))
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Pointez votre téléphone vers le sol")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                Text("Le placement automatique démarre dès que le sol est détecté.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.white.opacity(0.75))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(Color(hex: "#2BEE79").opacity(0.25), lineWidth: 1)
+                )
+        )
+        .background(Color.black.opacity(0.55).clipShape(RoundedRectangle(cornerRadius: 14)))
+        .shadow(color: .black.opacity(0.25), radius: 10, y: 4)
+    }
 
     private var autoPlacingOverlay: some View {
         ZStack {


### PR DESCRIPTION
Closes #169.

## Summary

The Coordinator already gates AI auto-placement behind a reticle-near-floor check (commit \`2a3fc3e\`, ±20 cm) so the batch can't land on a desk. But the gate failed silently — a user holding the phone naturally at chest level saw nothing and got no hint to point down.

Adds a coaching banner under the topBar:
- Glyph \`arrow.down\` + "Pointez votre téléphone vers le sol pour démarrer le placement automatique"
- Visible only when \`mode == .create && !selectedPlants.isEmpty && !isAutoPlacing && !hasTriggeredAutoPlace\`
- Latched off on the first \`isAutoPlacing → true\` transition so it doesn't reappear after the batch finishes

Self-contained — no binding bubbled from the Coordinator, since the prompt is meaningful for the whole pre-trigger window regardless of the exact reticle Y.

## Test plan

- [x] Build succeeds
- [ ] Manual on device: arrive at AR placement with AI plants queued holding phone at chest level → banner visible
- [ ] Manual: lower phone toward floor → after ~15 frames stability, banner disappears, autoPlacingOverlay shows
- [ ] Manual: after placement done, banner does NOT reappear when toast fades
- [ ] Manual: mode == .reopen (no AI plants) → banner never appears