### PR TITLE
test(ui): add boot-flow smoke tests + wire UITests target to scheme

### DIFF
--- a/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
+++ b/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
@@ -40,6 +40,17 @@
                ReferencedContainer = "container:ArboreUi.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77DD7AF62D84270800A6F6F1"
+               BuildableName = "ArboreUiUITests.xctest"
+               BlueprintName = "ArboreUiUITests"
+               ReferencedContainer = "container:ArboreUi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ArboreUi/ArboreUiUITests/ArboreUiUITests.swift
+++ b/ArboreUi/ArboreUiUITests/ArboreUiUITests.swift
@@ -7,34 +7,108 @@
 
 import XCTest
 
+/// Boot-flow smoke tests (#66, first foothold of XCUITest coverage).
+///
+/// Scope chosen for pre-jury :
+///  - The app launches and reaches an interactive state (not crashed,
+///    not stuck on a blank/error screen).
+///  - State-agnostic : the host simulator may have a persisted Firebase
+///    session (lands on Home) or not (lands on Login). Both are valid
+///    boot outcomes ; we just assert the app reached one of them.
+///
+/// Out of scope (post-jury follow-up for #66) :
+///  - Deterministic logged-out launches (needs a test-mode hook in
+///    AppDelegate that actually flushes the Firebase keychain before
+///    LoginView's auth observer fires — a `CommandLine.arguments`
+///    flag was attempted but Firebase Auth had already restored the
+///    session by the time the observer mounted).
+///  - Login flow, garden creation, plant placement end-to-end (needs
+///    a test backend tenant + camera-less AR placeholder).
 final class ArboreUiUITests: XCTestCase {
 
+    private var app: XCUIApplication!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app = XCUIApplication()
+        app.launch()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        // Unconditional screenshot for the test report — useful for
+        // visual-only regressions (truncated text, wrong colour, …)
+        // that XCTAssert can't catch.
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "End-of-test state"
+        shot.lifetime = .keepAlways
+        add(shot)
     }
 
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
+    // MARK: - Smoke tests
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    /// The app launches, the splash plays out, and the process is still
+    /// in the foreground. Catches the "white screen of death" /
+    /// fatalError-on-launch regression class : missing required
+    /// Info.plist key, fatalError in AppConfig, broken Firebase init,
+    /// missing assets.
+    @MainActor
+    func test_appLaunches_reachesForegroundState() throws {
+        // 8 s covers the 2 s splash plus cold-start jitter on CI runners.
+        sleep(8)
+        XCTAssertEqual(
+            app.state, .runningForeground,
+            "App should be in foreground after launch — crash, watchdog kill, or stuck launch screen otherwise."
+        )
     }
 
+    /// After the splash, the app exposes an interactive UI : at least
+    /// one tappable button is in the view hierarchy. Catches the
+    /// regression "scene mounted but body returned EmptyView" without
+    /// over-specifying which screen we land on (Home if a Firebase
+    /// session is persisted, Login otherwise — both expose buttons).
     @MainActor
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
+    func test_appLaunches_exposesAtLeastOneTappableControl() throws {
+        sleep(8)
+        XCTAssertGreaterThan(
+            app.buttons.count, 0,
+            "After launch the app should expose at least one tappable button — blank/error state otherwise."
+        )
+    }
+
+    /// The app reaches one of the two known good entry surfaces :
+    /// LoginView (unauthed, identified by its tagline) or the authed
+    /// Home tab bar (identified by its 'Accueil' tab). Catches
+    /// "rendered something but not what we expect" regressions like a
+    /// stuck splash, an alert overlay covering the screen, or a wrong
+    /// initial NavigationView.
+    @MainActor
+    func test_appLaunches_reachesEitherLoginOrHomeTab() throws {
+        // Allow up to 12 s : splash + auth state restore + initial render.
+        let deadline = Date().addingTimeInterval(12)
+        var landed = false
+        while Date() < deadline {
+            if app.staticTexts["Grow with harmony"].exists
+                || app.tabBars.buttons["Accueil"].exists {
+                landed = true
+                break
+            }
+            usleep(250_000)   // 0.25 s poll
+        }
+        XCTAssertTrue(
+            landed,
+            "App should reach LoginView (tagline 'Grow with harmony') or authed Home (tab 'Accueil') within 12 s."
+        )
+    }
+
+    // MARK: - Performance baseline
+
+    /// Captures cold launch time across builds so we notice regressions
+    /// when an init path grows (e.g. CoreML model loading creeping into
+    /// AppDelegate, blocking SwiftUI scene mount). Xcode re-baselines
+    /// automatically on each re-record.
+    @MainActor
+    func test_launchPerformance() throws {
+        if #available(iOS 13.0, *) {
             measure(metrics: [XCTApplicationLaunchMetric()]) {
                 XCUIApplication().launch()
             }


### PR DESCRIPTION
Closes #66.

## Summary

- The \`ArboreUiUITests\` target existed (Xcode-generated boilerplate) but **was never a member of the scheme's test plan** — \`xcodebuild test\` silently skipped it. Adds the target as a \`TestableReference\` so CI actually exercises it.
- Replaces the no-op template test with **4 state-agnostic smoke tests** (all pass locally on iOS 26.2 sim) :
  - \`test_appLaunches_reachesForegroundState\` — process didn't crash, watchdog didn't kill
  - \`test_appLaunches_exposesAtLeastOneTappableControl\` — scene body actually mounted, not EmptyView
  - \`test_appLaunches_reachesEitherLoginOrHomeTab\` — landed on a known good entry surface (LoginView tagline OR authed Home tab)
  - \`test_launchPerformance\` — cold-start metric, baselined by Xcode

State-agnostic by design : the simulator may have a persisted Firebase session (lands on Home) or not (lands on Login). Both are valid boot outcomes ; the tests assert one of them was reached. End-of-test screenshot attached unconditionally for visual evidence.

## Out of scope (post-jury follow-up)

Deterministic logged-out launches + full E2E (login flow, garden create, plant placement) need a test-mode hook in AppDelegate that flushes the Firebase keychain BEFORE LoginView's auth observer mounts. Attempted via a \`CommandLine.arguments\` flag but the Auth observer fired first and restored the session — backed out cleanly. Will be tracked separately in Sprint 5.

## Test plan

- [x] \`xcodebuild test -only-testing:ArboreUiUITests/ArboreUiUITests\` passes locally (4/4 in 110 s)
- [ ] CI green on this PR (xcodebuild test against iPhone 16 Pro / iOS 18.2)
- [ ] Tests stay green on the next 3-4 unrelated PRs (regression confidence)