### PR TITLE
ops(mongo): cleanup script + weekly cron for @arbore.test users

### DIFF
--- a/ArboreBackend/scripts/cleanup-test-users.js
+++ b/ArboreBackend/scripts/cleanup-test-users.js
@@ -1,0 +1,43 @@
+// Issue #160 — cleanup batch des comptes de test laissés en base par la
+// CI (pattern d'email `@arbore.test`). À exécuter via le wrapper bash
+// `cleanup-test-users.sh` qui injecte la bonne URI Mongo, ou directement
+// via `mongosh "<uri>" --file scripts/cleanup-test-users.js`.
+//
+// Comportement :
+//   1. Trouve tous les users dont l'email matche `/@arbore\.test$/`.
+//   2. Cascade : supprime gardens + consents liés à leurs `uid`.
+//   3. Supprime les users eux-mêmes.
+//   4. Imprime un résumé (counts) en JSON-ish pour parsing aval.
+//
+// Précautions :
+//   - Le pattern est ancré strict (`$`) pour éviter de matcher un email
+//     comme `user@arbore.test.example.com`.
+//   - Ne touche PAS aux users dont l'email est nul/absent — c'est un cas
+//     valide pour des comptes Firebase fraîchement créés sans email
+//     vérifié (cf. #137 orphans).
+//   - Ne touche PAS au pool Firebase Auth. La cohérence Firebase ↔ Mongo
+//     se règle à part : un user Firebase sans doc Mongo peut être
+//     re-créé via le signup flow.
+
+const TEST_EMAIL_PATTERN = /@arbore\.test$/;
+
+const candidateUids = db.users.distinct("uid", { email: TEST_EMAIL_PATTERN });
+const usersFound = candidateUids.length;
+
+print(`[cleanup-test-users] found ${usersFound} candidate users matching ${TEST_EMAIL_PATTERN}`);
+
+if (usersFound === 0) {
+    print(`[cleanup-test-users] nothing to do.`);
+    quit(0);
+}
+
+const gardensResult = db.gardens.deleteMany({ uid: { $in: candidateUids } });
+const consentsResult = db.consents.deleteMany({ uid: { $in: candidateUids } });
+const usersResult = db.users.deleteMany({ email: TEST_EMAIL_PATTERN });
+
+print(`[cleanup-test-users] deleted: ` + JSON.stringify({
+    users: usersResult.deletedCount,
+    gardens: gardensResult.deletedCount,
+    consents: consentsResult.deletedCount,
+    timestampUTC: new Date().toISOString(),
+}));

--- a/ArboreBackend/scripts/cleanup-test-users.sh
+++ b/ArboreBackend/scripts/cleanup-test-users.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Issue #160 — wrapper d'exécution du script Mongo de cleanup des
+# comptes de test. Conçu pour le cron hebdomadaire :
+#
+#   0 4 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh \
+#     >> /home/fedora/Arbore/logs/cleanup-test-users.log 2>&1
+#
+# Lit `MONGODB_URI` depuis le `.env` de la racine du repo (priorité 1)
+# ou du backend (fallback). Sort en erreur si introuvable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+JS_SCRIPT="$SCRIPT_DIR/cleanup-test-users.js"
+
+if [[ ! -f "$JS_SCRIPT" ]]; then
+    echo "[cleanup-test-users] missing $JS_SCRIPT" >&2
+    exit 2
+fi
+
+# Localise un .env utilisable : root du repo en priorité, backend en fallback.
+ENV_CANDIDATES=(
+    "$SCRIPT_DIR/../../.env"
+    "$SCRIPT_DIR/../.env"
+)
+
+ENV_FILE=""
+for candidate in "${ENV_CANDIDATES[@]}"; do
+    if [[ -f "$candidate" ]]; then
+        ENV_FILE="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$ENV_FILE" ]]; then
+    echo "[cleanup-test-users] no .env found in any of: ${ENV_CANDIDATES[*]}" >&2
+    exit 3
+fi
+
+# Extrait MONGODB_URI (tolère guillemets simples ou doubles autour de la valeur).
+MONGODB_URI="$(grep -E '^MONGODB_URI=' "$ENV_FILE" | head -1 | sed -E 's/^MONGODB_URI=//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
+
+if [[ -z "$MONGODB_URI" ]]; then
+    echo "[cleanup-test-users] MONGODB_URI not set in $ENV_FILE" >&2
+    exit 4
+fi
+
+printf '[cleanup-test-users] %s UTC — starting cleanup against %s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$(echo "$MONGODB_URI" | sed -E 's|mongodb[^@]*@||; s|/.*||')"
+
+mongosh "$MONGODB_URI" --quiet --file "$JS_SCRIPT"

--- a/docs/legacy/CI-CD.md
+++ b/docs/legacy/CI-CD.md
@@ -245,6 +245,17 @@ Le fichier `.github/CODEOWNERS` définit les reviewers automatiques par composan
 - [CodeQL](https://codeql.github.com/)
 - [Trivy](https://aquasecurity.github.io/trivy/)
 
+## 🧹 Cron de cleanup VPS
+
+Deux jobs cron sur la VPS de prod (`fedora@terraformid-171`) maintiennent la base propre :
+
+| Job | Cron | Script | Rôle |
+|---|---|---|---|
+| `cleanup-test-db` | `0 4 * * *` (daily) | `/home/fedora/Arbore/scripts/cleanup-test-db.sh` | Vide la DB `arbore_test` (cf. #159 séparation prod/test) |
+| `cleanup-test-users` | `0 4 * * 0` (Sunday) | `ArboreBackend/scripts/cleanup-test-users.sh` | Filet de sécurité : supprime cascade les comptes `@arbore.test` qui auraient fuité en `arbore` (cf. #160) |
+
+Logs : `/home/fedora/Arbore/logs/cleanup-test-{db,users}.log`. Toujours backup `mongodump` avant tout cleanup manuel — exemple dans `/home/fedora/Arbore/.backups/pre-cleanup-160-*/`.
+
 ## 🆘 Support
 
 Pour toute question sur la CI/CD, ouvrez une issue avec le label `ci/cd`.


### PR DESCRIPTION
Closes #160.

## Summary

- The 2026-05-13 mongodump showed 1318 users in \`users\`, most of which were CI test accounts (\`@arbore.test\` pattern). At the time of this PR (2026-05-23), the count was **1330 / 1354 (98 %)**. Cleanup executed against prod : 1330 users + 64 gardens + 681 consents deleted in cascade. **24 real users preserved.**
- Adds an idempotent mongosh script (\`cleanup-test-users.js\`) + bash wrapper (\`cleanup-test-users.sh\`) that reads \`MONGODB_URI\` from \`.env\`, matches the strict anchored pattern \`/@arbore\.test$/\`, cascades through gardens + consents via \`distinct(\"uid\", ...)\` + \`deleteMany\`, prints a JSON-ish summary.
- Weekly cron installed on the VPS (\`fedora@terraformid-171\`) :
  \`0 4 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh >> /home/fedora/Arbore/logs/cleanup-test-users.log 2>&1\`
- Doc updated in \`docs/legacy/CI-CD.md\` with a new "Cron de cleanup VPS" table that also covers the existing daily \`cleanup-test-db.sh\` (cf. #159).

## Safety

- Fresh mongodump taken before the destructive op (\`.backups/pre-cleanup-160-2026-05-24T00-14-37Z\`, 1.1 MB, all collections — kept on the VPS, not in git).
- Email pattern is anchored strict (\`$\`) so \`user@arbore.test.example.com\` would not match.
- No action on the Firebase Auth pool — keep that manual to avoid messing with #137-style orphans.

## Post-cleanup verification

\`\`\`
total users:           24
@arbore.test remaining: 0
real users:            24
total gardens:         54
total consents:         1
\`\`\`

## Test plan

- [x] Script ran successfully on prod, expected counts deleted
- [x] Crontab installed (verified via \`crontab -l\`)
- [ ] Sunday 04:00 UTC : verify next run logs cleanly in \`/home/fedora/Arbore/logs/cleanup-test-users.log\`