### PR TITLE
feat(auth): implement Sign in with Apple end-to-end

### DIFF
--- a/ArboreUi/ArboreUi/ArboreUi.entitlements
+++ b/ArboreUi/ArboreUi/ArboreUi.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Issue #201 — Sign in with Apple capability. Apple Guideline 4.8
+	     impose qu'on offre SIWA dès lors qu'on propose un autre social
+	     login (Google). Le bouton "Continue with Apple" était dead
+	     avant cette PR. -->
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.Arbore.ArboreUi</string>

--- a/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
@@ -1,0 +1,216 @@
+//
+//  AppleAuthService.swift
+//  ArboreUi
+//
+//  Issue #201 — Sign in with Apple. Mirror du `GoogleAuthService.swift`,
+//  exposé sous la même surface (`signInWithApple()` + Published
+//  `isLoginSuccessed` + `@AppStorage isLoggedIn`) pour que les vues
+//  Login/Signup/ModernLogin puissent l'injecter sans changer leur
+//  contrat.
+//
+//  Architecture :
+//   - `ASAuthorizationController` est delegate-based, donc cette classe
+//     hérite de `NSObject` et conforme les 2 protocoles
+//     (`...Delegate` + `...PresentationContextProviding`).
+//   - Le nonce est généré localement (random 32-byte string), passé
+//     SHA-256 dans la requête Apple, puis raw au moment de l'échange
+//     Firebase. Firebase vérifie que le hash dans le id_token Apple
+//     correspond bien au raw nonce qu'on envoie (anti-replay).
+//   - Apple ne fournit `fullName` + `email` QU'AU PREMIER SIGNUP. À
+//     l'occasion on persiste sur Firebase displayName + backend Mongo
+//     `users.name`. Aux signins suivants, on trust ce qu'on a déjà.
+//   - Si l'user a coché « Hide my email », Apple renvoie un relay
+//     address `xxx@privaterelay.appleid.com` — c'est l'email réel
+//     côté Firebase + backend, les notifs envoyées dessus sont
+//     relayées par Apple.
+//
+
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+import FirebaseAuth
+
+final class AppleAuthService: NSObject, ObservableObject {
+
+    @Published var isLoginSuccessed = false
+    @AppStorage("isLoggedIn") var isLoggedIn = false
+
+    private var currentNonce: String?
+
+    /// Démarre le flow Sign in with Apple. Le callback delegate gère
+    /// l'enchaînement Firebase → backend → flip de `isLoggedIn`. La
+    /// caller (vue SwiftUI) observe `isLoginSuccessed` pour réagir.
+    func signInWithApple() {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+    }
+
+    /// Déconnexion symétrique du `GoogleAuthService.logout()`. Apple ne
+    /// fournit pas d'API « sign out » côté SDK (le credential reste
+    /// valide sur l'appareil tant que l'user n'a pas révoqué l'app
+    /// depuis Réglages → Apple ID → Mots de passe et sécurité). On se
+    /// contente donc de virer Firebase + flip le flag local.
+    func logout() async throws {
+        try Auth.auth().signOut()
+        await MainActor.run {
+            self.isLoggedIn = false
+            self.isLoginSuccessed = false
+        }
+    }
+
+    // MARK: - Crypto helpers (Apple sample-code pattern)
+
+    /// 32 caractères pseudo-aléatoires dans le charset URL-safe Apple
+    /// recommande. SecRandomCopyBytes (CSPRNG) — pas d'arc4random.
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remaining = length
+        while remaining > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var byte: UInt8 = 0
+                let status = SecRandomCopyBytes(kSecRandomDefault, 1, &byte)
+                if status != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes status: \(status)")
+                }
+                return byte
+            }
+            for byte in randoms where remaining > 0 {
+                if byte < charset.count {
+                    result.append(charset[Int(byte)])
+                    remaining -= 1
+                }
+            }
+        }
+        return result
+    }
+
+    private func sha256(_ input: String) -> String {
+        let hashed = SHA256.hash(data: Data(input.utf8))
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleAuthService: ASAuthorizationControllerDelegate {
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            print("❌ Apple Sign-In: credential is not an AppleIDCredential")
+            return
+        }
+        guard let nonce = currentNonce else {
+            // Programmer error : signInWithApple n'a pas été appelée
+            // avant de recevoir un callback. Crash en debug, log en
+            // release.
+            assertionFailure("Apple Sign-In callback without a prior request — nonce missing.")
+            return
+        }
+        guard let identityTokenData = appleCredential.identityToken,
+              let idTokenString = String(data: identityTokenData, encoding: .utf8) else {
+            print("❌ Apple Sign-In: identityToken missing or not UTF-8")
+            return
+        }
+
+        // Capture du nom (premier signup uniquement, sinon nil).
+        let firstName = appleCredential.fullName?.givenName ?? ""
+        let lastName = appleCredential.fullName?.familyName ?? ""
+        let fullName = [firstName, lastName].filter { !$0.isEmpty }.joined(separator: " ")
+        let appleEmail = appleCredential.email ?? ""
+
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: idTokenString,
+            rawNonce: nonce,
+            fullName: appleCredential.fullName
+        )
+
+        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+            if let error = error {
+                print("❌ Firebase Apple Auth Error:", error.localizedDescription)
+                return
+            }
+            guard let user = authResult?.user else {
+                print("❌ Firebase user is nil after Apple sign-in")
+                return
+            }
+
+            // Premier signup : Apple a fourni le nom. On le pousse à
+            // Firebase displayName (si pas déjà set) ET au backend
+            // Mongo pour qu'il soit disponible côté profil. Aux
+            // signins suivants, fullName est nil — on trust ce qui
+            // existe déjà.
+            let resolvedName = fullName.isEmpty
+                ? (user.displayName ?? "")
+                : fullName
+            let resolvedEmail = user.email ?? appleEmail
+
+            if !fullName.isEmpty,
+               (user.displayName ?? "").isEmpty {
+                let change = user.createProfileChangeRequest()
+                change.displayName = fullName
+                change.commitChanges { commitError in
+                    if let commitError = commitError {
+                        print("⚠️ Failed to commit Firebase displayName for Apple user:", commitError.localizedDescription)
+                    }
+                    saveUserToBackendIfNeeded(
+                        uid: user.uid,
+                        email: resolvedEmail,
+                        name: resolvedName,
+                        createdAt: Date()
+                    )
+                }
+            } else {
+                saveUserToBackendIfNeeded(
+                    uid: user.uid,
+                    email: resolvedEmail,
+                    name: resolvedName,
+                    createdAt: Date()
+                )
+            }
+
+            print("✅ Apple user signed in:", resolvedEmail.isEmpty ? "unknown" : resolvedEmail)
+
+            DispatchQueue.main.async {
+                self?.isLoginSuccessed = true
+                self?.isLoggedIn = true
+            }
+        }
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // ASAuthorizationError.canceled (code 1001) = user a tapé Cancel
+        // dans la sheet Apple — comportement attendu, pas une erreur.
+        if let asError = error as? ASAuthorizationError, asError.code == .canceled {
+            print("ℹ️ Apple Sign-In cancelled by user")
+            return
+        }
+        print("❌ Apple Sign-In Error:", error.localizedDescription)
+    }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+extension AppleAuthService: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        // Trouver le UIWindow actif pour ancrer la sheet Apple. Sans
+        // ça, le système throw une exception au runtime.
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first
+        else {
+            return ASPresentationAnchor()
+        }
+        return window
+    }
+}

--- a/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
@@ -6,6 +6,7 @@ import GoogleSignInSwift
 
 struct LoginView: View {
     @StateObject private var authViewModel = AuthenticationView()
+    @StateObject private var appleAuth = AppleAuthService()
 
     @State private var showSignUp = false
     @State private var showReset = false
@@ -165,7 +166,7 @@ struct LoginView: View {
                             .padding(.horizontal, 30)
 
                             VStack(spacing: 12) {
-                                Button(action: {}) {
+                                Button(action: { appleAuth.signInWithApple() }) {
                                     HStack {
                                         Image(systemName: "apple.logo")
                                             .resizable()

--- a/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
@@ -6,6 +6,7 @@ import GoogleSignInSwift
 
 struct ModernLoginView: View {
     @StateObject internal var authViewModel = AuthenticationView()
+    @StateObject internal var appleAuth = AppleAuthService()
     @EnvironmentObject var themeManager: ThemeManager
 
     @State internal var showSignUp = false
@@ -252,7 +253,7 @@ struct ModernLoginView: View {
                     icon: "apple.logo",
                     backgroundColor: themeManager.textColor,
                     foregroundColor: themeManager.backgroundColor,
-                    action: {}
+                    action: { appleAuth.signInWithApple() }
                 )
 
                 ArborSocialButton(

--- a/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
@@ -18,6 +18,7 @@ struct SignUpView: View {
     @State private var showVerificationScreen = false
     @State private var registeredEmail: String = ""
     @StateObject private var authViewModel = AuthenticationView()
+    @StateObject private var appleAuth = AppleAuthService()
     @FocusState private var focusedField: Field?
 
     enum Field {
@@ -214,7 +215,7 @@ struct SignUpView: View {
                     .padding(.horizontal, 30)
 
                     VStack(spacing: 12) {
-                        Button(action: {}) {
+                        Button(action: { appleAuth.signInWithApple() }) {
                             HStack {
                                 Image(systemName: "apple.logo")
                                     .resizable()


### PR DESCRIPTION
Closes #201.

## Summary

Apple Guideline 4.8 hard blocker. The 3 \"Continue with Apple\" buttons were dead (\`action: {}\`). Now :
- Capability \`com.apple.developer.applesignin\` enabled in entitlements
- New \`AppleAuthService.swift\` mirroring \`GoogleAuthService.swift\` — \`ASAuthorizationController\` + delegate, nonce + SHA-256 anti-replay, exchange via \`OAuthProvider.appleCredential(...)\` → \`Auth.auth().signIn(with:)\`
- First-signup name capture (\`fullName\` only sent by Apple on first auth) → Firebase \`displayName\` + backend Mongo
- \"Hide my email\" relay address transparently handled
- 3 buttons wired (LoginView, SignUpView, ModernLoginView)

## Prerequisite (Firebase Console — manual one-time setup)

Without this step the iOS code will call Firebase but get \`operation-not-allowed\` :

1. Firebase Console → Authentication → Sign-in method → Apple → Enable
2. Provide :
   - **Services ID** (Apple Developer → Identifiers → Services IDs, create one for the app with SIWA capability)
   - **Apple Team ID** (top-right of Developer portal)
   - **Key ID** : \`8VRZJGH7W5\` (matches the .p8 already on file)
   - **Private Key** : upload \`AuthKey_8VRZJGH7W5.p8\` contents

To verify on device after Console setup : tap \"Continue with Apple\" → Apple sheet appears → choose email → land on Home with the user signed in via Firebase + a Mongo \`users\` doc created with the resolved name + email.

## Test plan

- [x] Build succeeds (\`xcodebuild ... iphonesimulator\` → BUILD SUCCEEDED)
- [ ] **Firebase Console** : Apple provider enabled with the .p8 key
- [ ] Device : tap \"Continue with Apple\" → Apple sheet → first signup → Mongo \`users\` doc created with Apple-provided name + email
- [ ] Device : second login (same Apple ID) → no re-prompt for name (Apple doesn't resend), existing displayName intact
- [ ] Device : tap Cancel on Apple sheet → graceful, no crash, no error log

## Out of scope (follow-up)

Apple account revocation on \`DELETE /users\` (Guideline 5.1.1(v)) — separate task. Uses the same \`AuthKey_8VRZJGH7W5.p8\` to sign a JWT \`client_secret\` for Apple's \`/auth/revoke\` endpoint, backend Go side. To create as a Sprint 3 follow-up issue once this lands.