### PR TITLE
chore(deps): remove vestigial Facebook SDK (#204)

### DIFF
--- a/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
+++ b/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		774C3B512ED1FFB100324E07 /* scanRoom */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = scanRoom;
 			sourceTree = "<group>";
 		};
@@ -89,11 +91,15 @@
 		};
 		77DD7AF02D84270800A6F6F1 /* ArboreUiTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ArboreUiTests;
 			sourceTree = "<group>";
 		};
 		77DD7AFA2D84270800A6F6F1 /* ArboreUiUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ArboreUiUITests;
 			sourceTree = "<group>";
 		};
@@ -191,7 +197,6 @@
 				77DD7ADA2D84270700A6F6F1 /* Frameworks */,
 				77DD7ADB2D84270700A6F6F1 /* Resources */,
 				774B710D2D84BE8E002595B2 /* Embed Frameworks */,
-				FBF6C8B756B8B7ADCBA34CB5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -345,27 +350,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FBF6C8B756B8B7ADCBA34CB5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ArboreUi/Pods-ArboreUi-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ArboreUi/Pods-ArboreUi-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ArboreUi/Pods-ArboreUi-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
+++ b/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
@@ -21,10 +21,12 @@
 <plist version="1.0">
 <dict>
     <!-- Pas de tracking cross-app. Aucun SDK n'est utilisé pour suivre
-         l'utilisateur à travers d'autres apps / sites. Si l'audit
-         Facebook SDK (#204) conclut qu'il est effectivement utilisé
-         pour du tracking, basculer NSPrivacyTracking à true ET ajouter
-         les domaines CDN concernés dans NSPrivacyTrackingDomains. -->
+         l'utilisateur à travers d'autres apps / sites. L'audit Facebook SDK
+         (#204, 2026-05-31) a conclu qu'il était vestigial : retiré du Podfile
+         (aucun appel FBSDK dans le code, aucun FacebookAppID dans Info.plist).
+         Donc NSPrivacyTracking reste false et NSPrivacyTrackingDomains vide.
+         Si un SDK de tracking est réintroduit un jour, basculer à true ET
+         lister les domaines concernés ici. -->
     <key>NSPrivacyTracking</key>
     <false/>
     <key>NSPrivacyTrackingDomains</key>

--- a/ArboreUi/Podfile
+++ b/ArboreUi/Podfile
@@ -10,11 +10,14 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ArboreUi' do
-  # Firebase et GoogleSignIn sont gérés via Swift Package Manager (voir project.pbxproj)
-  # Seul Facebook SDK reste dans CocoaPods (pas disponible via SPM)
-
-  # --- Facebook Login ---
-  pod 'FBSDKLoginKit', '~> 18.0'
+  # Firebase et GoogleSignIn sont gérés via Swift Package Manager (voir project.pbxproj).
+  #
+  # Facebook SDK retiré (issue #204) : l'audit a montré qu'il était vestigial —
+  # aucun appel FBSDK/LoginKit dans le code, aucun FacebookAppID ni URL scheme
+  # dans Info.plist (il ne pouvait donc pas fonctionner), et la connexion se fait
+  # via email / Google / Apple. Apple traite ces SDK comme du tracking par défaut :
+  # les supprimer évite un prompt ATT et garde NSPrivacyTracking = false.
+  # Aucune dépendance CocoaPods restante à ce jour.
 end
 
 # post_install minimal et sur

--- a/ArboreUi/Podfile.lock
+++ b/ArboreUi/Podfile.lock
@@ -1,29 +1,3 @@
-PODS:
-  - FBAEMKit (18.0.2):
-    - FBSDKCoreKit_Basics (= 18.0.2)
-  - FBSDKCoreKit (18.0.2):
-    - FBAEMKit (= 18.0.2)
-    - FBSDKCoreKit_Basics (= 18.0.2)
-  - FBSDKCoreKit_Basics (18.0.2)
-  - FBSDKLoginKit (18.0.2):
-    - FBSDKCoreKit (= 18.0.2)
-
-DEPENDENCIES:
-  - FBSDKLoginKit (~> 18.0)
-
-SPEC REPOS:
-  trunk:
-    - FBAEMKit
-    - FBSDKCoreKit
-    - FBSDKCoreKit_Basics
-    - FBSDKLoginKit
-
-SPEC CHECKSUMS:
-  FBAEMKit: 56a4f5a9607957b547b6458b17a98c5bb2736367
-  FBSDKCoreKit: 54f1240567e16862ab71c53c33dc347db5c524c5
-  FBSDKCoreKit_Basics: eb530cd6a79030dbb11df460aafb2767bcad9028
-  FBSDKLoginKit: 6a70798793e499335a98fab1a758d7da34af196e
-
-PODFILE CHECKSUM: 4844bd71ac2f00e778162db219a00fd9b8c55a77
+PODFILE CHECKSUM: 49a90e4c2946c72e65543bb012c6ec44d0472f5d
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Closes #204.

## Audit result: used for nothing
- **No code references** to `FBSDK*` / `FBSDKLoginKit` / `AppEvents` / `LoginManager` / `Settings.shared` / `ApplicationDelegate.shared` anywhere in `ArboreUi/ArboreUi`. Sign-in is email / Google / Apple.
- **Info.plist has no `FacebookAppID`, no `fb…` URL scheme, no `LSApplicationQueriesSchemes`** → the SDK could not have functioned even if called.
- It entered the build only through `pod 'FBSDKLoginKit', '~> 18.0'`, which transitively pulled `FBSDKCoreKit` + `FBAEMKit` (the three frameworks that showed up in the `fastlane beta` build log).

Apple treats these SDKs as **tracking by default**, so removing them is simpler and safer than wiring up an ATT prompt — and it keeps `NSPrivacyTracking = false`.

## Changes
- `Podfile`: drop `FBSDKLoginKit` (target now has no pods; Firebase/GoogleSignIn are SPM).
- `pod install`: removes `FBAEMKit` / `FBSDKCoreKit(_Basics)` / `FBSDKLoginKit`; updates `Podfile.lock` and the project (drops the `[CP] Embed Pods Frameworks` phase).
- `PrivacyInfo.xcprivacy`: record the audit conclusion; `NSPrivacyTracking` stays `false`, `NSPrivacyTrackingDomains` stays empty.

## Verification
- **BUILD SUCCEEDED** on `ArboreUi.xcworkspace` (the release/TestFlight path), iOS Simulator.
- Xcode strips the orphaned `FBSDK*` frameworks from the `.app` bundle.

No ATT prompt needed; no App Store Connect "Data used to track you" to declare.