### PR TITLE
feat(ops): integrate Sentry for crash + perf reporting on iOS (#205)

### DIFF
--- a/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
+++ b/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5E27A0010000000000000003 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5E27A0010000000000000002 /* Sentry */; };
 		77F4355D2D86E1AC00E8E78D /* RealityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4355C2D86E1AC00E8E78D /* RealityKit.framework */; };
 		77F4355F2D86E1B400E8E78D /* ARKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4355E2D86E1B400E8E78D /* ARKit.framework */; };
 		974EF1E72EC2AFC900565B6A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 974EF1E62EC2AFC900565B6A /* FirebaseAuth */; };
@@ -111,6 +112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				77F4355F2D86E1B400E8E78D /* ARKit.framework in Frameworks */,
+				5E27A0010000000000000003 /* Sentry in Frameworks */,
 				974EF1E72EC2AFC900565B6A /* FirebaseAuth in Frameworks */,
 				974EF1EF2EC2B48F00565B6A /* GoogleSignInSwift in Frameworks */,
 				974EF1E92EC2AFC900565B6A /* FirebaseCore in Frameworks */,
@@ -289,6 +291,7 @@
 			mainGroup = 77DD7AD42D84270700A6F6F1;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				5E27A0010000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				77A24D4A2D877E9D00D5DBD3 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				97AE3ED12DD2989D008631AF /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				974EF1E52EC2AFC900565B6A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
@@ -719,6 +722,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5E27A0010000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 		77A24D4A2D877E9D00D5DBD3 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
@@ -746,6 +757,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5E27A0010000000000000002 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E27A0010000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
 		974EF1E62EC2AFC900565B6A /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 974EF1E52EC2AFC900565B6A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/ArboreUi/ArboreUi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArboreUi/ArboreUi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64dcdf48457e09e8e7cc0f9fd184565ad097d3aa14da919b36e31aabf50313ea",
+  "originHash" : "3f7fedb83d796949340aacd70ab5d5532549b71061d7903f98676fd47b515966",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -143,6 +143,15 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
+        "version" : "8.58.3"
       }
     },
     {

--- a/ArboreUi/ArboreUi.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ArboreUi/ArboreUi.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64dcdf48457e09e8e7cc0f9fd184565ad097d3aa14da919b36e31aabf50313ea",
+  "originHash" : "3f7fedb83d796949340aacd70ab5d5532549b71061d7903f98676fd47b515966",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -143,6 +143,15 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "dad229c665bfd043c5d80ac7aa77717cbd19a1c3",
+        "version" : "8.58.3"
       }
     },
     {

--- a/ArboreUi/ArboreUi/Config/AppConfig.swift
+++ b/ArboreUi/ArboreUi/Config/AppConfig.swift
@@ -92,4 +92,43 @@ struct AppConfig {
 
     /// Numéro de build
     static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+
+    // MARK: - Observability (Sentry — issue #205)
+
+    /// Environnement reporté à Sentry pour filtrer les events.
+    /// DEBUG = "debug" (builds Xcode locaux), sinon "beta" (TestFlight / release).
+    static var environment: String {
+        #if DEBUG
+        return "debug"
+        #else
+        return "beta"
+        #endif
+    }
+
+    /// Nom de release Sentry, au format `version+build` (ex. "1.0+10").
+    /// Doit matcher le release créé à l'upload des dSYM pour la symbolication.
+    static var sentryReleaseName: String { "\(appVersion)+\(buildNumber)" }
+
+    /// DSN Sentry reconstruit depuis 3 champs de Secrets.xcconfig.
+    ///
+    /// Un DSN est une URL `https://<publicKey>@<host>/<projectID>`. Or les
+    /// fichiers .xcconfig traitent `//` comme un commentaire : on ne peut pas y
+    /// stocker l'URL telle quelle (même raison que le split protocol/host pour
+    /// le backend). On stocke donc les 3 composants séparément et on
+    /// reconstruit le DSN ici.
+    ///
+    /// Retourne "" si non configuré → Sentry reste désactivé (cf. SentryManager).
+    static var sentryDSN: String {
+        func value(_ key: String) -> String? {
+            guard let v = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+                  !v.isEmpty, !v.hasPrefix("$(") else { return nil }
+            return v
+        }
+        guard let publicKey = value("SENTRY_DSN_PUBLIC_KEY"),
+              let host = value("SENTRY_DSN_HOST"),
+              let projectID = value("SENTRY_DSN_PROJECT_ID") else {
+            return ""
+        }
+        return "https://\(publicKey)@\(host)/\(projectID)"
+    }
 }

--- a/ArboreUi/ArboreUi/Info.plist
+++ b/ArboreUi/ArboreUi/Info.plist
@@ -8,6 +8,12 @@
 	<string>$(ARBORE_BACKEND_HOST)</string>
 	<key>ARBORE_BACKEND_PROTOCOL</key>
 	<string>$(ARBORE_BACKEND_PROTOCOL)</string>
+	<key>SENTRY_DSN_PUBLIC_KEY</key>
+	<string>$(SENTRY_DSN_PUBLIC_KEY)</string>
+	<key>SENTRY_DSN_HOST</key>
+	<string>$(SENTRY_DSN_HOST)</string>
+	<key>SENTRY_DSN_PROJECT_ID</key>
+	<string>$(SENTRY_DSN_PROJECT_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
@@ -13,7 +13,22 @@ import GoogleSignInSwift
 
 class AppDelegate: NSObject, UIApplicationDelegate{
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool{
+        // Sentry en premier (issue #205), AVANT Firebase, pour capturer aussi un
+        // éventuel crash pendant l'init de Firebase. No-op si pas de DSN.
+        SentryManager.start()
+
         FirebaseApp.configure()
+
+        // Le contexte user Sentry suit l'état d'auth Firebase (login → UID,
+        // logout → nil). Centralisé ici : inutile de toucher chaque écran de
+        // connexion/déconnexion.
+        Auth.auth().addStateDidChangeListener { _, user in
+            if let uid = user?.uid {
+                SentryManager.setUser(uid: uid)
+            } else {
+                SentryManager.clearUser()
+            }
+        }
 
         // Release heavy RealityKit caches when iOS signals memory pressure.
         // Without this, the singleton ThumbnailRenderHost's ARView accumulates

--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -1,0 +1,82 @@
+//
+//  SentryManager.swift
+//  ArboreUi
+//
+//  Thin wrapper around the Sentry SDK (issue #205).
+//
+//  Tout est gardé derrière `isEnabled` : si aucun DSN n'est configuré dans
+//  Secrets.xcconfig (cf. AppConfig.sentryDSN), Sentry ne démarre pas et toutes
+//  les méthodes sont des no-op. L'app se comporte donc à l'identique sans
+//  secrets — pratique pour les contributeurs et la CI.
+//
+
+import Foundation
+import Sentry
+
+enum SentryManager {
+
+    /// Vrai si un DSN est configuré → crash reporting actif.
+    static var isEnabled: Bool { !AppConfig.sentryDSN.isEmpty }
+
+    /// Démarre Sentry. À appeler tout au début de
+    /// `AppDelegate.didFinishLaunchingWithOptions`, AVANT
+    /// `FirebaseApp.configure()`, afin de capturer aussi un éventuel crash
+    /// pendant l'init de Firebase.
+    static func start() {
+        let dsn = AppConfig.sentryDSN
+        guard !dsn.isEmpty else {
+            #if DEBUG
+            print("ℹ️ Sentry désactivé (aucun DSN dans Secrets.xcconfig).")
+            #endif
+            return
+        }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.environment = AppConfig.environment
+            options.releaseName = AppConfig.sentryReleaseName
+            options.dist = AppConfig.buildNumber
+
+            // 10% de transactions de performance : marge confortable sous le
+            // free tier (5k events/mois) pour la beta.
+            options.tracesSampleRate = 0.1
+
+            // Vie privée : pas de capture d'écran (peut contenir des données
+            // personnelles). La hiérarchie de vues (structure, sans pixels)
+            // reste utile pour diagnostiquer les crashs d'UI.
+            options.attachScreenshot = false
+            options.attachViewHierarchy = true
+
+            #if DEBUG
+            options.debug = true
+            #endif
+        }
+    }
+
+    /// Rattache les events au user via son UID Firebase (pseudonyme).
+    /// On n'envoie ni e-mail ni nom à Sentry : minimisation des données (RGPD).
+    static func setUser(uid: String) {
+        guard isEnabled else { return }
+        let user = Sentry.User()        // Sentry.User, à ne pas confondre avec le modèle `User` de l'app
+        user.userId = uid
+        SentrySDK.setUser(user)
+    }
+
+    /// Efface le contexte user (au logout).
+    static func clearUser() {
+        guard isEnabled else { return }
+        SentrySDK.setUser(nil)
+    }
+
+    #if DEBUG
+    /// Envoie un event de test non-crashant pour vérifier que le DSN
+    /// fonctionne (visible sur sentry.io en quelques secondes).
+    static func sendTestEvent() {
+        guard isEnabled else {
+            print("⚠️ Sentry désactivé : renseigne le DSN dans Secrets.xcconfig.")
+            return
+        }
+        SentrySDK.capture(message: "Arbore test event — \(AppConfig.sentryReleaseName)")
+    }
+    #endif
+}

--- a/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
+++ b/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
@@ -109,12 +109,36 @@
             </array>
         </dict>
 
-        <!--
-            Note : NSPrivacyCollectedDataTypeCrashData et
-            NSPrivacyCollectedDataTypeOtherDiagnosticData seront ajoutés
-            quand #205 (intégration Sentry) sera mergée. Côté
-            actuel : aucun crash reporting → rien à déclarer.
-        -->
+        <!-- Crash data : stacktraces / rapports de crash envoyés à Sentry
+             (#205). Rattachés à l'UID Firebase (Linked) pour le debug par
+             user, mais pas utilisés pour du tracking cross-app. -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCrashData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Other diagnostic data : performance / breadcrumbs Sentry
+             (tracesSampleRate = 0.1). Même régime que les crash data. -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
 
         <!--
             Note : caméra (AR), calendrier (rappels arrosage), micro,

--- a/ArboreUi/ArboreUi/Views/Profile/ProfileView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/ProfileView.swift
@@ -249,6 +249,17 @@ struct ProfileView: View {
                     )
                 }
                 .buttonStyle(.plain)
+
+                // Sentry (#205) : envoie un event de test pour vérifier le DSN.
+                // No-op si Sentry n'est pas configuré dans Secrets.xcconfig.
+                Button(action: { SentryManager.sendTestEvent() }) {
+                    SettingsRow(
+                        systemImage: "ladybug",
+                        title: "Send Sentry test event",
+                        tint: ArboreDesign.Colors.accentGold
+                    )
+                }
+                .buttonStyle(.plain)
             }
             #endif
         }

--- a/ArboreUi/Secrets.xcconfig.example
+++ b/ArboreUi/Secrets.xcconfig.example
@@ -16,3 +16,19 @@ ARBORE_BACKEND_PROTOCOL = https
 // http + 79.137.92.154:8080 ; l'exception ATS dans Info.plist autorise
 // ce host précis.
 ARBORE_BACKEND_HOST = api.arbore.app
+
+// === OBSERVABILITÉ (Sentry — issue #205) ===
+// Le DSN Sentry est une URL https://<publicKey>@<host>/<projectID>.
+// On ne peut PAS la stocker telle quelle ici : un .xcconfig traite "//"
+// comme un commentaire. On éclate donc le DSN en 3 champs, recomposés
+// dans AppConfig.sentryDSN.
+//
+// Récupère le DSN sur sentry.io → Projet iOS → Settings → Client Keys (DSN).
+// Exemple :  https://abc123def456@o4509000000.ingest.de.sentry.io/4510000000
+//   → PUBLIC_KEY = abc123def456
+//   → HOST       = o4509000000.ingest.de.sentry.io   (org EU = .de.sentry.io)
+//   → PROJECT_ID = 4510000000
+// Laisser vide = Sentry désactivé (l'app build et tourne normalement).
+SENTRY_DSN_PUBLIC_KEY =
+SENTRY_DSN_HOST =
+SENTRY_DSN_PROJECT_ID =

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,80 @@
+# Observability (Sentry)
+
+Crash + performance reporting for Arbore. Phase 1 (this doc) covers **iOS**;
+the Go/Gin backend and the Python AiGenerator are Phase 2 (separate issues).
+
+- Issue: #205
+- SDK: [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa) via Swift Package Manager
+- Org: `epi-apps` (sentry.io, **EU** data residency)
+- Projects: `arbore-frontend` (iOS), `arbore-backend` (Gin — Phase 2)
+
+## How it works
+
+| Piece | Location |
+|-------|----------|
+| SDK wrapper | `ArboreUi/ArboreUi/Observability/SentryManager.swift` |
+| Init (before Firebase) | `ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift` |
+| Config / DSN assembly | `ArboreUi/ArboreUi/Config/AppConfig.swift` |
+| Secrets (gitignored) | `ArboreUi/Secrets.xcconfig` (+ `.example`) |
+| Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
+| dSYM upload | `fastlane/Fastfile` → `beta` lane |
+
+`SentryManager` is **disabled unless a DSN is configured** — without secrets the
+app builds and runs exactly the same (handy for contributors and CI). The user
+context is the Firebase **UID only** (no email/name) and follows the auth state
+via a single `addStateDidChangeListener` in `AppDelegate`.
+
+Options set: `environment` (`debug`/`beta`), `releaseName = version+build`,
+`dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy),
+`attachViewHierarchy = true`.
+
+## Setup (one-shot)
+
+### 1. DSN → `Secrets.xcconfig`
+
+The DSN is a URL `https://<publicKey>@<host>/<projectID>`. Because `.xcconfig`
+treats `//` as a comment, it is stored as **three fields** and reassembled in
+`AppConfig.sentryDSN`. From the iOS project DSN
+(`sentry.io → arbore-frontend → Settings → Client Keys`):
+
+```
+# Secrets.xcconfig (gitignored — never commit)
+SENTRY_DSN_PUBLIC_KEY = <public key>
+SENTRY_DSN_HOST       = o<org>.ingest.de.sentry.io   # .de = EU
+SENTRY_DSN_PROJECT_ID = <project id>
+```
+
+Leave empty to keep Sentry off.
+
+### 2. dSYM symbolication (fastlane)
+
+The `beta` lane uploads dSYMs after the TestFlight upload, but only if these are
+set (otherwise it logs a skip and continues):
+
+```bash
+brew install getsentry/tools/sentry-cli
+export SENTRY_AUTH_TOKEN=<org token: scopes project:releases + project:write>
+export SENTRY_ORG=epi-apps
+export SENTRY_PROJECT=arbore-frontend
+bundle exec fastlane beta
+```
+
+Create the auth token at `sentry.io → Settings → Auth Tokens`. Keep it out of
+git (env var or `.sentryclirc`, which is gitignored).
+
+## Verify
+
+1. Set the DSN in `Secrets.xcconfig`, run a **Debug** build.
+2. Profile → **Debug Tools → “Send Sentry test event”** (visible in DEBUG only).
+3. The event appears in `sentry.io → arbore-frontend → Issues` within seconds,
+   tagged with environment `debug` and your Firebase UID.
+4. For symbolicated **release** crashes, ship a `fastlane beta` build with the
+   env vars above, then trigger a crash on the TestFlight build.
+
+## Notes / follow-ups
+
+- Breadcrumb bridge from the app's `AppLog` (nav / AR session / garden save) is a
+  nice-to-have not yet wired — follow-up.
+- Backend (`sentry-go` + `sentrygin`) and AiGenerator (`sentry-python`) are
+  Phase 2; the `arbore-backend` Sentry project already exists.
+- Session Replay is a paid feature — not used.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,7 +91,45 @@ platform :ios do
       changelog: "Build interne automatique (lane: beta)."
     )
 
+    # --- Sentry : upload des dSYM pour symboliser les crashes (#205) ---
+    # Skippé proprement si non configuré, pour ne pas casser la lane chez
+    # quelqu'un sans Sentry. Nécessite `sentry-cli`
+    # (brew install getsentry/tools/sentry-cli) + variables d'env :
+    #   SENTRY_AUTH_TOKEN  (token org : scopes project:releases + project:write)
+    #   SENTRY_ORG         (ex. "arboreteam")
+    #   SENTRY_PROJECT     (ex. "arbore-ios")
+    upload_dsyms_to_sentry(version: version, build: latest + 1)
+
     UI.success("✅ Build #{latest + 1} déployée sur TestFlight → groupe #{INTERNAL_GROUP}")
+  end
+
+  desc "Upload des dSYM vers Sentry (no-op si non configuré)."
+  private_lane :upload_dsyms_to_sentry do |options|
+    missing = %w[SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT].select { |k| ENV[k].to_s.empty? }
+    if missing.any?
+      UI.important("Sentry dSYM upload ignoré (variables manquantes : #{missing.join(', ')}).")
+      next
+    end
+    if `which sentry-cli`.strip.empty?
+      UI.important("Sentry dSYM upload ignoré : sentry-cli introuvable (brew install getsentry/tools/sentry-cli).")
+      next
+    end
+
+    dsym_zip = File.expand_path("./fastlane/builds/Arbore.app.dSYM.zip")
+    unless File.exist?(dsym_zip)
+      UI.important("Sentry dSYM upload ignoré : #{dsym_zip} introuvable.")
+      next
+    end
+
+    org     = ENV["SENTRY_ORG"]
+    project = ENV["SENTRY_PROJECT"]
+    release = "#{options[:version]}+#{options[:build]}"
+
+    # Crée la release puis associe les dSYM (symbolication des stacktraces).
+    sh("sentry-cli releases -o #{org} -p #{project} new '#{release}' || true")
+    sh("sentry-cli debug-files upload -o #{org} -p #{project} '#{dsym_zip}'")
+    sh("sentry-cli releases -o #{org} -p #{project} finalize '#{release}' || true")
+    UI.success("✅ dSYM uploadés sur Sentry (release #{release}).")
   end
 
   error do |lane, exception|


### PR DESCRIPTION
Closes #205 (Phase 1 — iOS). Gives us real stacktraces / device info / breadcrumbs from external beta testers; App Store Connect only shows an anonymous crash count.

## What
- **`sentry-cocoa` via SPM** (pinned **8.58.3**), linked like the existing SPM products.
- **`SentryManager`** wrapper — **disabled unless a DSN is configured**, so the app builds and runs identically with no secrets (contributors / CI).
- Started in **`AppDelegate` before `FirebaseApp.configure()`** to also catch crashes during Firebase init. User context = **Firebase UID only** (no email/name), driven by one auth-state listener — no per-screen wiring.
- **DSN as 3 fields** in `Secrets.xcconfig` (xcconfig treats `//` as a comment, so the URL can't be stored whole) reassembled in `AppConfig`; `Info.plist` + `Secrets.xcconfig.example` updated.
- **`PrivacyInfo.xcprivacy`**: declares `CrashData` + `OtherDiagnosticData` (Linked to UID, not tracking); `NSPrivacyTracking` stays `false`.
- **fastlane `beta`**: guarded **dSYM upload** via `sentry-cli` (no-op unless `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` are set).
- **Debug-only** "Send Sentry test event" button in *Profile → Debug Tools*.
- `docs/operations/observability.md`.

Options: `environment` debug/beta, `releaseName` version+build, `tracesSampleRate` 0.1, `attachScreenshot=false` (privacy), `attachViewHierarchy=true`.

## Sentry setup (done by @Matribuk)
Org `epi-apps` (EU residency), projects `arbore-frontend` (iOS) and `arbore-backend` (Gin, Phase 2). The iOS DSN lives in the local gitignored `Secrets.xcconfig` — **not** in this PR.

## Verification
- **BUILD SUCCEEDED** on `ArboreUi.xcworkspace` (iOS Simulator) with Sentry **enabled** (real DSN locally).
- Live dashboard check is on the reviewer's side: Debug build → *Debug Tools → Send Sentry test event* → appears in `sentry.io → arbore-frontend → Issues`.

## Out of scope (follow-ups)
- Backend (`sentry-go` + `sentrygin`) and AiGenerator (`sentry-python`) instrumentation — Phase 2.
- `AppLog` → breadcrumbs bridge.