### PR TITLE
fix(privacy): AR WorldMaps are on-device only, not collected

### DIFF
--- a/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
+++ b/ArboreUi/ArboreUi/PrivacyInfo.xcprivacy
@@ -93,9 +93,12 @@
             </array>
         </dict>
 
-        <!-- Garden data : positions des plantes, WorldMaps, JSON de
-             scène, modèles 3D sélectionnés. Stocké dans Mongo
-             /gardens. Pas d'analyse cross-user. -->
+        <!-- Garden data : plantes sélectionnées, positions/disposition 3D,
+             réponses au questionnaire. Stocké dans Mongo /gardens.
+             NB : les ARKit WorldMaps restent en LOCAL sur l'appareil
+             (GardenLocalStore, fichier archivé), jamais uploadées — donc
+             ni "collected" au sens d'Apple ni "Environment Scanning".
+             Pas d'analyse cross-user. -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeOtherUserContent</string>

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -227,9 +227,9 @@
 "PRIVACY_SECTION_DATA_TITLE" = "Daten, die wir verarbeiten";
 "PRIVACY_SECTION_DATA_ITEM1" = "Identität: E-Mail, Name, Firebase-ID und der genutzte Anmeldedienst (E-Mail, Google oder Apple).";
 "PRIVACY_SECTION_DATA_ITEM2" = "Profilbild: nur, wenn du eines hinzufügst.";
-"PRIVACY_SECTION_DATA_ITEM3" = "Gärten & AR: ausgewählte Pflanzen, 3D-Positionen, ARKit-Weltkarten, Antworten im Fragebogen.";
+"PRIVACY_SECTION_DATA_ITEM3" = "Gärten & AR: ausgewählte Pflanzen, 3D-Positionen, Antworten im Fragebogen.";
 "PRIVACY_SECTION_DATA_ITEM4" = "Einwilligungen: Typ, Version und Datum sowie IP-Adresse und User-Agent als Nachweis.";
-"PRIVACY_SECTION_DATA_ITEM5" = "Nur auf deinem Gerät (nie hochgeladen): Kamera und LiDAR für AR, Bewegung, Standort für Sonnenlicht, Kalender für Erinnerungen, Face ID.";
+"PRIVACY_SECTION_DATA_ITEM5" = "Nur auf deinem Gerät (nie hochgeladen): Kamera und LiDAR für AR, Bewegung, ARKit-Weltkarten, Standort für Sonnenlicht, Kalender für Erinnerungen, Face ID.";
 
 // Warum wir sie nutzen
 "PRIVACY_SECTION_USAGE_TITLE" = "Warum wir diese Daten nutzen";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -246,9 +246,9 @@
 "PRIVACY_SECTION_DATA_TITLE" = "Data we process";
 "PRIVACY_SECTION_DATA_ITEM1" = "Identity: email, name, Firebase ID, and the sign-in provider you use (email, Google or Apple).";
 "PRIVACY_SECTION_DATA_ITEM2" = "Profile photo: only if you choose to add one.";
-"PRIVACY_SECTION_DATA_ITEM3" = "Gardens & AR: selected plants, 3D positions, ARKit world maps, questionnaire answers.";
+"PRIVACY_SECTION_DATA_ITEM3" = "Gardens & AR: selected plants, 3D positions, questionnaire answers.";
 "PRIVACY_SECTION_DATA_ITEM4" = "Consent records: type, version and date, plus IP address and user agent kept as proof.";
-"PRIVACY_SECTION_DATA_ITEM5" = "On your device only (never uploaded): camera and LiDAR for AR, motion, location for sunlight, calendar for reminders, Face ID.";
+"PRIVACY_SECTION_DATA_ITEM5" = "On your device only (never uploaded): camera and LiDAR for AR, motion, ARKit world maps, location for sunlight, calendar for reminders, Face ID.";
 
 // Why we use it
 "PRIVACY_SECTION_USAGE_TITLE" = "Why we use this data";

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -227,9 +227,9 @@
 "PRIVACY_SECTION_DATA_TITLE" = "Datos que tratamos";
 "PRIVACY_SECTION_DATA_ITEM1" = "Identidad: correo electrónico, nombre, identificador de Firebase y el proveedor de inicio de sesión que uses (correo, Google o Apple).";
 "PRIVACY_SECTION_DATA_ITEM2" = "Foto de perfil: solo si añades una.";
-"PRIVACY_SECTION_DATA_ITEM3" = "Jardines y RA: plantas seleccionadas, posiciones 3D, mapas espaciales de ARKit, respuestas del cuestionario.";
+"PRIVACY_SECTION_DATA_ITEM3" = "Jardines y RA: plantas seleccionadas, posiciones 3D, respuestas del cuestionario.";
 "PRIVACY_SECTION_DATA_ITEM4" = "Consentimientos: tipo, versión y fecha, además de dirección IP y agente de usuario conservados como prueba.";
-"PRIVACY_SECTION_DATA_ITEM5" = "Solo en tu dispositivo (nunca se envía): cámara y LiDAR para la RA, movimiento, ubicación para la luz solar, calendario para los recordatorios, Face ID.";
+"PRIVACY_SECTION_DATA_ITEM5" = "Solo en tu dispositivo (nunca se envía): cámara y LiDAR para la RA, movimiento, mapas espaciales de ARKit, ubicación para la luz solar, calendario para los recordatorios, Face ID.";
 
 // Por qué los usamos
 "PRIVACY_SECTION_USAGE_TITLE" = "Por qué usamos estos datos";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -246,9 +246,9 @@
 "PRIVACY_SECTION_DATA_TITLE" = "Données que nous traitons";
 "PRIVACY_SECTION_DATA_ITEM1" = "Identité : e-mail, nom, identifiant Firebase, et le fournisseur de connexion utilisé (e-mail, Google ou Apple).";
 "PRIVACY_SECTION_DATA_ITEM2" = "Photo de profil : uniquement si tu en ajoutes une.";
-"PRIVACY_SECTION_DATA_ITEM3" = "Jardins & RA : plantes sélectionnées, positions 3D, cartes spatiales ARKit, réponses au questionnaire.";
+"PRIVACY_SECTION_DATA_ITEM3" = "Jardins & RA : plantes sélectionnées, positions 3D, réponses au questionnaire.";
 "PRIVACY_SECTION_DATA_ITEM4" = "Consentements : type, version et date, plus adresse IP et agent utilisateur conservés comme preuve.";
-"PRIVACY_SECTION_DATA_ITEM5" = "Sur ton appareil uniquement (jamais envoyé) : caméra et LiDAR pour la RA, mouvement, localisation pour l’ensoleillement, calendrier pour les rappels, Face ID.";
+"PRIVACY_SECTION_DATA_ITEM5" = "Sur ton appareil uniquement (jamais envoyé) : caméra et LiDAR pour la RA, mouvement, cartes spatiales ARKit (WorldMap), localisation pour l’ensoleillement, calendrier pour les rappels, Face ID.";
 
 // Pourquoi nous les utilisons
 "PRIVACY_SECTION_USAGE_TITLE" = "Pourquoi nous utilisons ces données";


### PR DESCRIPTION
Accuracy fix so the in-app privacy text matches the App Store Connect label (where we do **not** declare *Environment Scanning*).

ARKit WorldMaps are archived to a **local file** (`GardenLocalStore`) and are **never** part of the `/gardens` upload — only plant selections, 3D positions and questionnaire answers leave the device. The policy previously listed WorldMaps as collected.

- Move "ARKit world maps" from the collected garden line to the on-device-only line (`PRIVACY_SECTION_DATA_ITEM3`/`ITEM5`, en/fr/de/es).
- Fix the `PrivacyInfo.xcprivacy` comment that wrongly said WorldMaps go to Mongo.

Doc accuracy only — no behaviour change. Pairs with the same fix on the public site.