### PR TITLE
chore(ops): simplify Sentry dSYM upload setup (#205 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,9 @@ fastlane/AuthKey.json
 fastlane/AuthKey*.json
 fastlane/AuthKey*.p8
 fastlane/report.xml
+
+# Sentry CLI auth token (dSYM upload) — never commit. Cf .sentryclirc.example
+.sentryclirc
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output

--- a/.sentryclirc.example
+++ b/.sentryclirc.example
@@ -1,0 +1,20 @@
+# Sentry CLI config — dSYM upload pour la symbolication des crashes (#205).
+#
+# Copier ce fichier en `.sentryclirc` (gitignored) et coller le token.
+#   cp .sentryclirc.example .sentryclirc
+#
+# Créer le token : sentry.io → Settings → Account → Auth Tokens (ou
+# Organization → Auth Tokens), scopes : project:releases + project:write.
+#
+# Alternative : exporter la variable d'env SENTRY_AUTH_TOKEN à la place de
+# ce fichier — la lane `fastlane beta` accepte les deux.
+#
+# org / project sont déjà câblés dans fastlane/Fastfile (epi-apps /
+# arbore-frontend) ; pas besoin de les répéter ici sauf override.
+
+[auth]
+token = sntrys_VOTRE_TOKEN_ICI
+
+[defaults]
+org = epi-apps
+project = arbore-frontend

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -48,19 +48,20 @@ Leave empty to keep Sentry off.
 
 ### 2. dSYM symbolication (fastlane)
 
-The `beta` lane uploads dSYMs after the TestFlight upload, but only if these are
-set (otherwise it logs a skip and continues):
+The `beta` lane uploads dSYMs after the TestFlight upload. Org/project are
+already wired in the Fastfile (`epi-apps` / `arbore-frontend`), so the **only**
+thing to provide is an auth token. If no token is found it logs a skip and the
+lane continues.
 
 ```bash
 brew install getsentry/tools/sentry-cli
-export SENTRY_AUTH_TOKEN=<org token: scopes project:releases + project:write>
-export SENTRY_ORG=epi-apps
-export SENTRY_PROJECT=arbore-frontend
+cp .sentryclirc.example .sentryclirc   # then paste the token (gitignored)
 bundle exec fastlane beta
 ```
 
-Create the auth token at `sentry.io → Settings → Auth Tokens`. Keep it out of
-git (env var or `.sentryclirc`, which is gitignored).
+Create the token at `sentry.io → Settings → Auth Tokens` (scopes
+`project:releases` + `project:write`). Instead of `.sentryclirc` you can export
+`SENTRY_AUTH_TOKEN`; override `SENTRY_ORG` / `SENTRY_PROJECT` via env if needed.
 
 ## Verify
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,6 +23,12 @@ SCHEME    = "ArboreUi"
 AUTH_KEY  = File.expand_path("AuthKey.json", __dir__)
 INTERNAL_GROUP = "Internal QA"
 
+# Sentry (#205) — org/projet ne sont pas des secrets, donc valeurs par défaut.
+# Overridables par variable d'env. Le token, lui, reste hors-repo : variable
+# SENTRY_AUTH_TOKEN ou fichier ~/.sentryclirc / .sentryclirc (gitignored).
+SENTRY_ORG     = ENV["SENTRY_ORG"]     || "epi-apps"
+SENTRY_PROJECT = ENV["SENTRY_PROJECT"] || "arbore-frontend"
+
 default_platform(:ios)
 
 platform :ios do
@@ -105,13 +111,18 @@ platform :ios do
 
   desc "Upload des dSYM vers Sentry (no-op si non configuré)."
   private_lane :upload_dsyms_to_sentry do |options|
-    missing = %w[SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT].select { |k| ENV[k].to_s.empty? }
-    if missing.any?
-      UI.important("Sentry dSYM upload ignoré (variables manquantes : #{missing.join(', ')}).")
-      next
-    end
     if `which sentry-cli`.strip.empty?
       UI.important("Sentry dSYM upload ignoré : sentry-cli introuvable (brew install getsentry/tools/sentry-cli).")
+      next
+    end
+
+    # Le token peut venir de l'env OU d'un fichier .sentryclirc (lu
+    # automatiquement par sentry-cli). On skippe proprement s'il n'y en a aucun.
+    has_token = !ENV["SENTRY_AUTH_TOKEN"].to_s.empty? ||
+                File.exist?(File.expand_path("~/.sentryclirc")) ||
+                File.exist?(".sentryclirc")
+    unless has_token
+      UI.important("Sentry dSYM upload ignoré : aucun token (SENTRY_AUTH_TOKEN ou .sentryclirc). Cf docs/operations/observability.md.")
       next
     end
 
@@ -121,15 +132,13 @@ platform :ios do
       next
     end
 
-    org     = ENV["SENTRY_ORG"]
-    project = ENV["SENTRY_PROJECT"]
     release = "#{options[:version]}+#{options[:build]}"
 
     # Crée la release puis associe les dSYM (symbolication des stacktraces).
-    sh("sentry-cli releases -o #{org} -p #{project} new '#{release}' || true")
-    sh("sentry-cli debug-files upload -o #{org} -p #{project} '#{dsym_zip}'")
-    sh("sentry-cli releases -o #{org} -p #{project} finalize '#{release}' || true")
-    UI.success("✅ dSYM uploadés sur Sentry (release #{release}).")
+    sh("sentry-cli releases -o #{SENTRY_ORG} -p #{SENTRY_PROJECT} new '#{release}' || true")
+    sh("sentry-cli debug-files upload -o #{SENTRY_ORG} -p #{SENTRY_PROJECT} '#{dsym_zip}'")
+    sh("sentry-cli releases -o #{SENTRY_ORG} -p #{SENTRY_PROJECT} finalize '#{release}' || true")
+    UI.success("✅ dSYM uploadés sur Sentry (#{SENTRY_ORG}/#{SENTRY_PROJECT}, release #{release}).")
   end
 
   error do |lane, exception|


### PR DESCRIPTION
Non-blocking polish so symbolicated **release/TestFlight** crash reports work with the least setup.

- **Only a token is needed now** — `SENTRY_ORG=epi-apps` / `SENTRY_PROJECT=arbore-frontend` are defaulted in the Fastfile (still env-overridable).
- The `beta` lane reads the token from `SENTRY_AUTH_TOKEN` **or** a gitignored `.sentryclirc` (sentry-cli finds it automatically), and skips cleanly if neither exists — never breaks the lane.
- Adds `.sentryclirc.example`, gitignores `.sentryclirc`, updates `docs/operations/observability.md`.

`ruby -c` on the Fastfile passes.

### One manual step left (yours — needs your account)
Create an auth token at `sentry.io → Settings → Auth Tokens` (scopes `project:releases` + `project:write`), then `cp .sentryclirc.example .sentryclirc` and paste it. Next `fastlane beta` will upload dSYMs automatically.