### PR TITLE
fix(security): enforce email_verified in the backend Firebase middleware (#110)

### DIFF
--- a/ArboreBackend/middleware/firebase_auth.go
+++ b/ArboreBackend/middleware/firebase_auth.go
@@ -162,6 +162,24 @@ func FirebaseAuthMiddleware() gin.HandlerFunc {
 			}
 		}
 
+		// #110 : exiger un email vérifié, SAUF pour la création initiale du
+		// compte (POST /users) — le document Mongo doit pouvoir être créé juste
+		// après le signup, avant que l'utilisateur clique le lien de vérif.
+		// Google / Apple renvoient email_verified=true ; seuls les comptes
+		// email/mot de passe non vérifiés sont bloqués.
+		isUserCreation := c.Request.Method == "POST" && c.FullPath() == "/users"
+		if !isUserCreation {
+			verified, _ := token.Claims["email_verified"].(bool)
+			if !verified {
+				c.JSON(403, gin.H{
+					"error": "Email not verified",
+					"code":  "EMAIL_NOT_VERIFIED",
+				})
+				c.Abort()
+				return
+			}
+		}
+
 		c.Set("uid", uid)
 
 		if email, ok := token.Claims["email"].(string); ok {

--- a/ArboreUi/ArboreUi/Services/NetworkManager.swift
+++ b/ArboreUi/ArboreUi/Services/NetworkManager.swift
@@ -19,6 +19,7 @@ enum NetworkError: Error {
     case serverError(String)
     case unauthorized
     case forbidden
+    case emailNotVerified
     case decodingError(Error)
 }
 
@@ -37,6 +38,8 @@ extension NetworkError: LocalizedError {
             return "Non autorisé - Token invalide ou expiré"
         case .forbidden:
             return "Accès interdit - Compte banni ou permissions insuffisantes"
+        case .emailNotVerified:
+            return "Email non vérifié - vérifie ta boîte mail pour activer ton compte"
         case .decodingError(let error):
             return "Erreur de décodage: \(error.localizedDescription)"
         }
@@ -155,7 +158,7 @@ class NetworkManager {
 
         case 403:
             print("❌ 403 Forbidden - Accès refusé")
-            throw NetworkError.forbidden
+            throw forbiddenError(from: data)
 
         default:
             if let errorData = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -172,6 +175,22 @@ class NetworkManager {
         body: [String: Any]? = nil
     ) async throws {
         let _: EmptyResponse = try await request(endpoint: endpoint, method: method, body: body)
+    }
+
+    /// #110 : un 403 du backend peut signifier `EMAIL_NOT_VERIFIED` (le token
+    /// Firebase est valide mais l'email n'est pas vérifié). Dans ce cas, on coupe
+    /// la session (le compte ne devrait pas être connecté tant qu'il n'est pas
+    /// vérifié) et on remonte une erreur dédiée. Sinon, c'est un vrai forbidden.
+    private func forbiddenError(from data: Data) -> NetworkError {
+        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           (obj["code"] as? String) == "EMAIL_NOT_VERIFIED" {
+            DispatchQueue.main.async {
+                try? Auth.auth().signOut()
+                UserDefaults.standard.set(false, forKey: "isLoggedIn")
+            }
+            return .emailNotVerified
+        }
+        return .forbidden
     }
 
     func requestDictionary(
@@ -217,7 +236,7 @@ class NetworkManager {
             throw NetworkError.unauthorized
 
         case 403:
-            throw NetworkError.forbidden
+            throw forbiddenError(from: data)
 
         default:
             if let errorData = try? JSONSerialization.jsonObject(with: data) as? [String: Any],


### PR DESCRIPTION
Closes #110.

Email verification was **client-side only** — a valid Firebase ID token for an unverified account could call the backend API freely (auth bypass).

## Backend — `middleware/firebase_auth.go`
After the token is verified, reject requests whose `email_verified` claim isn't `true` with **403 `EMAIL_NOT_VERIFIED`**, **except `POST /users`** (so the initial Mongo doc can be created right after signup, before the user clicks the link).
- Google / Apple sign-ins are `email_verified=true` → unaffected.
- Only **unverified email/password** accounts are blocked.
- No-token / dev-without-Firebase paths keep their existing behaviour.

## iOS — `Services/NetworkManager.swift`
- New `NetworkError.emailNotVerified` with a clear message.
- On a 403 carrying `code: EMAIL_NOT_VERIFIED`, **cut the session** (`signOut()` + `isLoggedIn=false`) → the user returns to the login screen, which already routes unverified accounts to `VerifyEmailView`. Defense-in-depth: in normal use an unverified user can't even log in (LoginView signs them out), so this path is rarely hit.

## Not involved
No email provider (Brevo/SMTP) — **Firebase already sends the verification email natively**. This PR is purely the missing server-side enforcement.

## Verification
- `go build ./...` + `go vet ./middleware/` ✓
- iOS workspace **BUILD SUCCEEDED** (simulator).

## Deploy note
The check is only active once the **Go backend is redeployed** to the VPS.