### PR TITLE
docs: fix doc-drift CI failure in observability.md

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -32,8 +32,8 @@ Options set: `environment` (`debug`/`beta`), `releaseName = version+build`,
 
 ### 1. DSN → `Secrets.xcconfig`
 
-The DSN is a URL `https://<publicKey>@<host>/<projectID>`. Because `.xcconfig`
-treats `//` as a comment, it is stored as **three fields** and reassembled in
+The DSN is a URL `https://<publicKey>@<host>/<projectID>`. Because an xcconfig
+file treats `//` as a comment, it is stored as **three fields** and reassembled in
 `AppConfig.sentryDSN`. From the iOS project DSN
 (`sentry.io → arbore-frontend → Settings → Client Keys`):
 


### PR DESCRIPTION
Fixes the red **📚 Docs validation → Doc drift** check on `main` (introduced by the Sentry observability doc).

## Cause
`.github/scripts/docs-drift-check.sh` treats any backtick token ending in a watched extension as a file path. `docs/operations/observability.md` used `` `.xcconfig` `` to mean *the xcconfig format* — the checker read it as a missing file `.xcconfig`.

## Fix
Reword to "an xcconfig file" (no path-looking backtick). The `Secrets.xcconfig` references are untouched — they're gitignored and the checker already tolerates gitignored paths via `git check-ignore` (same as `fastlane/AuthKey.json`).

Verified: `bash .github/scripts/docs-drift-check.sh` → ✅ *No doc drift detected.*