### PR TITLE
fix(security): enforce garden ownership on read + stop leaking PII in logs

### DIFF
--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1147,13 +1147,19 @@ func getGardenByID(c *gin.Context) {
 		return
 	}
 
+	uid, exists := c.Get("uid")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
 	collection := getDatabaseForRequest(c).Collection("gardens")
 	var garden Garden
 
-	err = collection.FindOne(context.Background(), bson.M{"_id": objectID}).Decode(&garden)
+	err = collection.FindOne(context.Background(), bson.M{"_id": objectID, "uid": uid}).Decode(&garden)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
-			c.JSON(http.StatusNotFound, gin.H{"message": "Garden non trouvé"})
+			c.JSON(http.StatusNotFound, gin.H{"message": "Garden non trouvé ou accès refusé"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lecture garden"})

--- a/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
@@ -180,7 +180,9 @@ extension AppleAuthService: ASAuthorizationControllerDelegate {
                 )
             }
 
+            #if DEBUG
             print("✅ Apple user signed in:", resolvedEmail.isEmpty ? "unknown" : resolvedEmail)
+            #endif
 
             DispatchQueue.main.async {
                 self?.isLoginSuccessed = true

--- a/ArboreUi/ArboreUi/LoginAuth/GoogleAuthService.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/GoogleAuthService.swift
@@ -75,7 +75,9 @@ class AuthenticationView: ObservableObject {
 
                 saveUserToBackendIfNeeded(uid: user.uid, email: user.email ?? "", name: user.displayName ?? "", createdAt: Date())
 
+                #if DEBUG
                 print("✅ Google user signed in:", user.email ?? "unknown")
+                #endif
 
                 DispatchQueue.main.async {
                     self.isLoginSuccessed = true

--- a/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
@@ -311,9 +311,11 @@ struct ModernLoginView: View {
                 self.isLoading = false
 
                 if let error = error as NSError? {
+                    #if DEBUG
                     print("❌ Firebase Auth error:")
                     print("Full error: \(error)")
                     print("UserInfo: \(error.userInfo)")
+                    #endif
 
                     if let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError,
                        let deserialized = underlyingError.userInfo["FIRAuthErrorUserInfoDeserializedResponseKey"] as? [String: Any],
@@ -344,12 +346,6 @@ struct ModernLoginView: View {
                         self.errorMessage = "Erreur d'authentification inconnue. Veuillez réessayer."
                     }
                     return
-                }
-
-                Task {
-                    if let token = try? await Auth.auth().currentUser?.getIDToken() {
-                        print("🔑 Firebase Token:", token)
-                    }
                 }
 
                 guard let user = result?.user else { return }

--- a/ArboreUi/ArboreUi/LoginAuth/saveAuthDB.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/saveAuthDB.swift
@@ -37,7 +37,9 @@ func saveUserToBackendThrowing(uid: String, email: String, name: String, created
                 method: .POST,
                 body: userData
             )
+            #if DEBUG
             print("✅ Utilisateur enregistré dans MongoDB (uid=\(uid)):", response.message ?? "success")
+            #endif
             return
         } catch NetworkError.unauthorized, NetworkError.forbidden {
             // 401/403: clé API ou token invalide — retry inutile, on remonte.

--- a/ArboreUi/ArboreUi/Services/NetworkManager.swift
+++ b/ArboreUi/ArboreUi/Services/NetworkManager.swift
@@ -147,8 +147,10 @@ class NetworkManager {
                 let decoded = try decoder.decode(T.self, from: data)
                 return decoded
             } catch {
+                #if DEBUG
                 print("❌ Erreur décodage:", error)
                 print("📄 Data reçue:", String(data: data, encoding: .utf8) ?? "nil")
+                #endif
                 throw NetworkError.decodingError(error)
             }
 
@@ -290,8 +292,10 @@ class NetworkManager {
                 let decoded = try decoder.decode(T.self, from: data)
                 return decoded
             } catch {
+                #if DEBUG
                 print("❌ Erreur décodage:", error)
                 print("📄 Data reçue:", String(data: data, encoding: .utf8) ?? "nil")
+                #endif
                 throw NetworkError.decodingError(error)
             }
 


### PR DESCRIPTION
Corrige deux bloquants beta de l'audit du 2026-06-02.

## Closes #222 — Contournement d'autorisation sur `GET /gardens/:id`
`getGardenByID` lisait un jardin par ID **sans vérifier le propriétaire** → un user authentifié pouvait lire le jardin de n'importe qui (escalade horizontale, exposition de données perso).

- Récupération du `uid` depuis le contexte, `401` si absent
- Filtre Mongo : `{"_id": objectID}` → `{"_id": objectID, "uid": uid}`
- Message 404 harmonisé (« non trouvé ou accès refusé ») pour ne pas divulguer l'existence d'un jardin d'autrui
- Aligné sur le pattern déjà en place dans `updateGarden` / `deleteGarden`

## Closes #223 — Token Firebase + logs de PII en release
- Suppression du `print("🔑 Firebase Token:", token)` dans `ModernLoginView` (visible en clair dans les logs device, non gardé)
- Logs PII restants gardés par `#if DEBUG` (invisibles en release) :
  - `ModernLoginView` — dump `error` / `userInfo` Firebase
  - `GoogleAuthService` — email Google
  - `AppleAuthService` — email Apple
  - `saveAuthDB` — uid
  - `NetworkManager` (×2) — corps de réponse API brut

## Validation
- `go build` / `go vet` OK
- **Tests backend verts** (`go test ./...`)
- Équilibre `#if DEBUG` / `#endif` vérifié ; plus aucun print de token

## Hors scope
`project.pbxproj` et `Info.plist` (déjà modifiés sur la working copy avant ce travail) ne sont volontairement pas inclus.