### PR TITLE
fix(ios): add NSPhotoLibraryUsageDescription to Info.plist

### DIFF
--- a/ArboreUi/ArboreUi/Info.plist
+++ b/ArboreUi/ArboreUi/Info.plist
@@ -70,6 +70,8 @@
 	<string>Nécessaire pour calculer la position du soleil par rapport à votre fenêtre.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>L'application a besoin d'accéder au microphone pour certaines fonctionnalités.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Arbore accède à vos photos pour définir votre photo de profil.</string>
 	<key>NSWorldSensingUsageDescription</key>
 	<string>Nous utilisons le scanner LiDAR pour créer un plan 3D précis de votre espace.</string>
 	<key>SENTRY_DSN_HOST</key>


### PR DESCRIPTION
## Closes #225 — `NSPhotoLibraryUsageDescription` manquant (rejet App Store)

Le flow photo de profil utilise `PHPickerViewController` (`Views/Profile/ProfileComponents.swift`), mais `Info.plist` ne déclarait aucune description d'usage de la photothèque → **rejet automatique** à la review App Store.

Ajout de la clé avec une description localisée FR, rangée alphabétiquement entre `NSMicrophoneUsageDescription` et `NSWorldSensingUsageDescription` :

```xml
<key>NSPhotoLibraryUsageDescription</key>
<string>Arbore accède à vos photos pour définir votre photo de profil.</string>
```

## Validation
- `plutil -lint Info.plist` → OK
- `plutil -extract NSPhotoLibraryUsageDescription` → chaîne présente

## Hors scope
Le bump `CFBundleVersion` et `project.pbxproj` (déjà modifiés sur la working copy) ne sont volontairement pas inclus dans ce commit.