### PR TITLE
fix(ios): gate Sentry on diagnostic consent + scrub PII before send

### DIFF
--- a/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
@@ -14,7 +14,9 @@ import GoogleSignInSwift
 class AppDelegate: NSObject, UIApplicationDelegate{
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool{
         // Sentry en premier (issue #205), AVANT Firebase, pour capturer aussi un
-        // éventuel crash pendant l'init de Firebase. No-op si pas de DSN.
+        // éventuel crash pendant l'init de Firebase. No-op si pas de DSN ou si
+        // l'utilisateur n'a pas consenti au diagnostic (opt-in RGPD, issue #226) ;
+        // réactivé par SentryManager.updateConsent dès qu'il accepte.
         SentryManager.start()
 
         FirebaseApp.configure()

--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -15,24 +15,42 @@ import Sentry
 
 enum SentryManager {
 
-    /// Vrai si un DSN est configuré → crash reporting actif.
-    static var isEnabled: Bool { !AppConfig.sentryDSN.isEmpty }
+    /// Clé `AppStorage` du consentement diagnostic/analytics (toggle « Partage
+    /// de données » dans PrivacySettingsView). Absente = `false` : opt-out par
+    /// défaut, Sentry ne démarre pas tant que l'utilisateur n'a pas accepté.
+    private static let consentKey = "privacy_shareData"
 
-    /// Démarre Sentry. À appeler tout au début de
-    /// `AppDelegate.didFinishLaunchingWithOptions`, AVANT
-    /// `FirebaseApp.configure()`, afin de capturer aussi un éventuel crash
-    /// pendant l'init de Firebase.
+    /// Vrai si un DSN est configuré dans Secrets.xcconfig.
+    static var isConfigured: Bool { !AppConfig.sentryDSN.isEmpty }
+
+    /// Vrai si l'utilisateur a consenti au partage des données de diagnostic.
+    static var hasConsent: Bool { UserDefaults.standard.bool(forKey: consentKey) }
+
+    /// Vrai si le crash reporting doit être actif : DSN présent ET consentement donné.
+    static var isEnabled: Bool { isConfigured && hasConsent }
+
+    /// Démarre Sentry si (et seulement si) un DSN est configuré ET que
+    /// l'utilisateur a donné son consentement diagnostic. Appelée au tout début
+    /// de `AppDelegate.didFinishLaunchingWithOptions`, AVANT
+    /// `FirebaseApp.configure()`, pour capturer un éventuel crash d'init — mais
+    /// sans consentement c'est un no-op (RGPD : aucune collecte avant opt-in).
+    /// Re-déclenchée par `updateConsent(...)` quand l'utilisateur accepte.
     static func start() {
-        let dsn = AppConfig.sentryDSN
-        guard !dsn.isEmpty else {
+        guard isConfigured else {
             #if DEBUG
             print("ℹ️ Sentry désactivé (aucun DSN dans Secrets.xcconfig).")
             #endif
             return
         }
+        guard hasConsent else {
+            #if DEBUG
+            print("ℹ️ Sentry en attente du consentement diagnostic (opt-in RGPD).")
+            #endif
+            return
+        }
 
         SentrySDK.start { options in
-            options.dsn = dsn
+            options.dsn = AppConfig.sentryDSN
             options.environment = AppConfig.environment
             options.releaseName = AppConfig.sentryReleaseName
             options.dist = AppConfig.buildNumber
@@ -47,9 +65,41 @@ enum SentryManager {
             options.attachScreenshot = false
             options.attachViewHierarchy = true
 
+            // Minimisation RGPD : ne jamais joindre les PII collectées « par
+            // défaut » par le SDK (adresse IP, etc.).
+            options.sendDefaultPii = false
+
+            // Défense en profondeur : on retire explicitement de chaque event
+            // l'IP, l'identité (e-mail/nom) et le payload de requête avant
+            // envoi. On conserve volontairement `user.userId` = UID Firebase,
+            // pseudonyme nécessaire pour corréler les crashs d'un même compte.
+            options.beforeSend = { event in
+                event.user?.ipAddress = nil
+                event.user?.email = nil
+                event.user?.username = nil
+                event.user?.name = nil
+                event.user?.data = nil
+                event.serverName = nil
+                event.request = nil
+                return event
+            }
+
             #if DEBUG
             options.debug = true
             #endif
+        }
+    }
+
+    /// Réagit à un changement du consentement diagnostic depuis
+    /// PrivacySettingsView : démarre Sentry à l'acceptation (et réattache le
+    /// contexte user si l'utilisateur était déjà connecté), le coupe au retrait.
+    static func updateConsent(granted: Bool, uid: String?) {
+        guard isConfigured else { return }
+        if granted {
+            if !SentrySDK.isEnabled { start() }
+            if let uid { setUser(uid: uid) }
+        } else {
+            SentrySDK.close()
         }
     }
 

--- a/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
@@ -68,6 +68,9 @@ struct PrivacySettingsView: View {
                 )
                 .onChange(of: shareData) { _, newValue in
                     recordConsentChange(type: "analytics", granted: newValue)
+                    // Ce toggle gouverne le crash reporting Sentry : on démarre /
+                    // coupe le SDK selon le consentement diagnostic (issue #226).
+                    SentryManager.updateConsent(granted: newValue, uid: Auth.auth().currentUser?.uid)
                 }
             }
 


### PR DESCRIPTION
## Closes #226 — Consentement avant init Sentry + hook `beforeSend`

Sentry était initialisé **inconditionnellement avant tout consentement** (RGPD Art. 7), et sans filtrage des PII.

### Consentement (opt-in)
Sentry est désormais gouverné par le consentement diagnostic/analytics existant — le toggle **« Partage de données »** (`privacy_shareData`, **opt-out par défaut**, type de consentement `"analytics"`) :
- `SentryManager.start()` devient un **no-op tant que l'utilisateur n'a pas consenti** (gardé par `isConfigured && hasConsent`).
- Le toggle dans `PrivacySettingsView` démarre / coupe le SDK **à chaud** via `updateConsent(granted:uid:)` (`SentrySDK.start` / `SentrySDK.close`), et réattache le contexte user (UID) si l'utilisateur était déjà connecté.
- `AppDelegate` appelle toujours `start()` au lancement (commentaire mis à jour) : capture des crashs d'init **uniquement** si l'utilisateur a déjà consenti.

### Minimisation des PII
- `options.sendDefaultPii = false`
- hook `options.beforeSend` qui retire de **chaque event** : `user.ipAddress`, `email`, `username`, `name`, `user.data`, `serverName`, `request` (payload).
- On conserve volontairement `user.userId` = **UID Firebase** (pseudonyme) pour corréler les crashs d'un même compte.

## Validation
- **`xcodebuild` simulateur (iPhone 17 Pro) → BUILD SUCCEEDED** avec les nouvelles API
- API confirmées sur sentry-cocoa 8.58.3 : `beforeSend`, `sendDefaultPii`, `SentrySDK.isEnabled`, `SentrySDK.close()`

## Note produit (non bloquant)
Le libellé du toggle « Partage de données » pourrait être précisé pour mentionner explicitement le **crash reporting / diagnostic** (consentement éclairé). À arbitrer côté copy/légal — les strings vivent dans le repo site.

## Hors scope
Le bump `CFBundleVersion` et `project.pbxproj` (déjà modifiés sur la working copy) ne sont pas inclus.