### PR TITLE
fix(ios): drop insecure ATS HTTP exception and hardcoded origin IP

### DIFF
--- a/ArboreUi/ArboreUi/Config/AppConfig.swift
+++ b/ArboreUi/ArboreUi/Config/AppConfig.swift
@@ -40,17 +40,11 @@ struct AppConfig {
             return "\(protocolScheme)://\(host)"
         }
 
-        #if DEBUG
-        // Fallback en développement — l'IP directe en HTTP reste utile
-        // pour le travail local. L'exception ATS dans Info.plist autorise
-        // ce host précis, uniquement en DEBUG.
-        return "http://79.137.92.154:8080"
-        #else
-        // Fallback en release — HTTPS via Cloudflare obligatoire (#121).
-        // Le TLD .app impose HSTS preload : URLSession refuserait HTTP
-        // de toute façon, donc ne jamais retomber sur l'IP nue en prod.
+        // Fallback HTTPS via Cloudflare (#121), en DEBUG comme en release :
+        // l'accès direct à l'origine est fermé par le firewall, on passe donc
+        // toujours par api.arbore.app. Le TLD .app impose HSTS preload —
+        // URLSession refuserait de toute façon tout HTTP.
         return "https://api.arbore.app"
-        #endif
     }()
 
     // MARK: - API Endpoints

--- a/ArboreUi/ArboreUi/Info.plist
+++ b/ArboreUi/ArboreUi/Info.plist
@@ -45,19 +45,6 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>79.137.92.154</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<false/>
-			</dict>
-		</dict>
-	</dict>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Arbore utilise ton calendrier pour planifier les rappels d'arrosage de tes plantes.</string>
 	<key>NSCalendarsUsageDescription</key>

--- a/ArboreUi/ArboreUi/Views/PlantCard.swift
+++ b/ArboreUi/ArboreUi/Views/PlantCard.swift
@@ -8,10 +8,8 @@ struct PlantCard: View {
 
     private let cardHeight: CGFloat = 220
 
-    private let backendBaseURL = "http://79.137.92.154:8080"
-
     private var thumbnailURL: URL? {
-        URL(string: "\(backendBaseURL)/models/thumbnails/\(plant.id).png")
+        URL(string: "\(AppConfig.baseURL)/models/thumbnails/\(plant.id).png")
     }
 
     var body: some View {


### PR DESCRIPTION
## Closes #224 — Exception ATS HTTP + IP de dev en dur

Suppression de l'autorisation de trafic **HTTP en clair** vers l'IP de l'origine `79.137.92.154` (risque MITM + motif de rejet App Store). Tout passe désormais en **HTTPS via `api.arbore.app`**, en DEBUG comme en release — l'accès direct à l'origine étant de toute façon fermé par le firewall (Cloudflare-only).

### Changements
- **`Info.plist`** : suppression complète du bloc `NSAppTransportSecurity` → ATS par défaut (HTTPS obligatoire, aucune exception).
- **`AppConfig.baseURL`** : le fallback DEBUG pointait sur `http://79.137.92.154:8080` → désormais `https://api.arbore.app` (DEBUG = prod, demandé). Les deux branches `#if DEBUG/#else` étant identiques, le fallback est unifié.
- **`PlantCard`** : URL des thumbnails via `AppConfig.baseURL` au lieu de `http://79.137.92.154:8080` en dur.

### Validation
- **`xcodebuild` simulateur → BUILD SUCCEEDED**
- `plutil -lint` OK ; plus aucune occurrence de `79.137.92.154` ni de `NSAppTransportSecurity` dans le code/plist
- Contexte infra : CF→origine désormais en TLS Full (strict), `:80/:443/:8080/:8000` verrouillés

### Note
Les builds DEBUG tapent maintenant la prod (`api.arbore.app`). Pour bosser contre un backend local : surcharger `ARBORE_BACKEND_PROTOCOL`/`ARBORE_BACKEND_HOST` dans Secrets.xcconfig, ou tunnel SSH.