### PR TITLE
feat(ios): show terms/privacy agreement on signup and login

### DIFF
--- a/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
@@ -202,6 +202,38 @@ struct LoginView: View {
                                 .padding(.horizontal, 30)
                             }
 
+                            // Sign-in wrap : couvre l'email ET les SSO Apple/Google
+                            // (où le « sign in » crée le compte). Pas de checkbox —
+                            // l'action affirmative est le tap sur un bouton d'auth
+                            // (issue #227). Le consentement analytics/marketing est
+                            // géré à part, en opt-in (cf. PrivacySettings / #226).
+                            VStack(spacing: 4) {
+                                Text(NSLocalizedString("AUTH_AGREE_CONTINUE", comment: ""))
+                                    .foregroundColor(ArboreDesign.Colors.textSecondary)
+
+                                HStack(spacing: 4) {
+                                    NavigationLink(destination: TermsConditionsView()) {
+                                        Text(NSLocalizedString("AUTH_AGREE_TERMS", comment: ""))
+                                            .foregroundColor(ArboreDesign.Colors.primaryGreen)
+                                            .underline()
+                                    }
+
+                                    Text(NSLocalizedString("AUTH_AGREE_AND", comment: ""))
+                                        .foregroundColor(ArboreDesign.Colors.textSecondary)
+
+                                    NavigationLink(destination: PrivacyPolicyView()) {
+                                        Text(NSLocalizedString("AUTH_AGREE_PRIVACY", comment: ""))
+                                            .foregroundColor(ArboreDesign.Colors.primaryGreen)
+                                            .underline()
+                                    }
+                                }
+                            }
+                            .font(.footnote)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity)
+                            .padding(.horizontal, 30)
+                            .padding(.top, 12)
+
                             HStack {
                                 Text("Don’t have an account?")
                                     .foregroundColor(ArboreDesign.Colors.textSecondary)

--- a/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
@@ -180,21 +180,21 @@ struct SignUpView: View {
                     }
 
                     VStack(spacing: 4) {
-                        Text("By signing up, you agree to Arbore’s")
+                        Text(NSLocalizedString("AUTH_AGREE_SIGNUP", comment: ""))
                             .foregroundColor(ArboreDesign.Colors.textSecondary)
 
                         HStack(spacing: 4) {
                             NavigationLink(destination: TermsConditionsView()) {
-                                Text("Terms & Conditions")
+                                Text(NSLocalizedString("AUTH_AGREE_TERMS", comment: ""))
                                     .foregroundColor(ArboreDesign.Colors.primaryGreen)
                                     .underline()
                             }
 
-                            Text("and")
+                            Text(NSLocalizedString("AUTH_AGREE_AND", comment: ""))
                                 .foregroundColor(ArboreDesign.Colors.textSecondary)
 
                             NavigationLink(destination: PrivacyPolicyView()) {
-                                Text("Privacy Policy")
+                                Text(NSLocalizedString("AUTH_AGREE_PRIVACY", comment: ""))
                                     .foregroundColor(ArboreDesign.Colors.primaryGreen)
                                     .underline()
                             }

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -752,6 +752,13 @@
 "SIGNUP_ACCEPT" = "Ich akzeptiere ";
 "SIGNUP_TERMS" = "die Nutzungsbedingungen";
 "SIGNUP_PRIVACY" = "die Datenschutzerklärung";
+
+// Auth — Zustimmung zu Nutzungsbedingungen/Datenschutz bei Registrierung + Login/SSO (issue #227)
+"AUTH_AGREE_SIGNUP" = "Mit der Registrierung akzeptierst du unsere";
+"AUTH_AGREE_CONTINUE" = "Wenn du fortfährst, akzeptierst du unsere";
+"AUTH_AGREE_TERMS" = "Nutzungsbedingungen";
+"AUTH_AGREE_AND" = "und unsere";
+"AUTH_AGREE_PRIVACY" = "Datenschutzerklärung";
 "SIGNUP_BACKEND_UNAVAILABLE" = "Registrierung konnte nicht abgeschlossen werden. Verbindung prüfen und erneut versuchen.";
 "SIGNUP_BACKEND_UNAUTHORIZED" = "Registrierung vom Server abgelehnt. Aktualisiere die App und versuche es erneut.";
 "SIGNUP_BACKEND_AUTH_ISSUE" = "Authentifizierungsproblem. Bitte gleich erneut versuchen.";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -770,6 +770,13 @@
 "SIGNUP_ACCEPT" = "I accept the ";
 "SIGNUP_TERMS" = "Terms of Service";
 "SIGNUP_PRIVACY" = "Privacy Policy";
+
+// Auth — terms/privacy agreement shown on signup + login/SSO (issue #227)
+"AUTH_AGREE_SIGNUP" = "By signing up, you agree to our";
+"AUTH_AGREE_CONTINUE" = "By continuing, you agree to our";
+"AUTH_AGREE_TERMS" = "Terms & Conditions";
+"AUTH_AGREE_AND" = "and";
+"AUTH_AGREE_PRIVACY" = "Privacy Policy";
 "SIGNUP_BACKEND_UNAVAILABLE" = "Couldn’t complete signup. Check your connection and try again.";
 "SIGNUP_BACKEND_UNAUTHORIZED" = "Signup rejected by the server. Update the app and try again.";
 "SIGNUP_BACKEND_AUTH_ISSUE" = "Authentication issue. Please try again in a moment.";

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -748,6 +748,13 @@
 "SIGNUP_ACCEPT" = "Acepto ";
 "SIGNUP_TERMS" = "los Términos de Servicio";
 "SIGNUP_PRIVACY" = "la Política de Privacidad";
+
+// Auth — aceptación de Términos/Privacidad en registro + inicio sesión/SSO (issue #227)
+"AUTH_AGREE_SIGNUP" = "Al registrarte, aceptas nuestras";
+"AUTH_AGREE_CONTINUE" = "Al continuar, aceptas nuestras";
+"AUTH_AGREE_TERMS" = "Condiciones de Uso";
+"AUTH_AGREE_AND" = "y nuestra";
+"AUTH_AGREE_PRIVACY" = "Política de Privacidad";
 "SIGNUP_BACKEND_UNAVAILABLE" = "No se pudo completar el registro. Comprueba tu conexión y vuelve a intentarlo.";
 "SIGNUP_BACKEND_UNAUTHORIZED" = "Registro rechazado por el servidor. Actualiza la app y vuelve a intentarlo.";
 "SIGNUP_BACKEND_AUTH_ISSUE" = "Problema de autenticación. Inténtalo de nuevo en un instante.";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -895,6 +895,13 @@
 "SIGNUP_ACCEPT" = "J'accepte ";
 "SIGNUP_TERMS" = "les Conditions Générales d'Utilisation";
 "SIGNUP_PRIVACY" = "la Politique de Confidentialité";
+
+// Auth — accord CGU/Confidentialité affiché au signup + login/SSO (issue #227)
+"AUTH_AGREE_SIGNUP" = "En vous inscrivant, vous acceptez nos";
+"AUTH_AGREE_CONTINUE" = "En continuant, vous acceptez nos";
+"AUTH_AGREE_TERMS" = "Conditions Générales d'Utilisation";
+"AUTH_AGREE_AND" = "et notre";
+"AUTH_AGREE_PRIVACY" = "Politique de Confidentialité";
 "SIGNUP_BACKEND_UNAVAILABLE" = "Impossible de finaliser l’inscription. Vérifie ta connexion et réessaie.";
 "SIGNUP_BACKEND_UNAUTHORIZED" = "Inscription refusée par le serveur. Mets à jour l’app puis réessaie.";
 "SIGNUP_BACKEND_AUTH_ISSUE" = "Problème d’authentification. Réessaie dans un instant.";


### PR DESCRIPTION
## Closes #227 — Consentement aux CGU/Confidentialité à l'auth

Implémente le pattern **« sign-up wrap »** (sans checkbox), conforme RGPD + App Store.

### Pourquoi pas de checkbox (vérifié)
Accepter les CGU/Politique = formation d'un **contrat** → base légale **Art. 6(1)(b) « nécessité contractuelle »**, *pas* le consentement. Le « En vous inscrivant/continuant, vous acceptez… » + liens est valide et standard (Google/Apple/Meta font pareil). Apple ne mandate pas de checkbox, juste une action affirmative (le tap sur un bouton d'auth).

Le **consentement RGPD Art. 7** (qui lui exige un opt-in séparé non pré-coché) ne concerne que analytics/marketing — **déjà gérés à part** en opt-in (Sentry off par défaut #226, marketing off, permissions iOS pour caméra/photos/localisation). C'est *grâce à* cette séparation que le sign-up wrap est suffisant.

### Changements
- **`LoginView`** (écran d'entrée réel : email + **SSO Apple/Google**, où le sign-in crée le compte) : ajout de la mention « By continuing, you agree to our [Terms] and [Privacy] » sous les boutons d'auth. C'était le **vrai trou** — aucune mention auparavant.
- **`SignUpView`** : la mention existait mais **hardcodée en anglais** → localisée.
- Nouvelles strings `AUTH_AGREE_*` en **4 langues** (en/fr/es/de), liens Terms/Privacy cliquables (`NavigationLink` vers `TermsConditionsView`/`PrivacyPolicyView`).

### Validation
- **`xcodebuild` simulateur → BUILD SUCCEEDED**
- `plutil -lint` OK sur les 4 `Localizable.strings`

### Note
Wording modifiable dans `*.lproj/Localizable.strings` (clés `AUTH_AGREE_*`) si tu veux ajuster la formulation.