### PR TITLE
chore(security): gitignore .deepl_api and drop hardcoded Mongo fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,7 +190,8 @@ fastlane/.env.local
 # locale `bundle config set --local path 'vendor/bundle'`.
 .bundle/
 
-# Deepl translations
+# Deepl translations — API key + its backups, never commit
+.deepl_api
 .deepl_api.backups/
 backups/
 

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1349,14 +1349,12 @@ func loadDotEnv(path string) {
 func main() {
 	loadDotEnv(".env")
 
-	// ✅ Recommandé: passe l'URI via env
+	// L'URI Mongo est obligatoire et passée par l'environnement
+	// (.env ou variable système) — jamais de credentials en dur dans le code.
 	// export MONGODB_URI="mongodb+srv://..."
 	uri := os.Getenv("MONGODB_URI")
-
-	// ⚠️ Fallback (si tu veux garder ton test local):
 	if uri == "" {
-		// nolint:gosec // This is a fallback for local development only
-		uri = "mongodb+srv://hugorath1234:hugopapa@arbore.cew6l.mongodb.net/arbore?retryWrites=true&w=majority&appName=Arbore"
+		log.Fatal("❌ MONGODB_URI non défini : renseigne-le dans l'environnement avant de démarrer le backend.")
 	}
 
 	clientOptions := options.Client().ApplyURI(uri)


### PR DESCRIPTION
## Closes #228 — Hygiène secrets

- **`.gitignore`** : ajout de `.deepl_api` (fichier clé DeepL) — non tracké aujourd'hui mais non protégé, donc risque de commit accidentel. Désormais ignoré (`git check-ignore .deepl_api` ✓).
- **`main.go`** : suppression de l'URI MongoDB hardcodée en fallback. `MONGODB_URI` est maintenant **obligatoire** (env/.env) ; le backend `log.Fatal` si absent. Plus aucun credential en dur dans le code.

Note : le compte Mongo concerné a déjà été supprimé (pas de fuite active) — ce changement est de l'hygiène pour ne plus avoir de credential en clair dans la source.

### Validation
- `go build` / `go vet` OK
- **`go test ./... -count=1` → verts** (fresh run)
- `git check-ignore .deepl_api` → ignoré ; plus aucune occurrence de `hugorath1234`/`mongodb+srv://hugo`