### PR TITLE
fix(ios): hide manage-subscription CTA on the Ultra (beta) plan

### DIFF
--- a/ArboreUi/ArboreUi/Views/Profile/ProfileView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/ProfileView.swift
@@ -184,15 +184,21 @@ struct ProfileView: View {
             SubscriptionPlanCard(currentPlanName: currentPlanLevel)
                 .environmentObject(themeManager)
 
-            Button(action: { showUpgradeSheet = true }) {
-                HStack(spacing: ArboreDesign.Spacing.xs) {
-                    Image(systemName: ctaIcon)
-                    Text(ctaText)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.86)
+            // En beta, tous les utilisateurs sont sur « Ultra » : on leur montre
+            // qu'ils testent la version complète, mais sans CTA « Gérer
+            // l'abonnement » (aucun abonnement réel à gérer, pas d'IAP). Le
+            // bouton n'apparaît que s'il y a un vrai upgrade à proposer.
+            if currentPlanLevel != "Ultra" {
+                Button(action: { showUpgradeSheet = true }) {
+                    HStack(spacing: ArboreDesign.Spacing.xs) {
+                        Image(systemName: ctaIcon)
+                        Text(ctaText)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.86)
+                    }
                 }
+                .buttonStyle(.arborePrimary)
             }
-            .buttonStyle(.arborePrimary)
         }
         .fullScreenCover(isPresented: $showUpgradeSheet) {
             UpgradePlanView().environmentObject(themeManager)


### PR DESCRIPTION
## Closes #235 (scope ajusté)

Décision produit : **on garde « Ultra »** — le but est de montrer au beta-testeur qu'il teste la version complète. On ne neutralise donc pas l'affichage du plan ni le `"Ultra"` forcé. On masque seulement le **CTA « Gérer l'abonnement »**, car il n'y a aucun abonnement réel à gérer (pas d'IAP en beta).

### Changement
`Views/Profile/ProfileView.swift` — le bouton upgrade/manage ne s'affiche que `if currentPlanLevel != "Ultra"`. La carte de plan continue d'afficher « Ultra ».

### Effet de bord positif
Comme tous les utilisateurs sont sur « Ultra », ce bouton était la **seule** entrée vers `UpgradePlanView` (le paywall placeholder avec les prix `« 4,99 € »` en dur). Il devient donc **inatteignable** depuis le profil → supprime le risque App Store d'afficher un pricing non fonctionnel, sans rien retirer d'autre.

### Validation
- **`xcodebuild` simulateur → BUILD SUCCEEDED** (aucun warning)

### Reste de #235 abandonné
Le « retirer le plan Ultra » initial est volontairement **non fait** (Ultra = messaging beta intentionnel).