### PR TITLE
feat(privacy): initial consent snapshot at signup + privacy-by-default (#218)

### DIFF
--- a/ArboreUi/ArboreUi/Config/ConsentDefaults.swift
+++ b/ArboreUi/ArboreUi/Config/ConsentDefaults.swift
@@ -1,0 +1,49 @@
+//
+//  ConsentDefaults.swift
+//  ArboreUi
+//
+//  Source unique des valeurs par défaut des consentements RGPD (issue #218).
+//  Référencée à la fois par `PrivacySettingsView` (defaults @AppStorage) et par
+//  la capture initiale au signup (`recordInitialConsents`) pour éviter toute
+//  divergence entre l'état réel des toggles et la preuve enregistrée.
+//
+
+import Foundation
+
+/// Valeurs par défaut des consentements, alignées sur le principe de
+/// **privacy by default** (RGPD Art. 25 / CJEU Planet49) : tout ce qui relève
+/// d'un consentement libre est `false` par défaut. Restent `true` uniquement :
+/// les traitements en base légale « contrat » (fonctionnalité cœur) et les
+/// toggles purement informatifs dont le vrai gate est une permission iOS.
+enum ConsentDefaults {
+    /// Profil privé par défaut — aucune exposition publique tant que l'utilisateur ne l'active pas.
+    static let profilePublic = false
+    /// Activité masquée par défaut.
+    static let showActivity = false
+    /// Diagnostics (Sentry) — opt-in strict (issue #226). Gate effectif : `SentryManager.hasConsent`.
+    static let analytics = false
+    /// Marketing — opt-in strict.
+    static let marketing = false
+    /// Caméra — informatif : le vrai consentement est la permission iOS (NSCameraUsageDescription).
+    static let camera = true
+    /// Suggestions / traitement IA — fonctionnalité cœur, base légale contrat (Art. 6(1)(b)),
+    /// pas un consentement. Le moteur de suggestion est local (aucun envoi de données tierces).
+    static let ai = true
+    /// Notifications — informatif : le vrai consentement est la permission iOS.
+    static let notifications = true
+
+    /// Snapshot ordonné (type backend ↔ valeur par défaut) capturé au premier
+    /// lancement / signup, pour disposer d'une preuve datée dès l'inscription
+    /// (accountability, RGPD Art. 5(2)) même si l'utilisateur n'ouvre jamais
+    /// l'écran Confidentialité. Les clés correspondent à `consent.consentType`
+    /// côté backend (`/consents`).
+    static let initialSnapshot: [(type: String, granted: Bool)] = [
+        ("profilePublic", profilePublic),
+        ("showActivity", showActivity),
+        ("analytics", analytics),
+        ("marketing", marketing),
+        ("camera", camera),
+        ("ai", ai),
+        ("notifications", notifications),
+    ]
+}

--- a/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
@@ -333,7 +333,7 @@ struct SignUpView: View {
                     )
 
                     // 2) Consentements RGPD (best-effort, on n'annule pas si ça loupe)
-                    recordInitialConsents(uid: user.uid, acceptedTerms: true, acceptedPrivacy: true)
+                    recordInitialConsents(uid: user.uid)
 
                     // 3) Envoyer l'email de vérification (best-effort aussi —
                     // l'utilisateur peut le renvoyer depuis l'écran de vérif)

--- a/ArboreUi/ArboreUi/LoginAuth/saveAuthDB.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/saveAuthDB.swift
@@ -90,58 +90,63 @@ func saveUserToBackendIfNeeded(uid: String, email: String, name: String, created
         let exists = await checkIfUserExists(uid: uid)
         if !exists {
             saveUserToBackend(uid: uid, email: email, name: name, createdAt: createdAt)
+            // Nouveau compte (SSO Google/Apple) → capture initiale des consentements (#218).
+            // L'inscription email passe par son propre appel dans SignUpView.
+            recordInitialConsents(uid: uid)
         } else {
             print("ℹ️ Utilisateur déjà existant dans MongoDB")
         }
     }
 }
 
-/// Enregistre les consentements initiaux (Terms + Privacy) lors de l'inscription
-func recordInitialConsents(uid: String, acceptedTerms: Bool, acceptedPrivacy: Bool) {
+/// Capture initiale des consentements au signup / première création de compte (issue #218).
+///
+/// - `terms` + `privacy` sont posés à `true` : l'inscription vaut acceptation
+///   (cf. le wrap « By signing up you agree… » de SignUpView / LoginView).
+/// - Les 7 consentements granulaires sont enregistrés à leur valeur **par défaut**
+///   (`ConsentDefaults`, privacy-by-default) afin de disposer d'une preuve datée
+///   dès l'inscription — accountability RGPD Art. 5(2) — même si l'utilisateur
+///   n'ouvre jamais l'écran Confidentialité.
+///
+/// Le backend dérive l'`uid` du token Firebase (le param sert au log) et exige
+/// `consentType` + `version` (cf. `recordConsent`, main.go) ; l'ancienne version
+/// envoyait `consentGiven`/`consentDate` sans `version` → 400 silencieux.
+func recordInitialConsents(uid: String) {
     Task {
-        do {
-            // Get user's IP address and user agent
-            let ipAddress = await getUserIPAddress()
-            let userAgent = "ArboreApp/iOS"
+        // IP + User-Agent récupérés une seule fois pour tout le snapshot.
+        let ipAddress = await getUserIPAddress()
+        let userAgent = "ArboreApp/iOS"
+        let version = AppConfig.privacyPolicyVersion
+        let timestamp = ISO8601DateFormatter().string(from: Date())
 
-            // Record Terms of Service consent
-            if acceptedTerms {
-                let termsConsent: [String: Any] = [
-                    "consentType": "terms",
-                    "consentGiven": true,
-                    "consentDate": ISO8601DateFormatter().string(from: Date()),
-                    "ipAddress": ipAddress,
-                    "userAgent": userAgent
-                ]
+        var snapshot: [(type: String, granted: Bool)] = [
+            ("terms", true),
+            ("privacy", true),
+        ]
+        snapshot.append(contentsOf: ConsentDefaults.initialSnapshot)
 
-                let _: ConsentResponse = try await NetworkManager.shared.request(
+        for entry in snapshot {
+            let body: [String: Any] = [
+                "consentType": entry.type,
+                "granted": entry.granted,
+                "version": version,
+                "timestamp": timestamp,
+                "ipAddress": ipAddress,
+                "userAgent": userAgent
+            ]
+            do {
+                try await NetworkManager.shared.requestNoResponse(
                     endpoint: "/consents",
                     method: .POST,
-                    body: termsConsent
+                    body: body
                 )
-                print("✅ Terms consent recorded")
+            } catch {
+                print("❌ Initial consent '\(entry.type)' failed:", error.localizedDescription)
             }
-
-            // Record Privacy Policy consent
-            if acceptedPrivacy {
-                let privacyConsent: [String: Any] = [
-                    "consentType": "privacy",
-                    "consentGiven": true,
-                    "consentDate": ISO8601DateFormatter().string(from: Date()),
-                    "ipAddress": ipAddress,
-                    "userAgent": userAgent
-                ]
-
-                let _: ConsentResponse = try await NetworkManager.shared.request(
-                    endpoint: "/consents",
-                    method: .POST,
-                    body: privacyConsent
-                )
-                print("✅ Privacy consent recorded")
-            }
-        } catch {
-            print("❌ Error recording consents:", error.localizedDescription)
         }
+        #if DEBUG
+        print("✅ Initial consent snapshot recorded (\(snapshot.count) types) for uid=\(uid)")
+        #endif
     }
 }
 

--- a/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
@@ -5,14 +5,17 @@ struct PrivacySettingsView: View {
     @EnvironmentObject var themeManager: ThemeManager
     @Environment(\.dismiss) var dismiss
 
-    // Consentements persistés localement avec AppStorage
-    @AppStorage("privacy_profilePublic") internal var profilePublic: Bool = true
-    @AppStorage("privacy_showActivity") internal var showActivity: Bool = true
-    @AppStorage("privacy_shareData") internal var shareData: Bool = false
-    @AppStorage("privacy_marketing") internal var marketingConsent: Bool = false
-    @AppStorage("privacy_camera") internal var cameraConsent: Bool = true
-    @AppStorage("privacy_ai") internal var aiConsent: Bool = true
-    @AppStorage("privacy_notifications") internal var notificationsConsent: Bool = true
+    // Consentements persistés localement avec AppStorage. Défauts = source unique
+    // ConsentDefaults (privacy-by-default, RGPD Art. 25 — issue #218). Ces défauts
+    // ne s'appliquent qu'aux clés absentes : les choix déjà faits par un utilisateur
+    // existant sont préservés.
+    @AppStorage("privacy_profilePublic") internal var profilePublic: Bool = ConsentDefaults.profilePublic
+    @AppStorage("privacy_showActivity") internal var showActivity: Bool = ConsentDefaults.showActivity
+    @AppStorage("privacy_shareData") internal var shareData: Bool = ConsentDefaults.analytics
+    @AppStorage("privacy_marketing") internal var marketingConsent: Bool = ConsentDefaults.marketing
+    @AppStorage("privacy_camera") internal var cameraConsent: Bool = ConsentDefaults.camera
+    @AppStorage("privacy_ai") internal var aiConsent: Bool = ConsentDefaults.ai
+    @AppStorage("privacy_notifications") internal var notificationsConsent: Bool = ConsentDefaults.notifications
 
     @State internal var showPrivacyPolicy: Bool = false
     @State internal var isSyncing: Bool = false


### PR DESCRIPTION
Closes #218. Suite de #67 (recueil/traçabilité des consentements) — couvre les 3 points de rigueur RGPD restants.

## 1. Capture initiale du consentement (accountability, Art. 5(2))
`recordInitialConsents` enregistre désormais un **snapshot daté complet à la création du compte** : `terms` + `privacy` (acceptés par l'acte d'inscription) + les **7 consentements granulaires** à leur valeur par défaut. Un utilisateur qui n'ouvre jamais l'écran Confidentialité a donc quand même une preuve datée dès l'inscription.
- Branché aussi sur le **chemin SSO** (`saveUserToBackendIfNeeded`, branche nouveau-compte) — avant, seule l'inscription email capturait quelque chose.

**Bug corrigé au passage** : l'ancienne version envoyait `consentGiven`/`consentDate` **sans `version`**, que le backend rejette (`400 — consentType et version requis`, `main.go:513`). Les consentements terms/privacy initiaux **ne persistaient donc jamais**. Corrigé → `consentType` + `granted` + `version` + `timestamp`.

## 2. Privacy by default (Art. 25 / CJEU Planet49)
`profilePublic` et `showActivity` passent à **`false`** par défaut. `analytics` et `marketing` étaient déjà en opt-in.
- Les défauts sont centralisés dans `ConsentDefaults` (source unique), référencés à la fois par `PrivacySettingsView` (`@AppStorage`) et par le snapshot initial → plus de divergence possible.
- Les choix déjà faits par un utilisateur existant sont préservés (le défaut ne s'applique qu'aux clés absentes).

## 3. Audit d'enforcement
- **analytics** → coupe/active Sentry : déjà câblé (`SentryManager.isEnabled = isConfigured && hasConsent`, #226). ✅
- **ai** → fonctionnalité cœur, base légale **contrat** (Art. 6(1)(b)). Le moteur de suggestion est **local** (aucun envoi tiers) → pas de gate consentement, conforme à la consigne de l'issue.
- **marketing / profilePublic / showActivity** → aucun chemin de traitement live aujourd'hui (pas d'emailing marketing, pas de profil public). Le défaut-off est la posture ; quand ces features arriveront, elles devront lire le consentement (`ConsentDefaults` / `/consents/latest`).
- **camera / notifications** → le vrai consentement est la permission iOS ; le toggle est informatif.

## À vérifier
- Build CI iOS (nouveau fichier `ConsentDefaults.swift` auto-inclus via le groupe synchronisé).
- Device : un nouveau signup (email + Google/Apple) doit produire 9 `ConsentRecord` dans `/consents` ; un compte existant garde ses choix.