### PR TITLE
fix(ci): satisfy golangci-lint on Apple revocation backend (#210)

### DIFF
--- a/ArboreBackend/apple_revocation.go
+++ b/ArboreBackend/apple_revocation.go
@@ -35,6 +35,7 @@ const appleAudience = "https://appleid.apple.com"
 // Endpoints OAuth Apple. Déclarés en var (et non const) pour être surchargés
 // par les tests (httptest). En prod ils pointent sur appleid.apple.com.
 var (
+	//nolint:gosec // G101 faux positif : URL d'endpoint OAuth public, pas un credential.
 	appleTokenURL  = "https://appleid.apple.com/auth/token"
 	appleRevokeURL = "https://appleid.apple.com/auth/revoke"
 )
@@ -72,6 +73,7 @@ func loadAppleSIWAConfig() (*appleSIWAConfig, error) {
 func loadApplePrivateKey() (*ecdsa.PrivateKey, error) {
 	var pemBytes []byte
 	if path := strings.TrimSpace(os.Getenv("APPLE_SIWA_KEY_PATH")); path != "" {
+		//nolint:gosec // G304 : chemin .p8 fourni par l'opérateur via env de confiance, pas un input utilisateur.
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("lecture APPLE_SIWA_KEY_PATH: %w", err)
@@ -188,7 +190,7 @@ func applePostForm(ctx context.Context, endpoint string, form url.Values, out in
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("apple %s: status %d: %s", endpoint, res.StatusCode, strings.TrimSpace(string(body)))

--- a/ArboreBackend/apple_revocation_test.go
+++ b/ArboreBackend/apple_revocation_test.go
@@ -5,12 +5,30 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v4"
 )
+
+// reqForm lit le corps x-www-form-urlencoded d'une requête de test sans passer
+// par r.ParseForm()/r.FormValue() (que gosec G120 flagge faute de limite de
+// taille — non pertinent ici, corps de test contrôlé).
+func reqForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := url.ParseQuery(string(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
 
 func newTestAppleConfig(t *testing.T) *appleSIWAConfig {
 	t.Helper()
@@ -63,19 +81,17 @@ func TestExchangeAuthorizationCode(t *testing.T) {
 	cfg := newTestAppleConfig(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatal(err)
-		}
-		if got := r.FormValue("grant_type"); got != "authorization_code" {
+		form := reqForm(t, r)
+		if got := form.Get("grant_type"); got != "authorization_code" {
 			t.Errorf("grant_type: %s", got)
 		}
-		if got := r.FormValue("code"); got != "the-auth-code" {
+		if got := form.Get("code"); got != "the-auth-code" {
 			t.Errorf("code: %s", got)
 		}
-		if got := r.FormValue("client_id"); got != cfg.clientID {
+		if got := form.Get("client_id"); got != cfg.clientID {
 			t.Errorf("client_id: %s", got)
 		}
-		if r.FormValue("client_secret") == "" {
+		if form.Get("client_secret") == "" {
 			t.Error("client_secret manquant")
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -120,11 +136,11 @@ func TestRevokeRefreshToken(t *testing.T) {
 	called := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		_ = r.ParseForm()
-		if got := r.FormValue("token"); got != "rt-to-revoke" {
+		form := reqForm(t, r)
+		if got := form.Get("token"); got != "rt-to-revoke" {
 			t.Errorf("token: %s", got)
 		}
-		if got := r.FormValue("token_type_hint"); got != "refresh_token" {
+		if got := form.Get("token_type_hint"); got != "refresh_token" {
 			t.Errorf("token_type_hint: %s", got)
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Le job `backend` de la CI échoue sur `c1a1e64` (#210 mergée) — **pas un échec de build/test** (`go build`/`vet`/`test` passent) mais le gate **golangci-lint** (gosec + errcheck) sur le nouveau code Apple.

## Corrections
- **errcheck** : `res.Body.Close()` non vérifié → `defer func() { _ = res.Body.Close() }()`.
- **gosec G101** (faux positif « hardcoded credentials » sur `appleTokenURL`, dont le nom contient « token ») → `//nolint:gosec` avec justification : c'est une URL d'endpoint OAuth public, pas un credential.
- **gosec G304** (`os.ReadFile(APPLE_SIWA_KEY_PATH)`) → `//nolint:gosec` : chemin `.p8` fourni par l'opérateur via env de confiance.
- **gosec G120** dans les tests (`ParseForm`/`FormValue` sans limite de taille) → lecture du corps via `io.ReadAll` + `url.ParseQuery` (helper `reqForm`), plus de `ParseForm`.

## Validé en local
- `golangci-lint run ./...` → **0 issues** (golangci-lint v2.11.3, config du projet).
- `go test ./...` → pass.

Note : `ios_ui` passait déjà sur le merge de #241 ; l'échec du run global venait uniquement de ce job `backend`.