### PR TITLE
fix(ios): native Sign in with Apple button (HIG compliance, Guideline 4.8)

### DIFF
--- a/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppleAuthService.swift
@@ -41,18 +41,130 @@ final class AppleAuthService: NSObject, ObservableObject {
     /// l'enchaînement Firebase → backend → flip de `isLoggedIn`. La
     /// caller (vue SwiftUI) observe `isLoginSuccessed` pour réagir.
     func signInWithApple() {
-        let nonce = randomNonceString()
-        currentNonce = nonce
-
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        request.nonce = sha256(nonce)
+        configureRequest(request)
 
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
+    }
+
+    /// Configure une requête SIWA (scopes + nonce SHA-256) et mémorise le nonce
+    /// brut pour l'échange Firebase. Appelée par le bouton natif
+    /// `SignInWithAppleButton` (`onRequest`) ET par `signInWithApple()`.
+    func configureRequest(_ request: ASAuthorizationAppleIDRequest) {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+    }
+
+    /// Traite une autorisation SIWA réussie : échange Firebase → backend →
+    /// forward de l'authorization_code (#210) → flip `isLoggedIn`. Partagé par
+    /// le bouton natif (`onCompletion`) et le delegate `ASAuthorizationController`.
+    func handleAuthorization(_ authorization: ASAuthorization) {
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            print("❌ Apple Sign-In: credential is not an AppleIDCredential")
+            return
+        }
+        guard let nonce = currentNonce else {
+            // Programmer error : configureRequest n'a pas été appelée avant le
+            // callback. Crash en debug, log en release.
+            assertionFailure("Apple Sign-In callback without a prior request — nonce missing.")
+            return
+        }
+        guard let identityTokenData = appleCredential.identityToken,
+              let idTokenString = String(data: identityTokenData, encoding: .utf8) else {
+            print("❌ Apple Sign-In: identityToken missing or not UTF-8")
+            return
+        }
+
+        // #210 — authorization_code (à usage unique) pour la révocation Apple à
+        // la suppression du compte. Forwardé au backend après le signin Firebase.
+        let authorizationCode = appleCredential.authorizationCode
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        // Capture du nom (premier signup uniquement, sinon nil).
+        let firstName = appleCredential.fullName?.givenName ?? ""
+        let lastName = appleCredential.fullName?.familyName ?? ""
+        let fullName = [firstName, lastName].filter { !$0.isEmpty }.joined(separator: " ")
+        let appleEmail = appleCredential.email ?? ""
+
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: idTokenString,
+            rawNonce: nonce,
+            fullName: appleCredential.fullName
+        )
+
+        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+            if let error = error {
+                print("❌ Firebase Apple Auth Error:", error.localizedDescription)
+                return
+            }
+            guard let user = authResult?.user else {
+                print("❌ Firebase user is nil after Apple sign-in")
+                return
+            }
+
+            // Premier signup : Apple a fourni le nom. On le pousse à Firebase
+            // displayName (si pas déjà set) ET au backend Mongo. Aux signins
+            // suivants, fullName est nil — on trust ce qui existe déjà.
+            let resolvedName = fullName.isEmpty
+                ? (user.displayName ?? "")
+                : fullName
+            let resolvedEmail = user.email ?? appleEmail
+
+            if !fullName.isEmpty,
+               (user.displayName ?? "").isEmpty {
+                let change = user.createProfileChangeRequest()
+                change.displayName = fullName
+                change.commitChanges { commitError in
+                    if let commitError = commitError {
+                        print("⚠️ Failed to commit Firebase displayName for Apple user:", commitError.localizedDescription)
+                    }
+                    saveUserToBackendIfNeeded(
+                        uid: user.uid,
+                        email: resolvedEmail,
+                        name: resolvedName,
+                        createdAt: Date()
+                    )
+                }
+            } else {
+                saveUserToBackendIfNeeded(
+                    uid: user.uid,
+                    email: resolvedEmail,
+                    name: resolvedName,
+                    createdAt: Date()
+                )
+            }
+
+            // #210 — forward l'authorization_code (best-effort, hors chemin
+            // critique de login ; se ré-exécute aux signins suivants).
+            if let authorizationCode = authorizationCode, !authorizationCode.isEmpty {
+                linkAppleAccountWithBackend(authorizationCode: authorizationCode)
+            }
+
+            #if DEBUG
+            print("✅ Apple user signed in:", resolvedEmail.isEmpty ? "unknown" : resolvedEmail)
+            #endif
+
+            DispatchQueue.main.async {
+                self?.isLoginSuccessed = true
+                self?.isLoggedIn = true
+            }
+        }
+    }
+
+    /// Traite une erreur SIWA. L'annulation utilisateur (code 1001) est
+    /// silencieuse (comportement attendu). Partagé bouton natif + delegate.
+    func handleError(_ error: Error) {
+        if let asError = error as? ASAuthorizationError, asError.code == .canceled {
+            print("ℹ️ Apple Sign-In cancelled by user")
+            return
+        }
+        print("❌ Apple Sign-In Error:", error.localizedDescription)
     }
 
     /// Déconnexion symétrique du `GoogleAuthService.logout()`. Apple ne
@@ -107,111 +219,11 @@ final class AppleAuthService: NSObject, ObservableObject {
 extension AppleAuthService: ASAuthorizationControllerDelegate {
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
-            print("❌ Apple Sign-In: credential is not an AppleIDCredential")
-            return
-        }
-        guard let nonce = currentNonce else {
-            // Programmer error : signInWithApple n'a pas été appelée
-            // avant de recevoir un callback. Crash en debug, log en
-            // release.
-            assertionFailure("Apple Sign-In callback without a prior request — nonce missing.")
-            return
-        }
-        guard let identityTokenData = appleCredential.identityToken,
-              let idTokenString = String(data: identityTokenData, encoding: .utf8) else {
-            print("❌ Apple Sign-In: identityToken missing or not UTF-8")
-            return
-        }
-
-        // #210 — authorization_code (à usage unique) pour la révocation Apple à
-        // la suppression du compte. Forwardé au backend après le signin Firebase.
-        let authorizationCode = appleCredential.authorizationCode
-            .flatMap { String(data: $0, encoding: .utf8) }
-
-        // Capture du nom (premier signup uniquement, sinon nil).
-        let firstName = appleCredential.fullName?.givenName ?? ""
-        let lastName = appleCredential.fullName?.familyName ?? ""
-        let fullName = [firstName, lastName].filter { !$0.isEmpty }.joined(separator: " ")
-        let appleEmail = appleCredential.email ?? ""
-
-        let credential = OAuthProvider.appleCredential(
-            withIDToken: idTokenString,
-            rawNonce: nonce,
-            fullName: appleCredential.fullName
-        )
-
-        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
-            if let error = error {
-                print("❌ Firebase Apple Auth Error:", error.localizedDescription)
-                return
-            }
-            guard let user = authResult?.user else {
-                print("❌ Firebase user is nil after Apple sign-in")
-                return
-            }
-
-            // Premier signup : Apple a fourni le nom. On le pousse à
-            // Firebase displayName (si pas déjà set) ET au backend
-            // Mongo pour qu'il soit disponible côté profil. Aux
-            // signins suivants, fullName est nil — on trust ce qui
-            // existe déjà.
-            let resolvedName = fullName.isEmpty
-                ? (user.displayName ?? "")
-                : fullName
-            let resolvedEmail = user.email ?? appleEmail
-
-            if !fullName.isEmpty,
-               (user.displayName ?? "").isEmpty {
-                let change = user.createProfileChangeRequest()
-                change.displayName = fullName
-                change.commitChanges { commitError in
-                    if let commitError = commitError {
-                        print("⚠️ Failed to commit Firebase displayName for Apple user:", commitError.localizedDescription)
-                    }
-                    saveUserToBackendIfNeeded(
-                        uid: user.uid,
-                        email: resolvedEmail,
-                        name: resolvedName,
-                        createdAt: Date()
-                    )
-                }
-            } else {
-                saveUserToBackendIfNeeded(
-                    uid: user.uid,
-                    email: resolvedEmail,
-                    name: resolvedName,
-                    createdAt: Date()
-                )
-            }
-
-            // #210 — forward l'authorization_code pour permettre la révocation
-            // du compte Apple à la suppression. Best-effort, hors chemin critique
-            // de login ; se ré-exécute aux signins suivants (code frais à chaque
-            // fois) si le tout premier passage a couru avec la création du user.
-            if let authorizationCode = authorizationCode, !authorizationCode.isEmpty {
-                linkAppleAccountWithBackend(authorizationCode: authorizationCode)
-            }
-
-            #if DEBUG
-            print("✅ Apple user signed in:", resolvedEmail.isEmpty ? "unknown" : resolvedEmail)
-            #endif
-
-            DispatchQueue.main.async {
-                self?.isLoginSuccessed = true
-                self?.isLoggedIn = true
-            }
-        }
+        handleAuthorization(authorization)
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        // ASAuthorizationError.canceled (code 1001) = user a tapé Cancel
-        // dans la sheet Apple — comportement attendu, pas une erreur.
-        if let asError = error as? ASAuthorizationError, asError.code == .canceled {
-            print("ℹ️ Apple Sign-In cancelled by user")
-            return
-        }
-        print("❌ Apple Sign-In Error:", error.localizedDescription)
+        handleError(error)
     }
 }
 

--- a/ArboreUi/ArboreUi/LoginAuth/AppleSignInButton.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppleSignInButton.swift
@@ -1,0 +1,52 @@
+//
+//  AppleSignInButton.swift
+//  ArboreUi
+//
+//  Bouton « Sign in with Apple » NATIF (`SignInWithAppleButton`), conforme aux
+//  Human Interface Guidelines d'Apple : logo officiel, police San Francisco,
+//  libellé + localisation fournis par Apple, styles approuvés, proportions
+//  normées. Remplace les boutons custom à base du SF Symbol `apple.logo`
+//  (interdit hors bouton officiel par la licence SF Symbols / le trademark
+//  Apple) qui exposaient à un rejet App Store (Guideline 4.8 + design SIWA).
+//
+//  Câble la logique existante d'`AppleAuthService` (nonce + échange Firebase +
+//  forward de l'authorization_code pour la révocation #210) via
+//  `configureRequest` / `handleAuthorization` / `handleError`.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct AppleSignInButton: View {
+    @ObservedObject var appleAuth: AppleAuthService
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// Libellé Apple (localisé automatiquement). `.continue` = « Continuer avec
+    /// Apple » / « Continue with Apple », cohérent avec l'ancien texte.
+    var label: SignInWithAppleButton.Label = .continue
+    var height: CGFloat = 50
+    /// Style explicite. Si nil : choisi selon le `colorScheme` (blanc en dark,
+    /// noir en light). À forcer sur un écran au fond non-adaptatif (ex. ReAuth,
+    /// fond clair fixe → `.black`).
+    var style: SignInWithAppleButton.Style?
+
+    private var resolvedStyle: SignInWithAppleButton.Style {
+        style ?? (colorScheme == .dark ? .white : .black)
+    }
+
+    var body: some View {
+        SignInWithAppleButton(label) { request in
+            appleAuth.configureRequest(request)
+        } onCompletion: { result in
+            switch result {
+            case .success(let authorization):
+                appleAuth.handleAuthorization(authorization)
+            case .failure(let error):
+                appleAuth.handleError(error)
+            }
+        }
+        .signInWithAppleButtonStyle(resolvedStyle)
+        .frame(height: height)
+        .cornerRadius(ArboreDesign.Radius.button)
+    }
+}

--- a/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/LoginView.swift
@@ -166,21 +166,9 @@ struct LoginView: View {
                             .padding(.horizontal, 30)
 
                             VStack(spacing: 12) {
-                                Button(action: { appleAuth.signInWithApple() }) {
-                                    HStack {
-                                        Image(systemName: "apple.logo")
-                                            .resizable()
-                                            .frame(width: 18, height: 18)
-                                        Text("Continue with Apple")
-                                            .fontWeight(.medium)
-                                    }
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(ArboreDesign.Colors.textPrimary)
-                                    .foregroundColor(ArboreDesign.Colors.background)
-                                    .cornerRadius(ArboreDesign.Radius.button)
-                                }
-                                .padding(.horizontal, 30)
+                                // Bouton SIWA natif (conforme HIG) — cf. AppleSignInButton.
+                                AppleSignInButton(appleAuth: appleAuth)
+                                    .padding(.horizontal, 30)
 
                                 Button(action: {
                                     authViewModel.signInWithGoogle()

--- a/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/ModernLoginView.swift
@@ -248,13 +248,8 @@ struct ModernLoginView: View {
 
             // ── Boutons sociaux ───────────────────────────────────────
             VStack(spacing: 12) {
-                ArborSocialButton(
-                    title: "Continuer avec Apple",
-                    icon: "apple.logo",
-                    backgroundColor: themeManager.textColor,
-                    foregroundColor: themeManager.backgroundColor,
-                    action: { appleAuth.signInWithApple() }
-                )
+                // Bouton SIWA natif (conforme HIG) — cf. AppleSignInButton.
+                AppleSignInButton(appleAuth: appleAuth)
 
                 ArborSocialButton(
                     title: "Continuer avec Google",

--- a/ArboreUi/ArboreUi/LoginAuth/ReAuthView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/ReAuthView.swift
@@ -8,6 +8,7 @@ struct ReAuthView: View {
 
     @Environment(\.dismiss) var dismiss
     @StateObject private var authViewModel = AuthenticationView()
+    @StateObject private var appleAuth = AppleAuthService()
 
     @State private var email = ""
     @State private var password = ""
@@ -87,22 +88,14 @@ struct ReAuthView: View {
                             .padding(.horizontal, 30)
 
                             VStack(spacing: 12) {
-                                Button(action: {
-                                    // Apple sign-in logic to be implemented
-                                }) {
-                                    HStack {
-                                        Image(systemName: "apple.logo")
-                                            .resizable()
-                                            .frame(width: 18, height: 18)
-                                        Text("Continue with Apple")
-                                            .fontWeight(.medium)
+                                // Bouton SIWA natif (conforme HIG). Le re-signin
+                                // Apple rétablit une session récemment authentifiée,
+                                // ce qui satisfait l'exigence de re-auth Firebase
+                                // avant une action sensible (style .black : fond clair).
+                                AppleSignInButton(appleAuth: appleAuth, style: .black)
+                                    .onChange(of: appleAuth.isLoginSuccessed) { _, success in
+                                        if success { onSuccess() }
                                     }
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color.black)
-                                    .foregroundColor(.white)
-                                    .cornerRadius(10)
-                                }
 
                                 Button(action: handleGoogleDeletion) {
                                     HStack {

--- a/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/SignUpView.swift
@@ -215,21 +215,9 @@ struct SignUpView: View {
                     .padding(.horizontal, 30)
 
                     VStack(spacing: 12) {
-                        Button(action: { appleAuth.signInWithApple() }) {
-                            HStack {
-                                Image(systemName: "apple.logo")
-                                    .resizable()
-                                    .frame(width: 18, height: 18)
-                                Text("Continue with Apple")
-                                    .fontWeight(.medium)
-                            }
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(ArboreDesign.Colors.textPrimary)
-                            .foregroundColor(ArboreDesign.Colors.background)
-                            .cornerRadius(ArboreDesign.Radius.button)
-                        }
-                        .padding(.horizontal, 30)
+                        // Bouton SIWA natif (conforme HIG) — cf. AppleSignInButton.
+                        AppleSignInButton(appleAuth: appleAuth)
+                            .padding(.horizontal, 30)
 
                         Button(action: {
                             authViewModel.signInWithGoogle()


### PR DESCRIPTION
## Problème
Les boutons « Sign in with Apple » étaient des `Button` **custom** : `Image(systemName: "apple.logo")` + texte + style maison. Risque de **reject App Store** :
- le SF Symbol `apple.logo` est **interdit** par la licence SF Symbols / le trademark Apple en dehors du bouton officiel ;
- un bouton SIWA custom doit respecter des specs précises (logo, police San Francisco, libellé, couleurs, proportions).

Le **texte** (« Continue with Apple ») était OK ; le **logo + le style custom** étaient le problème.

## Fix
- **`AppleSignInButton`** (nouveau) : wrappe le **`SignInWithAppleButton` natif** SwiftUI → logo officiel, police SF, libellé **localisé par Apple**, styles approuvés (blanc sur écran sombre / noir sur fond clair), proportions normées. **Conforme par construction.**
- **`AppleAuthService`** : extraction de `configureRequest` / `handleAuthorization` / `handleError` pour que le bouton natif (`onRequest`/`onCompletion`) **et** l'ancien delegate `ASAuthorizationController` partagent la même logique (nonce + Firebase + forward de l'`authorization_code` #210). Rien de la logique métier ne change.
- Boutons remplacés dans **LoginView**, **SignUpView**, **ModernLoginView**.
- **ReAuthView** : le bouton Apple était un **stub mort** (`// to be implemented`) avec `apple.logo` → remplacé par le bouton natif, désormais **fonctionnel** (le re-signin Apple rétablit une session récemment authentifiée, ce qui satisfait l'exigence de re-auth Firebase avant suppression) **et conforme**.

## Vérifs
- **Zéro `apple.logo`** restant (hors commentaire).
- Le bouton Google et le composant `ArborSocialButton` sont inchangés.
- L'entitlement `com.apple.developer.applesignin` est déjà en place.
- Build iOS : à valider par la CI (`ios_ui`) — je n'ai pas pu compiler en local.

Closes la partie « conformité du bouton SIWA » du chemin App Store Review.