### PR TITLE
feat(web): custom Firebase authDomain in prod (web.arbore.app)

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,8 @@
+# Surcharge PRODUCTION (chargée par `next build`, NODE_ENV=production).
+# Config publique uniquement — aucun secret.
+#
+# authDomain custom : le popup Sign in with Apple / Google s'affiche sur
+# web.arbore.app (nginx proxifie /__/auth/ et /__/firebase/ vers
+# arbore-b1986.firebaseapp.com) au lieu du domaine Firebase par défaut.
+# En dev (`next dev`), .env garde firebaseapp.com (compatible localhost).
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=web.arbore.app


### PR DESCRIPTION
Pour que le popup SIWA/Google affiche **web.arbore.app** au lieu du domaine `*.firebaseapp.com` (spinner indigo).

- `web/.env.production` surcharge `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=web.arbore.app` (PROD uniquement).
- Dev (`next dev`) garde `firebaseapp.com` via `.env` → localhost OK.
- Côté VPS : nginx proxifie `/__/auth/` + `/__/firebase/` vers le handler Firebase.
- Côté consoles (fait) : Return URL Apple + redirect URI Google ajoutés pour `web.arbore.app/__/auth/handler`.