### PR TITLE
fix(web): revert Firebase authDomain so Apple sign-in works

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,8 +1,0 @@
-# Surcharge PRODUCTION (chargée par `next build`, NODE_ENV=production).
-# Config publique uniquement — aucun secret.
-#
-# authDomain custom : le popup Sign in with Apple / Google s'affiche sur
-# web.arbore.app (nginx proxifie /__/auth/ et /__/firebase/ vers
-# arbore-b1986.firebaseapp.com) au lieu du domaine Firebase par défaut.
-# En dev (`next dev`), .env garde firebaseapp.com (compatible localhost).
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=web.arbore.app


### PR DESCRIPTION
Le custom authDomain (`web.arbore.app`) casse Sign in with Apple : Apple renvoie le résultat en **form_post cross-site**, que le handler auto-hébergé/reverse-proxifié n'arrive pas à finaliser (limitation Firebase connue). Google marche (redirection GET). 

Retour à `authDomain = arbore-b1986.firebaseapp.com` → **Apple + Google marchent**. Seul effet : le popup d'auth réaffiche le domaine firebaseapp.com (cosmétique).

Config Apple (Services ID, return URLs) + Firebase (Services ID, Team/Key/Private key) toutes vérifiées correctes — c'est bien le handler proxifié le souci.