### PR TITLE
fix(web): restore custom authDomain (fix 'missing initial state')

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,8 @@
+# Surcharge PRODUCTION (chargée par `next build`, NODE_ENV=production).
+# Config publique uniquement — aucun secret.
+#
+# authDomain custom = MÊME origine que l'app (web.arbore.app) → évite le bug
+# "missing initial state" (partitionnement du sessionStorage entre l'app et
+# firebaseapp.com sur les navigateurs modernes). Requis pour que Google/email
+# fonctionnent de façon fiable. Le handler /__/auth/ est proxifié par nginx.
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=web.arbore.app


### PR DESCRIPTION
firebaseapp.com authDomain partitionne le sessionStorage (app vs firebase) → « missing initial state » sur tous les providers. Retour au custom authDomain same-origin (web.arbore.app) → Google + email fiables. Apple web = limitation connue du handler proxifié (marche en natif sur iOS).