### PR TITLE
feat(web): version in settings + graceful error/offline states (#23 #24)

### DIFF
--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import * as Sentry from '@sentry/nextjs';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 text-center">
+      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-arbore-danger/15">
+        <AlertTriangle className="h-9 w-9 text-arbore-danger" />
+      </div>
+      <h1 className="font-display text-2xl font-bold text-arbore-ink">Une erreur est survenue</h1>
+      <p className="mt-2 max-w-sm text-arbore-muted">
+        Quelque chose s&apos;est mal passé de notre côté. Réessayez, ou revenez à l&apos;accueil.
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <button onClick={reset} className="btn-arbore px-6 py-3">
+          <RotateCcw className="h-5 w-5" />
+          Réessayer
+        </button>
+        <Link href="/" className="btn-arbore-ghost px-6 py-3">
+          Accueil
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+// Capture les erreurs du root layout lui-même (remplace toute la page) — styles
+// inline car la CSS de l'app peut ne pas être chargée à ce niveau.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="fr">
+      <body
+        style={{
+          display: 'flex',
+          minHeight: '100vh',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#F0EEEA',
+          color: '#1B1F1A',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          textAlign: 'center',
+          padding: '1rem',
+          margin: 0,
+        }}
+      >
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 700, margin: 0 }}>Une erreur est survenue</h1>
+        <p style={{ marginTop: '.5rem', color: '#6E746B' }}>Réessayez, ou rechargez la page.</p>
+        <button
+          onClick={reset}
+          style={{
+            marginTop: '1.5rem',
+            borderRadius: 999,
+            background: '#234632',
+            color: '#fff',
+            padding: '.75rem 1.5rem',
+            fontWeight: 600,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          Réessayer
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Nunito } from 'next/font/google';
+import { OfflineBanner } from '@/components/shared/OfflineBanner';
 
 // Police d'affichage arrondie et chaleureuse (proche de SF Rounded utilisé par l'app iOS).
 // Le corps de texte utilise la pile système (-apple-system…) = SF sur les appareils Apple.
@@ -24,7 +25,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fr" className={display.variable}>
-      <body>{children}</body>
+      <body>
+        <OfflineBanner />
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { Leaf } from 'lucide-react';
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 text-center">
+      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-secondary">
+        <Leaf className="h-9 w-9 text-arbore-green" />
+      </div>
+      <p className="font-display text-6xl font-extrabold text-arbore-green">404</p>
+      <h1 className="mt-2 font-display text-2xl font-bold text-arbore-ink">Page introuvable</h1>
+      <p className="mt-2 max-w-sm text-arbore-muted">
+        Cette page n&apos;existe pas ou a été déplacée.
+      </p>
+      <Link href="/" className="btn-arbore mt-6 px-6 py-3">
+        Retour à l&apos;accueil
+      </Link>
+    </main>
+  );
+}

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -186,7 +186,9 @@ export default function ProfilePage() {
             </div>
           </section>
 
-          <p className="pt-2 text-center text-xs text-arbore-muted">Arbore — bêta publique</p>
+          <p className="pt-2 text-center text-xs text-arbore-muted">
+            Arbore Web · v{process.env.NEXT_PUBLIC_APP_VERSION} · bêta publique
+          </p>
         </div>
       </main>
       <Footer />

--- a/web/components/shared/OfflineBanner.tsx
+++ b/web/components/shared/OfflineBanner.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { WifiOff } from 'lucide-react';
+
+/** Bannière affichée quand le navigateur passe hors-ligne (#24). */
+export function OfflineBanner() {
+  const [offline, setOffline] = useState(false);
+
+  useEffect(() => {
+    const update = () => setOffline(!navigator.onLine);
+    update();
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  if (!offline) return null;
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-[70] flex items-center justify-center gap-2 bg-arbore-danger px-4 py-2 text-sm font-semibold text-white">
+      <WifiOff className="h-4 w-4 flex-shrink-0" />
+      Vous êtes hors ligne — certaines fonctionnalités sont indisponibles.
+    </div>
+  );
+}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,7 +1,12 @@
 const { withSentryConfig } = require('@sentry/nextjs');
+const pkg = require('./package.json');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Version de l'app exposée au bundle (affichée dans les paramètres). #23
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
   // Sortie autonome (server.js + node_modules minimal) → image Docker légère.
   output: 'standalone',
   eslint: {


### PR DESCRIPTION
**#23** : version de l'app (package.json) exposée via next.config + affichée en bas du profil.
**#24** : page 404 brandée, error boundary de route + global-error (remontés à Sentry), bannière hors-ligne (online/offline) dans le layout.

Closes #23. Closes #24.