### PR TITLE
perf(web): lazy-load images + responsive headings (#18 #14)

### DIFF
--- a/web/app/garden/calendar/page.tsx
+++ b/web/app/garden/calendar/page.tsx
@@ -224,7 +224,7 @@ export default function CalendarPage() {
                 Retour
               </button>
             </div>
-            <h1 className="text-5xl font-bold text-[#234632] mb-2">Calendrier d'Arrosage 📅</h1>
+            <h1 className="text-4xl md:text-5xl font-bold text-[#234632] mb-2">Calendrier d'Arrosage 📅</h1>
             <p className="text-lg text-arbore-muted">Planifiez et suivez l'arrosage de vos plantes</p>
           </motion.div>
 
@@ -333,7 +333,7 @@ export default function CalendarPage() {
                             >
                               <div className="flex items-center gap-3">
                                 {plant.imageURL ? (
-                                  <img src={plant.imageURL} alt={plant.name} className={`w-10 h-10 rounded-lg object-cover ${done ? 'opacity-50' : ''}`} />
+                                  <img loading="lazy" decoding="async" src={plant.imageURL} alt={plant.name} className={`w-10 h-10 rounded-lg object-cover ${done ? 'opacity-50' : ''}`} />
                                 ) : (
                                   <div className="w-10 h-10 rounded-lg bg-secondary flex items-center justify-center">
                                     <Leaf className="w-5 h-5 text-green-600" />

--- a/web/app/garden/catalogue/page.tsx
+++ b/web/app/garden/catalogue/page.tsx
@@ -98,7 +98,7 @@ export default function CataloguePage() {
                   {/* Image + overlay + nom (façon PlantCard iOS) */}
                   <div className="relative h-52 overflow-hidden bg-arbore-soft">
                     {plant.imageURLs?.[0] ? (
-                      <img
+                      <img loading="lazy" decoding="async"
                         src={plant.imageURLs[0]}
                         alt={plant.name}
                         className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"

--- a/web/app/garden/history/page.tsx
+++ b/web/app/garden/history/page.tsx
@@ -134,7 +134,7 @@ export default function HistoryPage() {
                           className="bg-white rounded-card border border-border p-4 flex items-center gap-4 shadow-soft"
                         >
                           {entry.imageURL ? (
-                            <img src={entry.imageURL} alt={entry.plantName} className="w-12 h-12 rounded-card object-cover shrink-0" />
+                            <img loading="lazy" decoding="async" src={entry.imageURL} alt={entry.plantName} className="w-12 h-12 rounded-card object-cover shrink-0" />
                           ) : (
                             <div className="w-12 h-12 rounded-card bg-secondary flex items-center justify-center shrink-0">
                               <Leaf className="w-6 h-6 text-green-600" />

--- a/web/app/garden/page.tsx
+++ b/web/app/garden/page.tsx
@@ -151,7 +151,7 @@ function GardenContent() {
               >
                 <div className="bg-gradient-to-br from-green-400 to-green-600 h-44 relative overflow-hidden">
                   {plant.imageURLs?.[0] ? (
-                    <img
+                    <img loading="lazy" decoding="async"
                       src={plant.imageURLs[0]}
                       alt={plant.name}
                       className="w-full h-full object-cover group-hover:scale-110 transition-transform"

--- a/web/app/garden/seasons/page.tsx
+++ b/web/app/garden/seasons/page.tsx
@@ -311,7 +311,7 @@ export default function SeasonsPage() {
                 <span>Retour au jardin</span>
               </button>
             </div>
-            <h1 className="text-5xl font-bold text-[#234632] mb-2">Guide des Saisons</h1>
+            <h1 className="text-4xl md:text-5xl font-bold text-[#234632] mb-2">Guide des Saisons</h1>
             <p className="text-lg text-arbore-muted">Découvrez les tâches et conseils pour chaque saison</p>
           </motion.div>
 
@@ -490,7 +490,7 @@ export default function SeasonsPage() {
                                   <div className="h-24 overflow-hidden bg-arbore-soft">
                                     {p.imageURLs?.[0] ? (
                                       // eslint-disable-next-line @next/next/no-img-element
-                                      <img src={p.imageURLs[0]} alt={p.name} className="h-full w-full object-cover transition-transform group-hover:scale-105" />
+                                      <img loading="lazy" decoding="async" src={p.imageURLs[0]} alt={p.name} className="h-full w-full object-cover transition-transform group-hover:scale-105" />
                                     ) : (
                                       <div className="flex h-full items-center justify-center"><Leaf className="h-8 w-8 text-arbore-sage" /></div>
                                     )}

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -111,7 +111,7 @@ export default function ProfilePage() {
             <div className="relative">
               {user.photoURL ? (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img
+                <img loading="lazy" decoding="async"
                   src={user.photoURL}
                   alt=""
                   className="h-24 w-24 rounded-full object-cover ring-4 ring-white shadow-hero"


### PR DESCRIPTION
**#14** : lazy-load (loading=lazy + decoding=async) sur les images de liste (catalogue/calendar/history/seasons/garden/profile) ; héro plant-detail laissé eager (LCP). Polices déjà self-hosted (next/font).
**#18** : titres Calendrier & Saisons responsive (text-4xl md:text-5xl) ; le reste du redesign est déjà responsive.

Closes #18. Closes #14.