### PR TITLE
feat(web): accessibility baseline (#7)

### DIFF
--- a/web/app/garden/calendar/page.tsx
+++ b/web/app/garden/calendar/page.tsx
@@ -211,7 +211,7 @@ export default function CalendarPage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-arbore-beige pt-24 pb-12">
+      <main id="main-content" className="min-h-screen bg-arbore-beige pt-24 pb-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {/* Header */}
           <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="mb-8">

--- a/web/app/garden/catalogue/page.tsx
+++ b/web/app/garden/catalogue/page.tsx
@@ -43,7 +43,7 @@ export default function CataloguePage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-background pt-24 pb-16">
+      <main id="main-content" className="min-h-screen bg-background pt-24 pb-16">
         {/* Header */}
         <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-8">
           <button
@@ -64,6 +64,7 @@ export default function CataloguePage() {
             <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-arbore-muted" />
             <input
               type="text"
+              aria-label="Rechercher une plante"
               placeholder="Rechercher une plante…"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/web/app/garden/history/page.tsx
+++ b/web/app/garden/history/page.tsx
@@ -78,7 +78,7 @@ export default function HistoryPage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-arbore-beige pt-24 pb-16">
+      <main id="main-content" className="min-h-screen bg-arbore-beige pt-24 pb-16">
         <div className="max-w-2xl mx-auto px-4 sm:px-6">
 
           <button

--- a/web/app/garden/page.tsx
+++ b/web/app/garden/page.tsx
@@ -73,7 +73,7 @@ function GardenContent() {
   }
 
   return (
-    <main className="min-h-screen bg-arbore-beige pt-24 pb-16">
+    <main id="main-content" className="min-h-screen bg-arbore-beige pt-24 pb-16">
       {/* Header */}
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-10">
         <div className="flex items-center gap-4 mb-6">

--- a/web/app/garden/plant/[id]/page.tsx
+++ b/web/app/garden/plant/[id]/page.tsx
@@ -165,7 +165,7 @@ export default function PlantDetailPage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-arbore-beige pt-24 pb-16">
+      <main id="main-content" className="min-h-screen bg-arbore-beige pt-24 pb-16">
 
         {/* Barre retour + bouton ajouter */}
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 mb-6 flex items-center justify-between">

--- a/web/app/garden/seasons/page.tsx
+++ b/web/app/garden/seasons/page.tsx
@@ -294,7 +294,7 @@ export default function SeasonsPage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-arbore-beige pt-24 pb-12">
+      <main id="main-content" className="min-h-screen bg-arbore-beige pt-24 pb-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {/* Header */}
           <motion.div

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -47,6 +47,12 @@
     font-family: var(--font-display), system-ui, sans-serif;
     letter-spacing: -0.02em;
   }
+  /* Accessibilité (#7) : focus clavier visible sur tous les éléments interactifs. */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
 }
 
 @layer components {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -26,6 +26,12 @@ export default function RootLayout({
   return (
     <html lang="fr" className={display.variable}>
       <body>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[80] focus:rounded-pill focus:bg-primary focus:px-4 focus:py-2 focus:font-semibold focus:text-primary-foreground focus:shadow-hero"
+        >
+          Aller au contenu principal
+        </a>
         <OfflineBanner />
         {children}
       </body>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-12">
+    <main id="main-content" className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-12">
       {social && <AuthLoadingOverlay provider={social} />}
       {/* halo organique */}
       <div className="pointer-events-none absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-arbore-sage opacity-25 blur-3xl" />
@@ -74,22 +74,25 @@ export default function LoginPage() {
         <div className="arbore-card p-7">
           {error && (
             <motion.div
+              role="alert"
               initial={{ opacity: 0, y: -8 }}
               animate={{ opacity: 1, y: 0 }}
               className="mb-5 flex items-start gap-3 rounded-[14px] border border-arbore-danger/30 bg-arbore-danger/10 p-3.5"
             >
-              <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-arbore-danger" />
+              <AlertCircle aria-hidden className="mt-0.5 h-5 w-5 flex-shrink-0 text-arbore-danger" />
               <p className="text-sm text-arbore-danger">{error}</p>
             </motion.div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="mb-1.5 block text-sm font-semibold text-arbore-green">Adresse email</label>
+              <label htmlFor="login-email" className="mb-1.5 block text-sm font-semibold text-arbore-green">Adresse email</label>
               <div className="relative">
-                <Mail className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <Mail aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
                 <input
+                  id="login-email"
                   type="email"
+                  autoComplete="email"
                   placeholder="vous@exemple.com"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -101,13 +104,15 @@ export default function LoginPage() {
 
             <div>
               <div className="mb-1.5 flex items-center justify-between">
-                <label className="text-sm font-semibold text-arbore-green">Mot de passe</label>
+                <label htmlFor="login-password" className="text-sm font-semibold text-arbore-green">Mot de passe</label>
                 <a href="#" className="text-sm font-semibold text-arbore-green/80 hover:text-arbore-green">Oublié ?</a>
               </div>
               <div className="relative">
-                <Lock className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <Lock aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
                 <input
+                  id="login-password"
                   type="password"
+                  autoComplete="current-password"
                   placeholder="••••••••"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -99,7 +99,7 @@ export default function ProfilePage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-background pt-24 pb-16">
+      <main id="main-content" className="min-h-screen bg-background pt-24 pb-16">
         <div className="mx-auto max-w-2xl space-y-7 px-4 sm:px-6">
           {/* En-tête profil */}
           <motion.div

--- a/web/app/signup/page.tsx
+++ b/web/app/signup/page.tsx
@@ -62,7 +62,7 @@ export default function SignupPage() {
   };
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-12">
+    <main id="main-content" className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-12">
       {social && <AuthLoadingOverlay provider={social} />}
       <div className="pointer-events-none absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-arbore-sage opacity-25 blur-3xl" />
 
@@ -83,42 +83,43 @@ export default function SignupPage() {
         <div className="arbore-card p-7">
           {error && (
             <motion.div
+              role="alert"
               initial={{ opacity: 0, y: -8 }}
               animate={{ opacity: 1, y: 0 }}
               className="mb-5 flex items-start gap-3 rounded-[14px] border border-arbore-danger/30 bg-arbore-danger/10 p-3.5"
             >
-              <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-arbore-danger" />
+              <AlertCircle aria-hidden className="mt-0.5 h-5 w-5 flex-shrink-0 text-arbore-danger" />
               <p className="text-sm text-arbore-danger">{error}</p>
             </motion.div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="mb-1.5 block text-sm font-semibold text-arbore-green">Nom complet</label>
+              <label htmlFor="signup-name" className="mb-1.5 block text-sm font-semibold text-arbore-green">Nom complet</label>
               <div className="relative">
-                <User className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
-                <input type="text" placeholder="Votre nom" value={name} onChange={(e) => setName(e.target.value)} required className="arbore-input pl-10" />
+                <User aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <input id="signup-name" autoComplete="name" type="text" placeholder="Votre nom" value={name} onChange={(e) => setName(e.target.value)} required className="arbore-input pl-10" />
               </div>
             </div>
             <div>
-              <label className="mb-1.5 block text-sm font-semibold text-arbore-green">Adresse email</label>
+              <label htmlFor="signup-email" className="mb-1.5 block text-sm font-semibold text-arbore-green">Adresse email</label>
               <div className="relative">
-                <Mail className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
-                <input type="email" placeholder="vous@exemple.com" value={email} onChange={(e) => setEmail(e.target.value)} required className="arbore-input pl-10" />
+                <Mail aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <input id="signup-email" autoComplete="email" type="email" placeholder="vous@exemple.com" value={email} onChange={(e) => setEmail(e.target.value)} required className="arbore-input pl-10" />
               </div>
             </div>
             <div>
-              <label className="mb-1.5 block text-sm font-semibold text-arbore-green">Mot de passe</label>
+              <label htmlFor="signup-password" className="mb-1.5 block text-sm font-semibold text-arbore-green">Mot de passe</label>
               <div className="relative">
-                <Lock className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
-                <input type="password" placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} required className="arbore-input pl-10" />
+                <Lock aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <input id="signup-password" autoComplete="new-password" type="password" placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} required className="arbore-input pl-10" />
               </div>
             </div>
             <div>
-              <label className="mb-1.5 block text-sm font-semibold text-arbore-green">Confirmer le mot de passe</label>
+              <label htmlFor="signup-confirm" className="mb-1.5 block text-sm font-semibold text-arbore-green">Confirmer le mot de passe</label>
               <div className="relative">
-                <Lock className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
-                <input type="password" placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="arbore-input pl-10" />
+                <Lock aria-hidden className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-arbore-muted" />
+                <input id="signup-confirm" autoComplete="new-password" type="password" placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className="arbore-input pl-10" />
               </div>
             </div>
 

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -92,7 +92,7 @@ export default function WelcomePage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen bg-arbore-beige pt-24">
+      <main id="main-content" className="min-h-screen bg-arbore-beige pt-24">
         {/* Welcome Section */}
         <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-12">
           <motion.div
@@ -159,9 +159,10 @@ export default function WelcomePage() {
                     <button
                       onClick={(e) => { e.preventDefault(); deleteGarden(gardenId); }}
                       className="absolute top-3 right-3 p-2 bg-white rounded-lg shadow opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-50 text-arbore-muted hover:text-red-500"
+                      aria-label="Supprimer le jardin"
                       title="Supprimer le jardin"
                     >
-                      <Trash2 className="w-4 h-4" />
+                      <Trash2 aria-hidden className="w-4 h-4" />
                     </button>
                   </div>
                 );

--- a/web/components/shared/Navbar.tsx
+++ b/web/components/shared/Navbar.tsx
@@ -93,6 +93,8 @@ export function Navbar() {
             <div className="relative flex items-center gap-4">
               <button
                 onClick={() => setIsProfileOpen(!isProfileOpen)}
+                aria-label="Menu du profil"
+                aria-expanded={isProfileOpen}
                 className="flex items-center gap-2 rounded-pill px-2 py-1.5 transition-colors hover:bg-secondary"
               >
                 <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary">


### PR DESCRIPTION
Baseline accessibilité (lecteurs d'écran + navigation clavier) :
- focus clavier visible global
- skip-link « Aller au contenu » + ancres #main-content
- formulaires login/signup : labels liés (htmlFor/id), role=alert, icônes décoratives aria-hidden, autocomplete
- aria-label sur les boutons icône-only (recherche, suppression jardin, menu profil)

Closes #7.