### PR TITLE
feat(backend): serve garden wizard config + care rules via GET /config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,9 @@ linters:
         - trafic
         - exemple
         - marrage
+        - candidats
+        - intervalles
+        - interm
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/config.go
+++ b/ArboreBackend/config.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// config.go — endpoint /config (issue #236)
+//
+// Sert la configuration du wizard de création de jardin et les règles de soin
+// depuis le backend, afin que les clients (iOS + web) puissent récupérer les
+// options dynamiquement plutôt que de les coder en dur.
+//
+// Chaque option porte un champ `tier` ("free" | "premium") pour préparer le
+// contrôle des styles payants/gratuits (cf. #4 Paiement). Pendant la bêta,
+// `membership.enforced = false` : tout est accessible, le `tier` est purement
+// informatif. Le jour où l'on activera le gating, il suffira de passer
+// `enforced` à true et le backend rejettera les options premium pour les
+// comptes sans abonnement — sans rien changer côté config.
+
+// configVersion est incrémenté à chaque modification du contenu servi.
+// Les clients peuvent comparer cette valeur pour invalider leur cache local.
+const configVersion = 1
+
+// wizardOption représente une option proposée dans le questionnaire de jardin.
+type wizardOption struct {
+	Value string `json:"value"`          // identifiant stable (raw value Swift)
+	Label string `json:"label"`          // libellé affiché (FR)
+	Icon  string `json:"icon,omitempty"` // SF Symbol / nom d'icône
+	Tier  string `json:"tier"`           // "free" | "premium"
+}
+
+const (
+	tierFree    = "free"
+	tierPremium = "premium"
+)
+
+// free construit une option gratuite (cas par défaut pendant la bêta).
+func free(value, label, icon string) wizardOption {
+	return wizardOption{Value: value, Label: label, Icon: icon, Tier: tierFree}
+}
+
+// getConfig répond au GET /config.
+//
+// Accessible avec uniquement l'API key (pas de session Firebase requise) :
+// la config est une donnée de référence non sensible, nécessaire dès le
+// lancement de l'app avant même que l'utilisateur soit authentifié.
+func getConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"version": configVersion,
+
+		// Pendant la bêta gratuite, aucun gating : tous les tiers sont
+		// accessibles. Les clients peuvent afficher un badge "Premium" mais
+		// ne doivent rien bloquer tant que enforced == false.
+		"membership": gin.H{
+			"enforced": false,
+			"tiers":    []string{tierFree, tierPremium},
+		},
+
+		// Options du questionnaire de création de jardin.
+		"wizard": gin.H{
+			// Styles de jardin — premiers candidats au gating premium (#4).
+			"gardenStyles": []wizardOption{
+				free("modern", "Moderne", "square.grid.2x2"),
+				free("traditional", "Traditionnel", "house"),
+				free("japanese", "Japonais", "leaf"),
+				free("mediterranean", "Méditerranéen", "sun.max"),
+				free("cottage", "Cottage", "house.lodge"),
+				free("tropical", "Tropical", "tree"),
+				free("minimalist", "Minimaliste", "minus.square"),
+				free("wild", "Sauvage/Naturel", "mountain.2"),
+			},
+
+			// Type d'espace à aménager.
+			"spaceTypes": []wizardOption{
+				free("room", "Pièce", "door.left.hand.closed"),
+				free("outdoor", "Extérieur", "tree"),
+				free("both", "Intérieur/Extérieur", "house.and.flag"),
+			},
+
+			// Exposition au soleil.
+			"sunExposures": []wizardOption{
+				free("fullSun", "Plein soleil (6h+)", "sun.max.fill"),
+				free("partialSun", "Mi-ombre (3-6h)", "cloud.sun.fill"),
+				free("shade", "Ombre (moins de 3h)", "cloud.fill"),
+				free("mixed", "Mixte", "sun.haze.fill"),
+			},
+
+			// Type de sol.
+			"soilTypes": []wizardOption{
+				free("clay", "Argileux", "square.stack.3d.up"),
+				free("sandy", "Sableux", "circle.grid.3x3"),
+				free("loamy", "Limoneux", "leaf.circle"),
+				free("chalky", "Calcaire", "mountain.2"),
+				free("peaty", "Tourbeux", "drop.fill"),
+				free("unknown", "Je ne sais pas", "questionmark.circle"),
+			},
+
+			// Niveau d'entretien souhaité.
+			"maintenanceLevels": []wizardOption{
+				free("veryLow", "Très facile (arrosage rare)", "tortoise"),
+				free("low", "Facile (1x/semaine)", "leaf"),
+				free("moderate", "Modéré (2-3x/semaine)", "drop"),
+				free("high", "Intensif (quotidien)", "hare"),
+			},
+
+			// Contraintes de sécurité (animaux / enfants).
+			"safetyOptions": []wizardOption{
+				free("pets", "Éviter les plantes toxiques pour les animaux", "pawprint"),
+				free("children", "Éviter les plantes dangereuses pour les enfants", "person.2"),
+				free("none", "Aucune contrainte", "checkmark.shield"),
+			},
+
+			// Densité de plantation.
+			"densityLevels": []wizardOption{
+				free("sparse", "Épuré (peu de plantes)", "circle"),
+				free("moderate", "Modéré", "circle.grid.2x2"),
+				free("dense", "Dense (beaucoup de plantes)", "circle.grid.3x3.fill"),
+			},
+
+			// Niveau d'expérience / complexité des plantes.
+			"complexityLevels": []wizardOption{
+				free("beginner", "Débutant (plantes résistantes)", "1.circle"),
+				free("intermediate", "Intermédiaire", "2.circle"),
+				free("advanced", "Expert (plantes exigeantes)", "3.circle"),
+				free("mixed", "Mixte", "shuffle"),
+			},
+
+			// Budget indicatif.
+			"budgetRanges": []wizardOption{
+				free("low", "Petit budget (< 100€)", "eurosign.circle"),
+				free("medium", "Moyen (100-500€)", "eurosign.circle.fill"),
+				free("high", "Élevé (500-1000€)", "creditcard"),
+				free("unlimited", "Illimité", "infinity"),
+			},
+
+			// Types de plantes recherchés.
+			"plantTypes": []wizardOption{
+				free("flowers", "Fleurs", "camera.macro"),
+				free("shrubs", "Arbustes", "leaf"),
+				free("trees", "Arbres", "tree"),
+				free("vegetables", "Légumes", "carrot"),
+				free("herbs", "Herbes aromatiques", "leaf.circle"),
+				free("succulents", "Succulentes", "drop.triangle"),
+				free("grasses", "Graminées", "scribble.variable"),
+				free("climbers", "Plantes grimpantes", "arrow.up.right"),
+			},
+		},
+
+		// Règles de soin : intervalles par défaut (en jours) et fréquences
+		// d'arrosage, alignés sur GardenCareKind / WateringFrequency (iOS).
+		"care": gin.H{
+			// Intervalle par défaut de chaque type d'action d'entretien.
+			"intervalsDays": gin.H{
+				"pruneLeaves": 30,
+				"cleanLeaves": 14,
+				"fertilize":   21,
+				"repot":       180,
+				"pestCheck":   14,
+				"rotatePot":   7,
+				"soilCheck":   7,
+				"custom":      14,
+			},
+			// Correspondance fréquence d'arrosage -> nombre de jours.
+			"wateringFrequencyDays": gin.H{
+				"daily":       1,
+				"twiceWeekly": 3,
+				"weekly":      7,
+				"biweekly":    14,
+				"monthly":     30,
+				"custom":      7,
+			},
+		},
+
+		// Poids du moteur de suggestion (multi-axes, somme ≈ 1.0).
+		// Alignés sur GardenSuggestionEngine.Weights (iOS).
+		"suggestionEngine": gin.H{
+			"weights": gin.H{
+				"style":       0.30,
+				"exposure":    0.25,
+				"soil":        0.20,
+				"maintenance": 0.15,
+				"safety":      0.10,
+			},
+		},
+	})
+}

--- a/ArboreBackend/config_test.go
+++ b/ArboreBackend/config_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetConfig vérifie la forme de la réponse de GET /config (#236) :
+// version, membership non-enforced pendant la bêta, options du wizard avec
+// un tier par défaut "free", et règles de soin.
+func TestGetConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/config", getConfig)
+
+	req, _ := http.NewRequest(http.MethodGet, "/config", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	// Version présente
+	assert.Equal(t, float64(configVersion), body["version"])
+
+	// Membership : pas de gating pendant la bêta
+	membership, ok := body["membership"].(map[string]interface{})
+	assert.True(t, ok, "membership doit être un objet")
+	assert.Equal(t, false, membership["enforced"])
+
+	// Wizard : styles présents, chaque option a un tier
+	wizard, ok := body["wizard"].(map[string]interface{})
+	assert.True(t, ok, "wizard doit être un objet")
+	styles, ok := wizard["gardenStyles"].([]interface{})
+	assert.True(t, ok, "gardenStyles doit être une liste")
+	assert.Len(t, styles, 8)
+	for _, s := range styles {
+		opt := s.(map[string]interface{})
+		assert.NotEmpty(t, opt["value"])
+		assert.NotEmpty(t, opt["label"])
+		assert.Equal(t, tierFree, opt["tier"], "tout doit être free pendant la bêta")
+	}
+
+	// Care : intervalles de soin présents
+	care, ok := body["care"].(map[string]interface{})
+	assert.True(t, ok, "care doit être un objet")
+	intervals, ok := care["intervalsDays"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, float64(180), intervals["repot"])
+}

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1534,6 +1534,15 @@ func main() {
 		c.File(filePath)
 	})
 
+	// === ROUTES API KEY UNIQUEMENT (sans session Firebase) ===
+	// Config de référence (wizard + règles de soin, cf. #236) : non sensible,
+	// nécessaire dès le lancement de l'app avant authentification utilisateur.
+	apiKeyOnly := router.Group("/")
+	apiKeyOnly.Use(middleware.APIKeyMiddleware())
+	{
+		apiKeyOnly.GET("/config", getConfig)
+	}
+
 	// === ROUTES PROTÉGÉES (API Key + Firebase Auth) ===
 	// Ordre important: API Key PUIS Firebase Auth
 	protected := router.Group("/")

--- a/web/app/api/backend/[...path]/route.ts
+++ b/web/app/api/backend/[...path]/route.ts
@@ -21,7 +21,7 @@ const API_KEY = process.env.ARBORE_API_KEY || '';
 
 // Allowlist des préfixes backend exposés via le proxy (défense en profondeur :
 // empêche d'utiliser le proxy comme relais générique vers tout endpoint interne).
-const ALLOWED_PREFIXES = new Set(['users', 'plants', 'gardens', 'consents', 'models']);
+const ALLOWED_PREFIXES = new Set(['users', 'plants', 'gardens', 'consents', 'models', 'config']);
 
 async function proxy(req: Request, path: string[]) {
   // Anti-traversal + allowlist.


### PR DESCRIPTION
## Contexte — #236

Externalise la configuration du wizard de création de jardin et les règles de soin depuis le backend. iOS et le web peuvent désormais récupérer ces options dynamiquement via `GET /config` au lieu de les coder en dur.

## Endpoint

`GET /config` — protégé par **API key uniquement** (pas de session Firebase). C'est une donnée de référence non sensible, nécessaire dès le lancement de l'app avant authentification de l'utilisateur.

Réponse :
- `version` — entier incrémenté à chaque changement (cache-busting client).
- `membership` — `{ enforced: false, tiers: [free, premium] }`. **Pendant la bêta, aucun gating** : tout est accessible, le `tier` de chaque option est purement informatif.
- `wizard` — gardenStyles, spaceTypes, sunExposures, soilTypes, maintenanceLevels, safetyOptions, densityLevels, complexityLevels, budgetRanges, plantTypes. Chaque option : `{ value, label, icon, tier }`.
- `care` — `intervalsDays` (par type d'action) + `wateringFrequencyDays`.
- `suggestionEngine.weights` — poids multi-axes (style 0.30 / exposure 0.25 / soil 0.20 / maintenance 0.15 / safety 0.10).

Contenu extrait 1:1 de l'iOS (GardenProject.swift, WateringRoutine.swift, QuestionnaireView.swift, GardenSuggestionEngine.swift).

## Membership (préparation #4)

Chaque option porte un champ `tier` (`free` | `premium`). Les styles de jardin sont les premiers candidats au gating premium. Le jour où l'on activera le paiement, il suffira de passer `membership.enforced` à `true` côté backend pour rejeter les options premium des comptes sans abonnement — sans changer la structure de la config.

## Web

Ajout du préfixe `config` à l'allowlist du proxy same-origin pour que la web app puisse aussi consommer l'endpoint.

## Tests

`TestGetConfig` — vérifie le code 200, la version, `membership.enforced=false`, les 8 styles tous en `tier=free`, et les intervalles de soin. `go build ./...` et `go test` passent.

Closes #236