### PR TITLE
feat(ios): consume backend /config for wizard tiers, care rules and engine weights

### DIFF
--- a/ArboreBackend/config.go
+++ b/ArboreBackend/config.go
@@ -21,7 +21,11 @@ import (
 
 // configVersion est incrémenté à chaque modification du contenu servi.
 // Les clients peuvent comparer cette valeur pour invalider leur cache local.
-const configVersion = 1
+//
+// v2 : alignement des options du wizard sur les enums réellement consommés par
+// l'iOS (QuestionnaireView.swift) — les `value` correspondent aux noms de cas
+// Swift, les `label` aux rawValue affichés.
+const configVersion = 2
 
 // wizardOption représente une option proposée dans le questionnaire de jardin.
 type wizardOption struct {
@@ -59,92 +63,55 @@ func getConfig(c *gin.Context) {
 		},
 
 		// Options du questionnaire de création de jardin.
+		// `value` = nom du cas Swift (clé stable), `label` = rawValue affiché,
+		// `icon` = iconName (SF Symbol). Aligné sur QuestionnaireView.swift.
 		"wizard": gin.H{
 			// Styles de jardin — premiers candidats au gating premium (#4).
 			"gardenStyles": []wizardOption{
-				free("modern", "Moderne", "square.grid.2x2"),
-				free("traditional", "Traditionnel", "house"),
-				free("japanese", "Japonais", "leaf"),
+				free("modern", "Moderne & minimaliste", "square.grid.2x2"),
+				free("floral", "Fleuri & coloré", "camera.macro"),
+				free("wild", "Champêtre & sauvage", "leaf"),
+				free("zen", "Zen & japonais", "wind"),
 				free("mediterranean", "Méditerranéen", "sun.max"),
-				free("cottage", "Cottage", "house.lodge"),
-				free("tropical", "Tropical", "tree"),
-				free("minimalist", "Minimaliste", "minus.square"),
-				free("wild", "Sauvage/Naturel", "mountain.2"),
+				free("noPreference", "Sans préférence", "sparkles"),
 			},
 
 			// Type d'espace à aménager.
 			"spaceTypes": []wizardOption{
-				free("room", "Pièce", "door.left.hand.closed"),
-				free("outdoor", "Extérieur", "tree"),
-				free("both", "Intérieur/Extérieur", "house.and.flag"),
+				free("garden", "Jardin extérieur", "house.and.flag"),
+				free("balcony", "Terrasse / balcon", "sun.max"),
+				free("interior", "Intérieur d'appartement", "house"),
 			},
 
 			// Exposition au soleil.
 			"sunExposures": []wizardOption{
-				free("fullSun", "Plein soleil (6h+)", "sun.max.fill"),
-				free("partialSun", "Mi-ombre (3-6h)", "cloud.sun.fill"),
-				free("shade", "Ombre (moins de 3h)", "cloud.fill"),
-				free("mixed", "Mixte", "sun.haze.fill"),
+				free("fullSun", "Soleil direct (6h+)", "sun.max"),
+				free("partialShade", "Mi-ombre", "cloud.sun"),
+				free("shade", "Ombragé", "cloud"),
+				free("unknown", "Je ne sais pas", "questionmark.circle"),
 			},
 
-			// Type de sol.
+			// Type de sol (étape affichée seulement pour un jardin extérieur).
 			"soilTypes": []wizardOption{
-				free("clay", "Argileux", "square.stack.3d.up"),
-				free("sandy", "Sableux", "circle.grid.3x3"),
-				free("loamy", "Limoneux", "leaf.circle"),
-				free("chalky", "Calcaire", "mountain.2"),
-				free("peaty", "Tourbeux", "drop.fill"),
+				free("rich", "Riche", "leaf"),
+				free("dry", "Sec", "sun.max"),
+				free("rocky", "Rocailleux", "mountain.2"),
+				free("waterRetentive", "Retient l'eau", "drop"),
 				free("unknown", "Je ne sais pas", "questionmark.circle"),
 			},
 
 			// Niveau d'entretien souhaité.
 			"maintenanceLevels": []wizardOption{
-				free("veryLow", "Très facile (arrosage rare)", "tortoise"),
-				free("low", "Facile (1x/semaine)", "leaf"),
-				free("moderate", "Modéré (2-3x/semaine)", "drop"),
-				free("high", "Intensif (quotidien)", "hare"),
+				free("veryEasy", "Très facile", "hand.thumbsup"),
+				free("easy", "Facile", "leaf"),
+				free("demanding", "Exigeant", "wrench.and.screwdriver"),
 			},
 
-			// Contraintes de sécurité (animaux / enfants).
+			// Contraintes de sécurité (animaux / enfants, multi-sélection).
 			"safetyOptions": []wizardOption{
 				free("pets", "Éviter les plantes toxiques pour les animaux", "pawprint"),
 				free("children", "Éviter les plantes dangereuses pour les enfants", "person.2"),
 				free("none", "Aucune contrainte", "checkmark.shield"),
-			},
-
-			// Densité de plantation.
-			"densityLevels": []wizardOption{
-				free("sparse", "Épuré (peu de plantes)", "circle"),
-				free("moderate", "Modéré", "circle.grid.2x2"),
-				free("dense", "Dense (beaucoup de plantes)", "circle.grid.3x3.fill"),
-			},
-
-			// Niveau d'expérience / complexité des plantes.
-			"complexityLevels": []wizardOption{
-				free("beginner", "Débutant (plantes résistantes)", "1.circle"),
-				free("intermediate", "Intermédiaire", "2.circle"),
-				free("advanced", "Expert (plantes exigeantes)", "3.circle"),
-				free("mixed", "Mixte", "shuffle"),
-			},
-
-			// Budget indicatif.
-			"budgetRanges": []wizardOption{
-				free("low", "Petit budget (< 100€)", "eurosign.circle"),
-				free("medium", "Moyen (100-500€)", "eurosign.circle.fill"),
-				free("high", "Élevé (500-1000€)", "creditcard"),
-				free("unlimited", "Illimité", "infinity"),
-			},
-
-			// Types de plantes recherchés.
-			"plantTypes": []wizardOption{
-				free("flowers", "Fleurs", "camera.macro"),
-				free("shrubs", "Arbustes", "leaf"),
-				free("trees", "Arbres", "tree"),
-				free("vegetables", "Légumes", "carrot"),
-				free("herbs", "Herbes aromatiques", "leaf.circle"),
-				free("succulents", "Succulentes", "drop.triangle"),
-				free("grasses", "Graminées", "scribble.variable"),
-				free("climbers", "Plantes grimpantes", "arrow.up.right"),
 			},
 		},
 

--- a/ArboreBackend/config_test.go
+++ b/ArboreBackend/config_test.go
@@ -40,7 +40,7 @@ func TestGetConfig(t *testing.T) {
 	assert.True(t, ok, "wizard doit être un objet")
 	styles, ok := wizard["gardenStyles"].([]interface{})
 	assert.True(t, ok, "gardenStyles doit être une liste")
-	assert.Len(t, styles, 8)
+	assert.Len(t, styles, 6)
 	for _, s := range styles {
 		opt := s.(map[string]interface{})
 		assert.NotEmpty(t, opt["value"])

--- a/ArboreUi/ArboreUi/ArboreUiApp.swift
+++ b/ArboreUi/ArboreUi/ArboreUiApp.swift
@@ -27,11 +27,15 @@ struct YourApp: App {
                 }
                 .environment(\.locale, Locale(identifier: selectedLanguage))
                 .environmentObject(themeManager)
+                .environmentObject(RemoteConfigService.shared)
                 .environment(\.themeManager, themeManager)
                 .preferredColorScheme(themeManager.colorScheme)
                 .environment(\.dynamicTypeSize, themeManager.mappedDynamicTypeSize)
                 .accentColor(themeManager.accentColor)
                 .environment(roomCaptureController)
+                // Charge la config distante (wizard + règles de soin, #236) au
+                // lancement. Échec silencieux → repli sur le cache / les défauts.
+                .task { await RemoteConfigService.shared.load() }
             }
         }
     }

--- a/ArboreUi/ArboreUi/Models/RemoteConfig.swift
+++ b/ArboreUi/ArboreUi/Models/RemoteConfig.swift
@@ -1,0 +1,78 @@
+//
+//  RemoteConfig.swift
+//  ArboreUi
+//
+//  Modèle de la configuration servie par le backend (GET /config, issue #236).
+//  Externalise les options du wizard, les règles de soin et les poids du moteur
+//  de suggestion afin qu'ils soient ajustables côté serveur sans mise à jour de
+//  l'app. Décodé par RemoteConfigService ; chaque consommateur garde une valeur
+//  de repli codée en dur si la config distante est indisponible.
+//
+
+import Foundation
+
+/// Réponse de `GET /config`.
+struct RemoteConfig: Codable, Equatable {
+    let version: Int
+    let membership: Membership
+    let wizard: Wizard
+    let care: Care
+    let suggestionEngine: SuggestionEngine
+
+    // MARK: - Membership
+
+    /// Contrôle du gating payant/gratuit. Pendant la bêta `enforced == false`
+    /// (tout accessible) ; le `tier` des options reste purement informatif.
+    struct Membership: Codable, Equatable {
+        let enforced: Bool
+        let tiers: [String]
+    }
+
+    // MARK: - Wizard
+
+    struct Wizard: Codable, Equatable {
+        let gardenStyles: [Option]
+        let spaceTypes: [Option]
+        let sunExposures: [Option]
+        let soilTypes: [Option]
+        let maintenanceLevels: [Option]
+        let safetyOptions: [Option]
+    }
+
+    /// Une option du questionnaire. `value` correspond au nom de cas Swift
+    /// (clé stable), `label` au libellé affiché, `tier` à "free" ou "premium".
+    struct Option: Codable, Equatable, Identifiable {
+        let value: String
+        let label: String
+        let icon: String?
+        let tier: String
+
+        var id: String { value }
+        var isPremium: Bool { tier == "premium" }
+    }
+
+    // MARK: - Care
+
+    struct Care: Codable, Equatable {
+        /// Intervalle par défaut (jours) par type d'action d'entretien,
+        /// clé = rawValue de `GardenCareKind` (ex. "pruneLeaves").
+        let intervalsDays: [String: Int]
+        /// Nombre de jours par fréquence d'arrosage,
+        /// clé = rawValue de `WateringFrequency` (ex. "weekly").
+        let wateringFrequencyDays: [String: Int]
+    }
+
+    // MARK: - Suggestion engine
+
+    struct SuggestionEngine: Codable, Equatable {
+        let weights: Weights
+
+        struct Weights: Codable, Equatable {
+            let style: Double
+            let exposure: Double
+            let soil: Double
+            let maintenance: Double
+            let safety: Double
+        }
+    }
+}

--- a/ArboreUi/ArboreUi/Models/WateringRoutine.swift
+++ b/ArboreUi/ArboreUi/Models/WateringRoutine.swift
@@ -219,6 +219,11 @@ enum GardenCareKind: String, Codable, CaseIterable {
     }
 
     var defaultIntervalDays: Int {
+        // Surcharge distante (config /config, issue #236) si disponible,
+        // sinon valeur de repli codée en dur.
+        if let remote = RemoteConfigService.shared.careIntervalDays(forKind: rawValue) {
+            return remote
+        }
         switch self {
         case .pruneLeaves: return 30
         case .cleanLeaves: return 14
@@ -534,6 +539,11 @@ enum WateringFrequency: String, Codable, CaseIterable {
     }
     
     var days: Int {
+        // Surcharge distante (config /config, issue #236) si disponible,
+        // sinon valeur de repli codée en dur.
+        if let remote = RemoteConfigService.shared.wateringDays(forFrequency: rawValue) {
+            return remote
+        }
         switch self {
         case .daily: return 1
         case .twiceWeekly: return 3

--- a/ArboreUi/ArboreUi/Services/GardenSuggestionEngine.swift
+++ b/ArboreUi/ArboreUi/Services/GardenSuggestionEngine.swift
@@ -46,13 +46,28 @@ final class GardenSuggestionEngine {
     /// Target number of plants to suggest (adjusted by composition rules)
     private let targetPlantCount: Int
 
-    /// Weight for each scoring axis (must sum to ~1.0)
+    /// Weight for each scoring axis (must sum to ~1.0).
+    /// Valeurs de repli codées en dur ; surchargées par la config distante
+    /// (`suggestionEngine.weights`, issue #236) quand elle est disponible.
     private struct Weights {
-        static let style: Double       = 0.30
-        static let exposure: Double    = 0.25
-        static let soil: Double        = 0.20
-        static let maintenance: Double = 0.15
-        static let safety: Double      = 0.10
+        let style: Double
+        let exposure: Double
+        let soil: Double
+        let maintenance: Double
+        let safety: Double
+
+        static let fallback = Weights(
+            style: 0.30, exposure: 0.25, soil: 0.20, maintenance: 0.15, safety: 0.10
+        )
+
+        /// Poids effectifs : config distante si présente, sinon repli.
+        static var resolved: Weights {
+            guard let w = RemoteConfigService.shared.suggestionWeights else { return fallback }
+            return Weights(
+                style: w.style, exposure: w.exposure, soil: w.soil,
+                maintenance: w.maintenance, safety: w.safety
+            )
+        }
     }
 
     init(targetPlantCount: Int = 7) {
@@ -149,12 +164,13 @@ final class GardenSuggestionEngine {
             reasons.append("⚠️ Plante potentiellement toxique")
         }
 
-        // Weighted average
-        let total = styleScore * Weights.style
-            + exposureScore * Weights.exposure
-            + soilScore * Weights.soil
-            + maintenanceScore * Weights.maintenance
-            + safetyScore * Weights.safety
+        // Weighted average (poids distants si disponibles, sinon repli)
+        let weights = Weights.resolved
+        let total = styleScore * weights.style
+            + exposureScore * weights.exposure
+            + soilScore * weights.soil
+            + maintenanceScore * weights.maintenance
+            + safetyScore * weights.safety
 
         if reasons.isEmpty {
             reasons.append("Compatible avec vos critères")

--- a/ArboreUi/ArboreUi/Services/RemoteConfigService.swift
+++ b/ArboreUi/ArboreUi/Services/RemoteConfigService.swift
@@ -1,0 +1,107 @@
+//
+//  RemoteConfigService.swift
+//  ArboreUi
+//
+//  Charge la configuration distante (GET /config, issue #236) au lancement de
+//  l'app, la met en cache pour un usage hors-ligne, et l'expose à la fois comme
+//  ObservableObject (UI) et via un singleton synchrone (couches modèle :
+//  GardenCareKind, WateringFrequency, GardenSuggestionEngine).
+//
+//  Chaque accesseur renvoie une valeur de repli codée en dur si la config
+//  distante n'est pas encore chargée : l'app reste 100 % fonctionnelle offline
+//  ou si le backend est injoignable.
+//
+
+import Foundation
+import Combine
+
+final class RemoteConfigService: ObservableObject {
+
+    /// Singleton accessible depuis les couches modèle (sans injection SwiftUI).
+    static let shared = RemoteConfigService()
+
+    /// Config courante (nil tant que rien n'a été chargé ni mis en cache).
+    /// Lue de façon synchrone par les couches modèle, écrite sur le main thread.
+    @Published private(set) var config: RemoteConfig?
+
+    /// Indique si l'utilisateur dispose d'un abonnement premium. Toujours false
+    /// pendant la bêta (aucun paiement) ; branché plus tard sur l'état d'achat
+    /// (cf. #4). Utilisé pour décider du verrouillage des options premium.
+    @Published var isPremiumMember = false
+
+    private let cacheKey = "arbore.remoteConfig.v1"
+    private let defaults = UserDefaults.standard
+
+    private init() {
+        // Au démarrage, on tente immédiatement de restaurer le dernier cache
+        // pour que les accesseurs synchrones aient une valeur avant le réseau.
+        config = loadCachedConfig()
+    }
+
+    // MARK: - Chargement
+
+    /// Récupère la config depuis le backend et met à jour le cache. Silencieux :
+    /// en cas d'échec on conserve la config en cache (ou les repli codés en dur).
+    func load() async {
+        do {
+            let fetched: RemoteConfig = try await NetworkManager.shared.requestWithoutAuth(
+                endpoint: "/config",
+                method: .GET
+            )
+            await MainActor.run { self.config = fetched }
+            cache(fetched)
+        } catch {
+            #if DEBUG
+            print("ℹ️ RemoteConfig: échec du chargement (\(error)), repli sur le cache/les valeurs par défaut.")
+            #endif
+        }
+    }
+
+    // MARK: - Cache (offline)
+
+    private func cache(_ config: RemoteConfig) {
+        guard let data = try? JSONEncoder().encode(config) else { return }
+        defaults.set(data, forKey: cacheKey)
+    }
+
+    private func loadCachedConfig() -> RemoteConfig? {
+        guard let data = defaults.data(forKey: cacheKey) else { return nil }
+        return try? JSONDecoder().decode(RemoteConfig.self, from: data)
+    }
+
+    // MARK: - Accesseurs (couche modèle)
+
+    /// Intervalle de soin distant (jours) pour une clé `GardenCareKind`,
+    /// ou nil si indisponible → l'appelant utilise sa valeur par défaut.
+    func careIntervalDays(forKind kind: String) -> Int? {
+        config?.care.intervalsDays[kind]
+    }
+
+    /// Nombre de jours distant pour une fréquence d'arrosage,
+    /// ou nil si indisponible → l'appelant utilise sa valeur par défaut.
+    func wateringDays(forFrequency frequency: String) -> Int? {
+        config?.care.wateringFrequencyDays[frequency]
+    }
+
+    /// Poids distants du moteur de suggestion, ou nil si indisponible.
+    var suggestionWeights: RemoteConfig.SuggestionEngine.Weights? {
+        config?.suggestionEngine.weights
+    }
+
+    // MARK: - Membership / gating
+
+    /// Tier d'un style de jardin ("free" par défaut si la config est absente).
+    func tier(forStyleKey key: String) -> String {
+        config?.wizard.gardenStyles.first { $0.value == key }?.tier ?? "free"
+    }
+
+    /// Un style est verrouillé seulement si le gating est actif, que l'option
+    /// est premium, et que l'utilisateur n'est pas abonné. En bêta
+    /// (`enforced == false`) cette méthode renvoie toujours false → tout reste
+    /// accessible, conformément au comportement attendu.
+    func isStyleLocked(forKey key: String) -> Bool {
+        guard let config, config.membership.enforced else { return false }
+        guard tier(forStyleKey: key) == "premium" else { return false }
+        return !isPremiumMember
+    }
+}

--- a/ArboreUi/ArboreUi/Views/GardenSteps/QuestionnaireView.swift
+++ b/ArboreUi/ArboreUi/Views/GardenSteps/QuestionnaireView.swift
@@ -27,9 +27,22 @@ enum GardenStyle: String, CaseIterable, Identifiable {
     case zen = "Zen & japonais"
     case mediterranean = "Méditerranéen"
     case noPreference = "Sans préférence"
-    
+
     var id: String { rawValue }
-    
+
+    /// Clé stable (nom de cas) utilisée pour mapper l'option sur la config
+    /// distante (tier free/premium, issue #236). Indépendante du libellé affiché.
+    var key: String {
+        switch self {
+        case .modern: return "modern"
+        case .floral: return "floral"
+        case .wild: return "wild"
+        case .zen: return "zen"
+        case .mediterranean: return "mediterranean"
+        case .noPreference: return "noPreference"
+        }
+    }
+
     var iconName: String {
         switch self {
         case .modern: return "square.grid.2x2"

--- a/ArboreUi/ArboreUi/Views/GardenSteps/StyleStepView.swift
+++ b/ArboreUi/ArboreUi/Views/GardenSteps/StyleStepView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct StyleStepView: View {
     @ObservedObject var state: GardenWizardState
+    // Observe la config distante pour le gating premium des styles (#236).
+    // En bêta `membership.enforced == false` → aucun style n'est verrouillé.
+    @ObservedObject private var remoteConfig = RemoteConfigService.shared
     let onNext: () -> Void
     let onBack: () -> Void
     
@@ -29,12 +32,27 @@ struct StyleStepView: View {
                 ScrollView(showsIndicators: false) {
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
                         ForEach(GardenStyle.allCases) { style in
+                            let isLocked = remoteConfig.isStyleLocked(forKey: style.key)
                             StyleCard(
                                 style: style,
                                 isSelected: state.style == style
                             ) {
+                                // Style verrouillé (premium, gating actif) : on ne
+                                // sélectionne pas. Le paywall sera branché avec #4.
+                                guard !isLocked else { return }
                                 state.style = style
                             }
+                            .overlay(alignment: .topTrailing) {
+                                if isLocked {
+                                    Image(systemName: "lock.fill")
+                                        .font(.system(size: 12, weight: .bold))
+                                        .foregroundColor(.white)
+                                        .padding(7)
+                                        .background(Color.black.opacity(0.45), in: Circle())
+                                        .padding(10)
+                                }
+                            }
+                            .opacity(isLocked ? 0.55 : 1)
                         }
                     }
                     .padding(.horizontal, 24)


### PR DESCRIPTION
## Contexte — #236 (suite)

Le backend sert déjà la config wizard + règles de soin via `GET /config` (PR #265). Cette PR **câble la consommation côté iOS**, avec repli codé en dur partout : l'app reste 100 % fonctionnelle offline ou si le backend est injoignable.

## iOS

- **`RemoteConfig`** — modèle `Codable` de la réponse `/config`.
- **`RemoteConfigService`** — singleton `ObservableObject` :
  - charge la config au lancement (`requestWithoutAuth`, API key seule, pas de session Firebase — comme le groupe `apiKeyOnly` backend) ;
  - met en cache la dernière config dans `UserDefaults` (restaurée à l'init → valeur dispo avant le réseau) ;
  - expose des accesseurs synchrones avec repli pour les couches modèle.
- **Consommateurs** (tous avec fallback historique) :
  - `GardenSuggestionEngine` → poids multi-axes depuis `suggestionEngine.weights` ;
  - `GardenCareKind.defaultIntervalDays` → `care.intervalsDays[rawValue]` ;
  - `WateringFrequency.days` → `care.wateringFrequencyDays[rawValue]` ;
  - `StyleStepView` → gating premium des styles via `membership` (verrouille un style premium uniquement si `membership.enforced` ; **toujours `false` en bêta → rien n'est verrouillé**). Scaffolding prêt pour #4 (Paiement).
- Chargement déclenché dans `ArboreUiApp` (`.task`), service injecté en `environmentObject`.

## Backend — config.go v2

En vérifiant la consommation, les options du wizard servies en v1 venaient des enums **legacy** `GardenPreferences` (`GardenProject.swift`), **pas** des enums réellement affichés par le wizard (`QuestionnaireView.swift`). v2 réaligne `gardenStyles` / `spaceTypes` / `sunExposures` / `soilTypes` / `maintenanceLevels` / `safetyOptions` sur les vraies valeurs, `value` = nom de cas Swift (clé stable pour le mapping tier). Les enums non utilisés par le wizard (density/complexity/budget/plantTypes) sont retirés. `care` + `suggestionEngine.weights` inchangés (déjà corrects).

## Vérifications

- `go build` + `go test` (TestGetConfig, 6 styles) + `golangci-lint` : OK.
- **Build iOS** : `xcodebuild -workspace ArboreUi.xcworkspace -scheme ArboreUi` (simulateur) → **BUILD SUCCEEDED**, 0 erreur.

Refs #236