### PR TITLE
fix(backend): include profile photo in data export (RGPD Art. 20)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
         - candidats
         - intervalles
         - interm
+        - incluse
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -344,6 +344,10 @@ func exportUserData(c *gin.Context) {
 			"name":      user.Name,
 			"createdAt": user.CreatedAt,
 			"banned":    user.Banned,
+			// Photo de profil incluse pour la portabilité RGPD (Art. 20, #268).
+			// AppleRefreshTokenEncrypted reste volontairement exclu (secret d'auth).
+			"photoData":        user.PhotoData,
+			"photoContentType": user.PhotoContentType,
 		},
 		"gardens":  gardens,
 		"consents": consents,


### PR DESCRIPTION
## #268

`GET /users/export` (`exportUserData`) renvoyait `uid` / `email` / `name` / `createdAt` / `banned` mais **pas la photo de profil**, pourtant une donnée personnelle stockée sur le compte → manque pour la portabilité RGPD (Art. 20).

## Changement

Ajout de `photoData` + `photoContentType` au bloc `user` de la réponse d'export. Les champs sont déjà chargés via le `FindOne` existant sur `users` → aucune requête supplémentaire.

`AppleRefreshTokenEncrypted` reste **volontairement exclu** (secret d'authentification chiffré, ne doit pas être exporté).

## Vérifs

- `go build` + `go vet` + `golangci-lint` : OK (ajout de `incluse` à l'allowlist misspell FR).
- Pas de test d'intégration ajouté : le handler nécessite un Mongo live et le changement se limite à exposer deux champs déjà récupérés.

Closes #268