### PR TITLE
fix(web): dead settings link, seasons deep-link bounce, garden card placeholders

### DIFF
--- a/web/app/garden/seasons/page.tsx
+++ b/web/app/garden/seasons/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { getCurrentUser } from '@/lib/authService';
+import { onAuthStateChange } from '@/lib/authService';
 import { API_URL, fetchWithAuth } from '@/lib/api';
 import { Navbar } from '@/components/shared/Navbar';
 import { Footer } from '@/components/shared/Footer';
@@ -215,22 +215,26 @@ export default function SeasonsPage() {
   const router = useRouter();
 
   useEffect(() => {
-    const currentUser = getCurrentUser();
-    if (!currentUser) {
-      router.push('/login');
-    } else {
+    // Écoute asynchrone de l'état Firebase : sur un chargement à froid (deep-link,
+    // refresh F5), auth.currentUser est encore null le temps que Firebase restaure
+    // la session. getCurrentUser() en synchrone renvoyait null -> redirection à tort
+    // vers /login (puis /welcome). On attend donc le listener comme les autres pages.
+    const unsubscribe = onAuthStateChange(async (currentUser) => {
+      if (!currentUser) {
+        router.push('/login');
+        return;
+      }
       setUser(currentUser);
       setLoading(false);
       // Charger les vraies plantes du catalogue (pour la section "Plantes de saison").
-      (async () => {
-        try {
-          const res = await fetchWithAuth(`${API_URL}/plants`);
-          if (res.ok) setAllPlants((await res.json()) || []);
-        } catch {
-          /* catalogue indisponible -> fallback sur les suggestions */
-        }
-      })();
-    }
+      try {
+        const res = await fetchWithAuth(`${API_URL}/plants`);
+        if (res.ok) setAllPlants((await res.json()) || []);
+      } catch {
+        /* catalogue indisponible -> fallback sur les suggestions */
+      }
+    });
+    return () => unsubscribe();
   }, [router]);
 
   // Déterminer la saison actuelle

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -139,7 +139,7 @@ export default function WelcomePage() {
                           </div>
                           <div className="flex items-center gap-1 text-sm text-arbore-muted">
                             <MapPin className="w-4 h-4" />
-                            {garden.wizard?.location || garden.location || 'Non défini'}
+                            {garden.wizard?.spaceType || 'Jardin'}
                           </div>
                         </div>
 
@@ -147,7 +147,7 @@ export default function WelcomePage() {
                           {garden.name}
                         </h3>
                         <p className="text-sm text-arbore-muted mb-4">
-                          {garden.wizard?.description || garden.description || 'Aucune description'}
+                          {garden.wizard?.style || 'Style libre'}
                         </p>
 
                         <div className="flex items-center gap-2 text-[#234632] font-semibold">

--- a/web/components/shared/Navbar.tsx
+++ b/web/components/shared/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
-import { Menu, X, LogOut, User, Settings, Leaf } from 'lucide-react';
+import { Menu, X, LogOut, User, Leaf } from 'lucide-react';
 import { onAuthStateChange, logout } from '@/lib/authService';
 
 function Logo() {
@@ -110,10 +110,6 @@ export function Navbar() {
                   <Link href="/profile" className="flex items-center gap-3 rounded-[12px] px-3 py-2.5 text-sm font-medium text-arbore-green transition-colors hover:bg-secondary">
                     <User className="h-4 w-4" />
                     <span>Mon profil</span>
-                  </Link>
-                  <Link href="/settings" className="flex items-center gap-3 rounded-[12px] px-3 py-2.5 text-sm font-medium text-arbore-green transition-colors hover:bg-secondary">
-                    <Settings className="h-4 w-4" />
-                    <span>Paramètres</span>
                   </Link>
                   <button
                     onClick={handleLogout}


### PR DESCRIPTION
Trois bugs trouvés en testant manuellement tous les flows de l'app web (connecté avec un vrai compte).

## 1. Lien « Paramètres » mort → 404
Le menu profil (Navbar) pointait vers `/settings`, page qui n'existe pas → cul-de-sac 404. Le lien est supprimé (le contenu type réglages — export, confidentialité, suppression, déconnexion — est déjà dans `/profile`).

## 2. Deep-link / refresh sur `/garden/seasons` rebondissait vers `/welcome`
La page Saisons lisait l'utilisateur via `getCurrentUser()` (synchrone). Au chargement à froid (deep-link, F5), `auth.currentUser` est encore `null` le temps que Firebase restaure la session → redirection à tort vers `/login`, puis `/welcome`. Passage à `onAuthStateChange` (listener async), exactement comme `calendar` et `history` qui, eux, survivaient déjà au cold load.

## 3. Cartes de jardin : « Non défini » / « Aucune description » en dur
Le dashboard lisait `garden.wizard.location` et `garden.wizard.description` — des champs **inexistants** dans `GardenWizardDTO` (qui n'a que style/spaceType/exposure/maintenance/safety/soil). Donc placeholder systématique. Affichage des vrais champs : **spaceType** dans le badge (ex. « Intérieur d'appartement ») et **style** en sous-titre (ex. « Zen & japonais »), avec repli.

## Vérifs
- `tsc --noEmit` (typecheck) : OK
- `next lint` : OK (seulement des warnings pré-existants, aucun dans les fichiers modifiés)
- `next build` : OK (aucune route `/settings` — confirme le lien mort)
- `vitest` : 8/8 OK

Bugs trouvés via test manuel Playwright des flows. Les points cosmétiques restants (double section « Compte » dans /profile, entrées catalogue de test, COOP popup) sont laissés de côté pour cette PR.