### PR TITLE
fix(web): cosmetic pass — profile heading, favicon, COOP popup, pricing copy

### DIFF
--- a/web/app/icon.svg
+++ b/web/app/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#234632"/>
+  <g transform="translate(4 4)" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z"/>
+    <path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12"/>
+  </g>
+</svg>

--- a/web/app/pricing/page.tsx
+++ b/web/app/pricing/page.tsx
@@ -157,10 +157,12 @@ export default function PricingPage() {
               </div>
               <div>
                 <h3 className="text-xl font-semibold text-arbore-ink mb-2">
-                  Quels moyens de paiement acceptez-vous ?
+                  Y a-t-il un paiement à prévoir ?
                 </h3>
                 <p className="text-arbore-muted">
-                  Nous acceptons toutes les cartes bancaires (Visa, Mastercard, American Express) ainsi que PayPal.
+                  Non. Arbore est une bêta étudiante gratuite et non commerciale : aucun
+                  paiement, aucun abonnement, aucun moyen de paiement n&apos;est demandé. Les
+                  tarifs ci-dessus sont indicatifs pour l&apos;après-bêta.
                 </p>
               </div>
             </div>

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -166,7 +166,7 @@ export default function ProfilePage() {
 
           {/* Zone danger */}
           <section>
-            <SectionHeader>Compte</SectionHeader>
+            <SectionHeader>Zone de danger</SectionHeader>
             <div className="space-y-3">
               <SettingsRow
                 icon={Trash2}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -32,6 +32,11 @@ const nextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
+          // OAuth via signInWithPopup (Google/Apple) : la valeur par défaut du
+          // navigateur isole la popup et fait échouer window.close/closed
+          // (warnings COOP en console). `same-origin-allow-popups` garde
+          // l'isolation cross-origin tout en autorisant le dialogue avec la popup.
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',


### PR DESCRIPTION
Seconde passe sur les points cosmétiques relevés pendant le test manuel des flows web.

- **Profil** : la section « zone danger » (suppression de compte + déconnexion) était intitulée **« Compte »**, comme la section au-dessus → renommée **« Zone de danger »**.
- **Favicon** : aucune icône → `GET /favicon.ico` 404 sur chaque page. Ajout de `app/icon.svg` (feuille Arbore blanche sur fond vert `#234632`, comme le logo de la navbar) — Next App Router la sert automatiquement.
- **OAuth popup** : `signInWithPopup` (Google/Apple) déclenchait des warnings COOP (`window.close/closed bloqués`). Ajout de l'en-tête `Cross-Origin-Opener-Policy: same-origin-allow-popups` (garde l'isolation cross-origin tout en autorisant le dialogue avec la popup — réglage recommandé pour Firebase Auth popup).
- **Pricing** : la FAQ affichait « cartes bancaires (Visa, Mastercard, Amex) + PayPal » alors qu'Arbore est une **bêta étudiante gratuite et non commerciale sans aucun paiement**. Reformulé pour refléter la réalité (tarifs indicatifs post-bêta, aucun moyen de paiement demandé) — cohérent avec le positionnement légal.

## Vérifs
- `tsc --noEmit` : OK
- `next lint` : OK
- `next build` : OK (`/icon.svg` servie)
- `vitest` : 8/8 OK

NB : le nettoyage des entrées de test du catalogue (`fleure`, `bambou`…) est une opération sur les données prod (collection `plants`), pas du code — traitée séparément avec vérification des références.