### PR TITLE
fix(web): remove Diagnostic IA teaser card from dashboard

### DIFF
--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -223,9 +223,8 @@ export default function WelcomePage() {
             transition={{ duration: 0.6, delay: 0.5 }}
           >
             <h2 className="text-2xl font-bold text-[#234632] mb-6">À découvrir</h2>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {[
-                { icon: Leaf, title: 'Diagnostic IA', description: 'Analysez la santé de vos plantes avec notre IA' },
                 { icon: Zap, title: 'Rappels intelligents', description: 'Recevez des notifications personnalisées' },
                 { icon: Lightbulb, title: 'Conseils experts', description: 'Obtenez des recommandations adaptées' },
               ].map((feature, index) => {


### PR DESCRIPTION
La carte « Diagnostic IA » de la section « À découvrir » du dashboard promettait une fonctionnalité d'analyse IA qui n'est **pas disponible sur le web** (debug-only / iOS uniquement). Retrait de la carte ; grille passée à 2 colonnes (Rappels intelligents + Conseils experts).

Vérifs : `tsc` OK, `next lint` OK, `next build` OK.