### PR TITLE
fix(appstore): point Support URL to mailto (arbore.app/support was 404)

### DIFF
--- a/fastlane/metadata/de-DE/support_url.txt
+++ b/fastlane/metadata/de-DE/support_url.txt
@@ -1,1 +1,1 @@
-https://arbore.app/support
+mailto:contact@arbore.app

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://arbore.app/support
+mailto:contact@arbore.app

--- a/fastlane/metadata/es-ES/support_url.txt
+++ b/fastlane/metadata/es-ES/support_url.txt
@@ -1,1 +1,1 @@
-https://arbore.app/support
+mailto:contact@arbore.app

--- a/fastlane/metadata/fr-FR/support_url.txt
+++ b/fastlane/metadata/fr-FR/support_url.txt
@@ -1,1 +1,1 @@
-https://arbore.app/support
+mailto:contact@arbore.app


### PR DESCRIPTION
Le **Support URL** déclaré dans les métadonnées App Store (`fastlane/metadata/<locale>/support_url.txt`) pointait vers `https://arbore.app/support` — qui renvoie un **HTTP 404** (page inexistante sur la vitrine). Apple peut flagger un Support URL non fonctionnel à la review.

Remplacement par `mailto:contact@arbore.app` dans les **4 locales** (de-DE, en-US, es-ES, fr-FR).

Trouvé en auditant #206. 

⚠️ **Caveat** : si App Store Connect refuse un `mailto:` dans le champ Support URL (certains comptes exigent http(s)), le fallback robuste est `https://arbore.app` (la vitrine répond). À ajuster si rejet à l'upload via `fastlane upload_metadata`.

Refs #206