### PR TITLE
fix(appstore): Support URL https instead of mailto (ASC rejects mailto)

### DIFF
--- a/fastlane/metadata/de-DE/support_url.txt
+++ b/fastlane/metadata/de-DE/support_url.txt
@@ -1,1 +1,1 @@
-mailto:contact@arbore.app
+https://arbore.app

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-mailto:contact@arbore.app
+https://arbore.app

--- a/fastlane/metadata/es-ES/support_url.txt
+++ b/fastlane/metadata/es-ES/support_url.txt
@@ -1,1 +1,1 @@
-mailto:contact@arbore.app
+https://arbore.app

--- a/fastlane/metadata/fr-FR/support_url.txt
+++ b/fastlane/metadata/fr-FR/support_url.txt
@@ -1,1 +1,1 @@
-mailto:contact@arbore.app
+https://arbore.app


### PR DESCRIPTION
Suite de #274. App Store Connect **rejette un `mailto:`** dans le champ Support URL :

> An attribute value is invalid. - The Support URL you entered is invalid. - /data/attributes/supportUrl

(échec sur les 4 locales via `fastlane upload_metadata`).

Bascule sur **`https://arbore.app`** (vitrine live, cohérent avec `marketing_url`). Vérifié : `bundle exec fastlane upload_metadata` **passe maintenant** sur de/en/es/fr (« fastlane.tools finished successfully 🎉 », métadonnées en brouillon ASC).

Refs #206