### PR TITLE
ci(docs-drift): add explicit allowlist for legitimately-absent references

### DIFF
--- a/.github/scripts/docs-drift-allowlist.txt
+++ b/.github/scripts/docs-drift-allowlist.txt
@@ -1,0 +1,18 @@
+# docs-drift — allowlist
+#
+# Liste de fichiers cités dans docs/ qui sont LÉGITIMEMENT absents du dépôt et
+# ne doivent donc PAS faire échouer le drift check, alors qu'ils ne sont pas
+# (ou pas au chemin exact) couverts par .gitignore :
+#   - secrets / clés référencés par leur nom nu (ex. AuthKey.json sans préfixe)
+#   - fichiers générés au build / à l'exécution
+#   - ressources d'un autre dépôt citées par leur nom
+#
+# Règle de matching : une référence est ignorée si elle est EXACTEMENT une de
+# ces entrées, ou si elle se termine par "/<entrée>" (suffixe de chemin).
+# Une entrée par ligne. '#' = commentaire, lignes vides ignorées.
+#
+# ⚠️ N'ajoute ici que des fichiers VRAIMENT censés être absents. Pour un vrai
+# fichier du dépôt, cite plutôt son chemin qualifié dans la doc.
+
+# Clé API App Store Connect (fastlane) — gitignorée, citée parfois sans préfixe.
+AuthKey.json

--- a/.github/scripts/docs-drift-check.sh
+++ b/.github/scripts/docs-drift-check.sh
@@ -64,6 +64,21 @@ done < <(
 echo "Indexed ${#repo_files[@]} source file(s) in the repository."
 echo ""
 
+# Allowlist explicite : fichiers cités dans docs/ légitimement absents du dépôt
+# (secrets cités par nom nu, fichiers générés, ressources externes). Une
+# référence qui matche une entrée n'est pas comptée comme drift.
+ALLOWLIST_FILE="$(dirname "$0")/docs-drift-allowlist.txt"
+allowlist=()
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"                                            # retire commentaires
+    line="$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -n "$line" ] && allowlist+=("$line")
+  done < "$ALLOWLIST_FILE"
+  echo "Loaded ${#allowlist[@]} allowlist entr(ies) from $ALLOWLIST_FILE."
+  echo ""
+fi
+
 for md in "${md_files[@]}"; do
   # Extrait tous les contenus entre backticks (single or double) du fichier.
   # On utilise grep -oP avec une regex Perl-compatible pour matcher uniquement
@@ -149,6 +164,19 @@ for md in "${md_files[@]}"; do
       if git check-ignore --quiet "$candidate" 2>/dev/null; then
         found=1
       fi
+    fi
+
+    # Skip si présent dans l'allowlist explicite : match exact ou suffixe de
+    # chemin ("/<entrée>"), pour couvrir aussi bien "AuthKey.json" que
+    # "fastlane/AuthKey.json".
+    if [ "$found" -eq 0 ] && [ ${#allowlist[@]} -gt 0 ]; then
+      for entry in "${allowlist[@]}"; do
+        if [[ "$candidate" == "$entry" ]] || [[ "$candidate" == *"/$entry" ]]; then
+          found=1
+          echo "  ℹ️  allowlisted: $candidate (entrée « $entry »)"
+          break
+        fi
+      done
     fi
 
     if [ "$found" -eq 0 ]; then


### PR DESCRIPTION
## Contexte

Le check **Doc drift** (`.github/scripts/docs-drift-check.sh`) fail si un chemin de fichier cité dans `docs/` n'existe nulle part dans le dépôt. Il skippe déjà les fichiers **gitignorés** (`git check-ignore`), mais pas les références **légitimement absentes non couvertes par `.gitignore`** — typiquement un secret cité par son **nom nu** (`AuthKey.json` sans préfixe, cf. l'accroc sur #276), un fichier généré, ou une ressource d'un autre dépôt.

## Changement

Ajout d'une **allowlist explicite** : `.github/scripts/docs-drift-allowlist.txt` (une entrée par ligne, `#` = commentaire). Une référence est ignorée si son chemin **est exactement** une entrée, ou **se termine par `/<entrée>`** (couvre `AuthKey.json` comme `fastlane/AuthKey.json`). Chaque skip est loggé (`ℹ️ allowlisted: …`).

Seedée avec `AuthKey.json` (la clé API fastlane).

## Vérif (self-test local)
- Entrée allowlistée (`AuthKey.json`, `path/to/AuthKey.json`) → **skippée** ✅
- Vrai fichier absent (`ArboreUi/NoSuchFile.swift`) → **drift détecté, exit 1** ✅ (l'allowlist ne masque pas le vrai drift)
- Suite docs/ actuelle → **✅ No doc drift**