### PR TITLE
feat: add botanic Source flag and Meshy image-to-3D generator

### DIFF
--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -192,6 +192,25 @@ type Plant struct {
 	UpAxis       *string                 `json:"upAxis,omitempty" bson:"upAxis,omitempty"`
 	Source       *string                 `json:"source,omitempty" bson:"source,omitempty"`       // "botanic" = scrapé depuis botanic.com ; nil/"" = legacy/beta
 	SourceURL    *string                 `json:"sourceUrl,omitempty" bson:"sourceUrl,omitempty"` // URL botanic.com d'origine (conservée pour ré-scrape/màj ultérieure)
+	Flags        *PlantFlags             `json:"flags,omitempty" bson:"flags,omitempty"`         // drapeaux structurés pour la reco wizard (fiables, vs matching mots-clés)
+}
+
+// PlantFlags : drapeaux booléens structurés alimentant la recommandation du
+// wizard (filtre + scoring). Renseignés par recherche ; nil sur les plantes
+// legacy (le wizard retombe alors sur le matching mots-clés du texte).
+type PlantFlags struct {
+	ToxicToPets     bool `json:"toxicToPets" bson:"toxicToPets"`         // toxique chats/chiens (ASPCA)
+	ToxicToChildren bool `json:"toxicToChildren" bson:"toxicToChildren"` // dangereuse/irritante si ingérée par un enfant
+	EasyCare        bool `json:"easyCare" bson:"easyCare"`               // facile / débutant
+	ShadeTolerant   bool `json:"shadeTolerant" bson:"shadeTolerant"`     // supporte ombre / faible lumière
+	FullSunTolerant bool `json:"fullSunTolerant" bson:"fullSunTolerant"` // supporte plein soleil 6h+
+	DroughtTolerant bool `json:"droughtTolerant" bson:"droughtTolerant"` // sol sec / arrosage espacé
+	HumidityLoving  bool `json:"humidityLoving" bson:"humidityLoving"`   // aime l'humidité (salle de bain)
+	Flowering       bool `json:"flowering" bson:"flowering"`             // cultivée pour ses fleurs
+	Climbing        bool `json:"climbing" bson:"climbing"`               // grimpante (tuteur)
+	Trailing        bool `json:"trailing" bson:"trailing"`               // retombante (suspension)
+	Compact         bool `json:"compact" bson:"compact"`                 // compacte / petits espaces
+	AirPurifying    bool `json:"airPurifying" bson:"airPurifying"`       // dépolluante (liste NASA)
 }
 
 type AIRequest struct {

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -196,7 +196,7 @@ type Plant struct {
 	HasHeavy     *bool                   `json:"hasHeavy,omitempty" bson:"hasHeavy,omitempty"`   // true = une version haute définition existe (servie via /models/<file>?lod=heavy)
 }
 
-// PlantFlags : drapeaux booléens structurés alimentant la recommandation du
+// PlantFlags : drapeaux booléens structurés alimentant la reco du
 // wizard (filtre + scoring). Renseignés par recherche ; nil sur les plantes
 // legacy (le wizard retombe alors sur le matching mots-clés du texte).
 type PlantFlags struct {
@@ -1644,7 +1644,7 @@ func main() {
 
 			// LOD: ?lod=heavy sert le modèle haute définition depuis ./models/heavy/.
 			// (Une seule route : un sous-chemin /models/heavy/:filename ferait paniquer
-			// httprouter — conflit wildcard ':filename' vs segment statique 'heavy'.)
+			// httprouter — collision wildcard ':filename' vs segment statique 'heavy'.)
 			baseDir := "./models"
 			if c.Query("lod") == "heavy" {
 				baseDir = "./models/heavy"

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -193,6 +193,7 @@ type Plant struct {
 	Source       *string                 `json:"source,omitempty" bson:"source,omitempty"`       // "botanic" = scrapé depuis botanic.com ; nil/"" = legacy/beta
 	SourceURL    *string                 `json:"sourceUrl,omitempty" bson:"sourceUrl,omitempty"` // URL botanic.com d'origine (conservée pour ré-scrape/màj ultérieure)
 	Flags        *PlantFlags             `json:"flags,omitempty" bson:"flags,omitempty"`         // drapeaux structurés pour la reco wizard (fiables, vs matching mots-clés)
+	HasHeavy     *bool                   `json:"hasHeavy,omitempty" bson:"hasHeavy,omitempty"`   // true = une version haute définition existe (servie via /models/<file>?lod=heavy)
 }
 
 // PlantFlags : drapeaux booléens structurés alimentant la recommandation du
@@ -1629,8 +1630,8 @@ func main() {
 		protected.GET("/models/:filename", func(c *gin.Context) {
 			filename := c.Param("filename")
 
-			// Sécurité: empêcher les path traversal attacks
-			if strings.Contains(filename, "..") || strings.Contains(filename, "/") {
+			// Sécurité: empêcher les path traversal attacks (parité avec le handler thumbnails)
+			if strings.Contains(filename, "..") || strings.ContainsAny(filename, "/\\") {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid filename"})
 				return
 			}
@@ -1641,7 +1642,14 @@ func main() {
 				return
 			}
 
-			filePath := fmt.Sprintf("./models/%s", filename)
+			// LOD: ?lod=heavy sert le modèle haute définition depuis ./models/heavy/.
+			// (Une seule route : un sous-chemin /models/heavy/:filename ferait paniquer
+			// httprouter — conflit wildcard ':filename' vs segment statique 'heavy'.)
+			baseDir := "./models"
+			if c.Query("lod") == "heavy" {
+				baseDir = "./models/heavy"
+			}
+			filePath := fmt.Sprintf("%s/%s", baseDir, filename)
 
 			// Vérifier si le fichier existe
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -190,7 +190,8 @@ type Plant struct {
 	Translations map[string]LanguageData `json:"translations" bson:"translations"`
 	Generated    *bool                   `json:"generated,omitempty" bson:"generated,omitempty"`
 	UpAxis       *string                 `json:"upAxis,omitempty" bson:"upAxis,omitempty"`
-	Source       *string                 `json:"source,omitempty" bson:"source,omitempty"` // "botanic" = scrapé depuis botanic.com ; nil/"" = legacy/beta
+	Source       *string                 `json:"source,omitempty" bson:"source,omitempty"`       // "botanic" = scrapé depuis botanic.com ; nil/"" = legacy/beta
+	SourceURL    *string                 `json:"sourceUrl,omitempty" bson:"sourceUrl,omitempty"` // URL botanic.com d'origine (conservée pour ré-scrape/màj ultérieure)
 }
 
 type AIRequest struct {

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -190,6 +190,7 @@ type Plant struct {
 	Translations map[string]LanguageData `json:"translations" bson:"translations"`
 	Generated    *bool                   `json:"generated,omitempty" bson:"generated,omitempty"`
 	UpAxis       *string                 `json:"upAxis,omitempty" bson:"upAxis,omitempty"`
+	Source       *string                 `json:"source,omitempty" bson:"source,omitempty"` // "botanic" = scrapé depuis botanic.com ; nil/"" = legacy/beta
 }
 
 type AIRequest struct {

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView+ManualReplacement.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView+ManualReplacement.swift
@@ -252,7 +252,8 @@ extension GardenARPlacementContainerView.Coordinator {
                                     upAxis: persisted.upAxis,
                                     surfaceType: persisted.surfaceType,
                                     surfaceHeight: persisted.surfaceHeight,
-                                    autoSelect: false  // batch — entering .adjusting
+                                    autoSelect: false,  // batch — entering .adjusting
+                                    hasHeavy: persisted.hasHeavy == true
                                 )
                             }
                         } catch {
@@ -268,7 +269,8 @@ extension GardenARPlacementContainerView.Coordinator {
                                         upAxis: persisted.upAxis,
                                         surfaceType: persisted.surfaceType,
                                         surfaceHeight: persisted.surfaceHeight,
-                                        autoSelect: false
+                                        autoSelect: false,
+                                        hasHeavy: persisted.hasHeavy == true
                                     )
                                 }
                             }

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -1236,6 +1236,7 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
         uiView.session.delegate = nil
         uiView.delegate = nil
         coordinator.cancelPendingRestore()
+        coordinator.cancelAllHeavyUpgrades()
         NotificationCenter.default.removeObserver(coordinator)
         coordinator.arView = nil
     }
@@ -1258,6 +1259,9 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
             // Rate-limit "no surface" warnings during boundary tracing.
             private var lastNoSurfaceWarnAt: TimeInterval = 0
             private var selectedNode: SCNNode?
+            /// LOD : upgrades heavy en cours, indexés par instanceId du placement,
+            /// pour pouvoir les annuler (suppression de la plante / teardown de la vue).
+            private var heavyUpgradeTasks: [UUID: Task<Void, Never>] = [:]
             private var isRestoring = false
             var isWaitingForWorldMapLoad = false
             var worldMapLoadedAt: TimeInterval = 0
@@ -1358,6 +1362,7 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                 let surfaceHeight: Float?
                 let instanceId: UUID  // anchor.identifier — used so the loaded node can find its anchor
                 let autoSelect: Bool  // false for batch placements (AI auto-place) to avoid orange-halo flicker
+                var hasHeavy: Bool = false  // LOD: si true, on charge la version lourde en fond puis on swap
             }
 
             // 🤖 AI Auto-placement
@@ -3297,6 +3302,15 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                 // Lookup is by per-instance UUID (not catalog plantId) so deleting
                 // one of two same-species plants targets the correct one.
                 let pid = plantId(of: node)
+                // LOD : couper un upgrade heavy éventuellement en cours pour ce placement
+                // (sinon le download + parse continuent inutilement après suppression).
+                if let uuid = instanceId(of: node) {
+                    heavyUpgradeTasks[uuid]?.cancel()
+                    heavyUpgradeTasks[uuid] = nil
+                    if let f = node.arboreModelURLString {
+                        Task { await ModelCacheManager.shared.cancelDownload(for: f) }
+                    }
+                }
                 if let uuid = instanceId(of: node),
                    let anchor = plantAnchorMap[uuid] {
                     arView.session.remove(anchor: anchor)
@@ -3409,7 +3423,7 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
 
                 saveStateForUndo()
                 if let axis = plant.upAxis { plantUpAxisMap[plant.id] = axis }
-                placeObject(at: transform, modelURL: url, id: plant.id, name: plant.name, modelURLString: plant.modelURL, upAxis: plant.upAxis)
+                placeObject(at: transform, modelURL: url, id: plant.id, name: plant.name, modelURLString: plant.modelURL, upAxis: plant.upAxis, hasHeavy: plant.hasHeavy == true)
             }
 
             @objc func handleLongPressToSelect(_ gesture: UILongPressGestureRecognizer) {
@@ -3499,7 +3513,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                 upAxis: String? = nil,
                 surfaceType: String? = nil,
                 surfaceHeight: Float? = nil,
-                autoSelect: Bool = true
+                autoSelect: Bool = true,
+                hasHeavy: Bool = false
             ) {
                 guard let arView = arView else { return }
 
@@ -3524,7 +3539,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                     surfaceType: surfaceType,
                     surfaceHeight: surfaceHeight,
                     instanceId: anchor.identifier,
-                    autoSelect: autoSelect
+                    autoSelect: autoSelect,
+                    hasHeavy: hasHeavy
                 )
                 plantAnchorMap[anchor.identifier] = anchor
                 arView.session.add(anchor: anchor)
@@ -3665,12 +3681,120 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                         selectNode(container)
                     }
 
+                    // LOD : si une version haute définition existe, on la charge en
+                    // tâche de fond et on swap le node léger une fois prête. Fail-safe :
+                    // toute erreur laisse le modèle léger en place.
+                    if pending.hasHeavy {
+                        scheduleHeavyUpgrade(pending: pending, parentNode: parentNode)
+                    }
+
                     AppLog.arAnchor.notice("""
                         instantiated plant=\(pending.plantName, privacy: .public) \
                         anchor=\(pending.instanceId.uuidString.prefix(8), privacy: .public) \
                         world=\(container.simdWorldTransform.logDescription, privacy: .public) \
                         local=\(container.simdTransform.logDescription, privacy: .public)
                         """)
+            }
+
+            // MARK: - LOD heavy upgrade
+
+            /// Après le placement d'un modèle LÉGER, télécharge sa variante LOURDE
+            /// (haute définition) en fond et la swappe une fois prête. Fail-safe :
+            /// toute erreur (réseau, parse) laisse le modèle léger en place.
+            /// ⚠️ À valider sur device (non testable en CI).
+            private func scheduleHeavyUpgrade(pending: PendingPlantPlacement, parentNode: SCNNode) {
+                guard let filename = pending.modelURLString, !filename.isEmpty else { return }
+                let instanceId = pending.instanceId
+                let upAxis = pending.upAxis
+                heavyUpgradeTasks[instanceId]?.cancel()
+                heavyUpgradeTasks[instanceId] = Task { [weak self, weak parentNode] in
+                    do {
+                        let heavyURL = try await ModelCacheManager.shared.getModelURL(for: filename, lod: .heavy)
+                        if Task.isCancelled { return }
+                        let scene = try SCNScene(url: heavyURL, options: nil)
+                        if Task.isCancelled { return }
+                        await MainActor.run {
+                            guard let self else { return }
+                            self.heavyUpgradeTasks[instanceId] = nil
+                            guard let parentNode else { return }
+                            self.swapToHeavy(scene: scene, instanceId: instanceId, upAxis: upAxis, parentNode: parentNode)
+                        }
+                    } catch {
+                        await MainActor.run { self?.heavyUpgradeTasks[instanceId] = nil }
+                    }
+                }
+            }
+
+            /// Remplace le node LÉGER déjà placé par sa variante LOURDE, avec un court
+            /// fondu croisé, puis libère le léger. Position/rotation/échelle sont reprises
+            /// du léger (préserve le placement + pinch-zoom) ; le pivot est re-dérivé depuis
+            /// la bbox du heavy (robuste si light/heavy ont des bbox légèrement différentes).
+            /// Hypothèse restante à valider on-device : même origine/échelle model-space
+            /// et même up-axis entre les deux LOD (garanti par le même source Meshy).
+            private func swapToHeavy(scene: SCNScene, instanceId: UUID, upAxis: String?, parentNode: SCNNode) {
+                // Le node léger a pu être supprimé (l'utilisateur a retiré la plante) → on abandonne.
+                guard let light = parentNode.childNodes.first(where: { $0.arboreInstanceId == instanceId }) else { return }
+
+                let heavy = SCNNode()
+                heavy.name = light.name
+                heavy.arborePlantId = light.arborePlantId
+                heavy.arborePlantName = light.arborePlantName
+                heavy.arboreInstanceId = light.arboreInstanceId
+                heavy.arboreModelURLString = light.arboreModelURLString
+
+                let wrapper = SCNNode()
+                for child in scene.rootNode.childNodes { wrapper.addChildNode(child) }
+                // Même correction d'axe que le wrapper léger (même plante).
+                let effectiveAxis = upAxis ?? plantUpAxisMap[light.arborePlantId ?? ""]
+                if effectiveAxis?.uppercased() == "Z" { wrapper.eulerAngles.x = -.pi / 2 }
+                heavy.addChildNode(wrapper)
+                stripPotIfNeeded(from: heavy)
+
+                // Position / rotation / échelle reprises du léger (même placement +
+                // pinch-zoom). simdTransform encode déjà T·R·S → pas de copie de .scale.
+                heavy.simdTransform = light.simdTransform
+                // Pivot RE-DÉRIVÉ depuis la bbox du HEAVY (et non copié du léger) : après
+                // décimation, light/heavy peuvent avoir des bbox légèrement différentes ;
+                // copier le pivot du léger ferait flotter/enfoncer la base du heavy.
+                let (heavyMin, heavyMax) = heavy.boundingBox
+                if heavyMax.y - heavyMin.y > 0 {
+                    heavy.pivot = SCNMatrix4MakeTranslation(0, heavy.scale.y * heavyMin.y, 0)
+                    heavy.setValue(NSNumber(value: heavyMin.y), forKey: "arboreOriginalMinY")
+                } else {
+                    heavy.pivot = light.pivot
+                }
+
+                buildHaloCache(for: heavy, source: wrapper)
+                if parentProps?.relocationPhase == .adjusting {
+                    applyOutline(to: heavy, color: Self.outlineDefaultColor)
+                }
+
+                // Fondu croisé : on révèle le heavy, on masque le léger, puis on le retire.
+                let wasSelected = (selectedNode === light)
+                heavy.opacity = 0
+                parentNode.addChildNode(heavy)
+                // Pendant le fondu, light + heavy coexistent au même endroit. On retire
+                // le léger du hit-test (isPlantNode filtre sur le préfixe "plant_") pour
+                // qu'un tap ne sélectionne pas le node en cours de suppression. L'identité
+                // de swap/suppression passe par arboreInstanceId (KVC), pas par le name.
+                light.name = nil
+
+                SCNTransaction.begin()
+                SCNTransaction.animationDuration = 0.25
+                heavy.opacity = 1
+                light.opacity = 0
+                SCNTransaction.completionBlock = { [weak light] in light?.removeFromParentNode() }
+                SCNTransaction.commit()
+
+                if wasSelected { selectNode(heavy) }
+
+                AppLog.arAnchor.notice("LOD swap → heavy anchor=\(instanceId.uuidString.prefix(8), privacy: .public)")
+            }
+
+            /// Annule tous les upgrades heavy en cours (teardown / reset de scène).
+            func cancelAllHeavyUpgrades() {
+                for (_, task) in heavyUpgradeTasks { task.cancel() }
+                heavyUpgradeTasks.removeAll()
             }
 
             /// Called on the main thread when SCNScene loading fails. Attempts a

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -1259,9 +1259,16 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
             // Rate-limit "no surface" warnings during boundary tracing.
             private var lastNoSurfaceWarnAt: TimeInterval = 0
             private var selectedNode: SCNNode?
-            /// LOD : upgrades heavy en cours, indexés par instanceId du placement,
-            /// pour pouvoir les annuler (suppression de la plante / teardown de la vue).
-            private var heavyUpgradeTasks: [UUID: Task<Void, Never>] = [:]
+            /// LOD : swaps (heavy↔light) en cours, indexés par instanceId, avec leur LOD
+            /// CIBLE — pour ne pas les annuler/redémarrer à tort, appliquer la bonne
+            /// hystérésis pendant le download, et annuler le download au bon niveau.
+            private struct InFlightLODSwap { let task: Task<Void, Never>; let target: ModelLOD }
+            private var heavyUpgradeTasks: [UUID: InFlightLODSwap] = [:]
+            /// LOD : throttle de l'évaluation per-frame (temps de rendu du dernier passage).
+            private var lastLODEvalAt: TimeInterval = 0
+            /// LOD : dernier instant de chauffe (thermal ≥ .serious / Low Power). -1 = jamais.
+            /// Sert au cooldown : on ne ré-autorise les upgrades qu'après un retour au frais soutenu.
+            private var lodLastHotAt: TimeInterval = -1
             private var isRestoring = false
             var isWaitingForWorldMapLoad = false
             var worldMapLoadedAt: TimeInterval = 0
@@ -1692,11 +1699,19 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                 // "delegate is retaining N ARFrames" warnings).
                 if let frame = arView.session.currentFrame {
                     let lux = Int(frame.lightEstimate?.ambientIntensity ?? 0)
-                    lastCameraY = frame.camera.transform.columns.3.y
+                    let camCol = frame.camera.transform.columns.3
+                    lastCameraY = camCol.y
                     DispatchQueue.main.async { [weak self] in
                         withAnimation(.linear(duration: 0.2)) {
                             self?.parentProps?.currentLux = lux
                         }
+                    }
+                    // LOD adaptatif : ré-évalue le light/heavy de chaque plante ~4 Hz
+                    // (thermique + budget + distance). Calcul + swaps sur le main thread.
+                    if time - lastLODEvalAt >= PlantLODPolicy.evalInterval {
+                        lastLODEvalAt = time
+                        let camPos = SIMD3<Float>(camCol.x, camCol.y, camCol.z)
+                        DispatchQueue.main.async { [weak self] in self?.evaluateLOD(cameraPosition: camPos) }
                     }
                 }
 
@@ -3309,11 +3324,12 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                 let pid = plantId(of: node)
                 // LOD : couper un upgrade heavy éventuellement en cours pour ce placement
                 // (sinon le download + parse continuent inutilement après suppression).
-                if let uuid = instanceId(of: node) {
-                    heavyUpgradeTasks[uuid]?.cancel()
+                if let uuid = instanceId(of: node), let inflight = heavyUpgradeTasks[uuid] {
+                    inflight.task.cancel()
                     heavyUpgradeTasks[uuid] = nil
                     if let f = node.arboreModelURLString {
-                        Task { await ModelCacheManager.shared.cancelDownload(for: f) }
+                        let lod = inflight.target
+                        Task { await ModelCacheManager.shared.cancelDownload(for: f, lod: lod) }
                     }
                 }
                 if let uuid = instanceId(of: node),
@@ -3609,6 +3625,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
 
                     let (minVec, maxVec) = container.boundingBox
                     let rawHeight = maxVec.y - minVec.y
+                    // Hauteur intrinsèque (avant le halo) pour le LOD distance.
+                    container.arboreModelRawHeight = Double(max(0, rawHeight))
 
                     AppLog.plants.debug("""
                         bbox plant=\(pending.plantName, privacy: .public) \
@@ -3687,12 +3705,10 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                         selectNode(container)
                     }
 
-                    // LOD : si une version haute définition existe, on la charge en
-                    // tâche de fond et on swap le node léger une fois prête. Fail-safe :
-                    // toute erreur laisse le modèle léger en place.
-                    if pending.hasHeavy {
-                        scheduleHeavyUpgrade(pending: pending, parentNode: parentNode)
-                    }
+                    // LOD adaptatif : le modèle LÉGER est posé immédiatement. L'upgrade
+                    // vers le heavy (et les downgrades) est piloté par evaluateLOD() depuis
+                    // renderer(_:updateAtTime:), selon thermique + budget K + distance.
+                    container.arboreCurrentLOD = PlantLODPolicy.LOD.light.rawValue
 
                     AppLog.arAnchor.notice("""
                         instantiated plant=\(pending.plantName, privacy: .public) \
@@ -3702,105 +3718,225 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                         """)
             }
 
-            // MARK: - LOD heavy upgrade
+            // MARK: - LOD adaptatif (light ↔ heavy)
 
-            /// Après le placement d'un modèle LÉGER, télécharge sa variante LOURDE
-            /// (haute définition) en fond et la swappe une fois prête. Fail-safe :
-            /// toute erreur (réseau, parse) laisse le modèle léger en place.
-            /// ⚠️ À valider sur device (non testable en CI).
-            private func scheduleHeavyUpgrade(pending: PendingPlantPlacement, parentNode: SCNNode) {
-                guard let filename = pending.modelURLString, !filename.isEmpty else { return }
-                let instanceId = pending.instanceId
-                let upAxis = pending.upAxis
-                heavyUpgradeTasks[instanceId]?.cancel()
-                heavyUpgradeTasks[instanceId] = Task { [weak self, weak parentNode] in
+            /// Programme un swap vers le LOD cible : télécharge le modèle (cache) en fond
+            /// et l'échange une fois prêt. Fail-safe : toute erreur laisse le modèle
+            /// courant en place. ⚠️ Comportement AR à valider on-device (non testable CI).
+            private func scheduleLODSwap(filename: String, upAxis: String?, instanceId: UUID,
+                                         parentNode: SCNNode, to lod: PlantLODPolicy.LOD) {
+                guard !filename.isEmpty else { return }
+                heavyUpgradeTasks[instanceId]?.task.cancel()
+                let modelLOD: ModelLOD = (lod == .heavy) ? .heavy : .light
+                let task = Task { [weak self, weak parentNode] in
                     do {
-                        let heavyURL = try await ModelCacheManager.shared.getModelURL(for: filename, lod: .heavy)
+                        let url = try await ModelCacheManager.shared.getModelURL(for: filename, lod: modelLOD)
                         if Task.isCancelled { return }
-                        let scene = try SCNScene(url: heavyURL, options: nil)
+                        let scene = try SCNScene(url: url, options: nil)
                         if Task.isCancelled { return }
                         await MainActor.run {
                             guard let self else { return }
                             self.heavyUpgradeTasks[instanceId] = nil
                             guard let parentNode else { return }
-                            self.swapToHeavy(scene: scene, instanceId: instanceId, upAxis: upAxis, parentNode: parentNode)
+                            self.swapModel(scene: scene, instanceId: instanceId, upAxis: upAxis, parentNode: parentNode, to: lod)
                         }
                     } catch {
                         await MainActor.run { self?.heavyUpgradeTasks[instanceId] = nil }
                     }
                 }
+                heavyUpgradeTasks[instanceId] = InFlightLODSwap(task: task, target: modelLOD)
             }
 
-            /// Remplace le node LÉGER déjà placé par sa variante LOURDE, avec un court
-            /// fondu croisé, puis libère le léger. Position/rotation/échelle sont reprises
-            /// du léger (préserve le placement + pinch-zoom) ; le pivot est re-dérivé depuis
-            /// la bbox du heavy (robuste si light/heavy ont des bbox légèrement différentes).
-            /// Hypothèse restante à valider on-device : même origine/échelle model-space
-            /// et même up-axis entre les deux LOD (garanti par le même source Meshy).
-            private func swapToHeavy(scene: SCNScene, instanceId: UUID, upAxis: String?, parentNode: SCNNode) {
-                // Le node léger a pu être supprimé (l'utilisateur a retiré la plante) → on abandonne.
-                guard let light = parentNode.childNodes.first(where: { $0.arboreInstanceId == instanceId }) else { return }
+            /// Remplace le node courant d'une plante par sa variante au LOD cible, avec un
+            /// court fondu croisé, puis libère l'ancien. Position/rotation/échelle reprises
+            /// de l'ancien (placement + pinch-zoom) ; pivot RE-DÉRIVÉ de la bbox du nouveau
+            /// modèle (robuste si les bbox light/heavy diffèrent légèrement).
+            /// Hypothèse à valider on-device : même origine/échelle model-space et même
+            /// up-axis entre les LOD (garanti par le même source Meshy).
+            private func swapModel(scene: SCNScene, instanceId: UUID, upAxis: String?,
+                                   parentNode: SCNNode, to lod: PlantLODPolicy.LOD) {
+                // Le node a pu être supprimé entre-temps → on abandonne.
+                guard let current = parentNode.childNodes.first(where: { $0.arboreInstanceId == instanceId }) else { return }
+                if current.arboreCurrentLOD == lod.rawValue { return } // déjà au bon LOD
 
-                let heavy = SCNNode()
-                heavy.name = light.name
-                heavy.arborePlantId = light.arborePlantId
-                heavy.arborePlantName = light.arborePlantName
-                heavy.arboreInstanceId = light.arboreInstanceId
-                heavy.arboreModelURLString = light.arboreModelURLString
+                let next = SCNNode()
+                next.name = current.name
+                next.arborePlantId = current.arborePlantId
+                next.arborePlantName = current.arborePlantName
+                next.arboreInstanceId = current.arboreInstanceId
+                next.arboreModelURLString = current.arboreModelURLString
+                next.arboreHasHeavy = current.arboreHasHeavy
+                next.arboreCurrentLOD = lod.rawValue
+                next.arboreLODLockedUntil = CACurrentMediaTime() + PlantLODPolicy.swapDebounce
 
                 let wrapper = SCNNode()
                 for child in scene.rootNode.childNodes { wrapper.addChildNode(child) }
-                // Même correction d'axe que le wrapper léger (même plante).
-                let effectiveAxis = upAxis ?? plantUpAxisMap[light.arborePlantId ?? ""]
+                let effectiveAxis = upAxis ?? plantUpAxisMap[current.arborePlantId ?? ""]
                 if effectiveAxis?.uppercased() == "Z" { wrapper.eulerAngles.x = -.pi / 2 }
-                heavy.addChildNode(wrapper)
-                stripPotIfNeeded(from: heavy)
+                next.addChildNode(wrapper)
+                stripPotIfNeeded(from: next)
 
-                // Position / rotation / échelle reprises du léger (même placement +
-                // pinch-zoom). simdTransform encode déjà T·R·S → pas de copie de .scale.
-                heavy.simdTransform = light.simdTransform
-                // Pivot RE-DÉRIVÉ depuis la bbox du HEAVY (et non copié du léger) : après
-                // décimation, light/heavy peuvent avoir des bbox légèrement différentes ;
-                // copier le pivot du léger ferait flotter/enfoncer la base du heavy.
-                let (heavyMin, heavyMax) = heavy.boundingBox
-                if heavyMax.y - heavyMin.y > 0 {
-                    heavy.pivot = SCNMatrix4MakeTranslation(0, heavy.scale.y * heavyMin.y, 0)
-                    heavy.setValue(NSNumber(value: heavyMin.y), forKey: "arboreOriginalMinY")
+                next.simdTransform = current.simdTransform  // encode déjà T·R·S
+                let (minV, maxV) = next.boundingBox
+                if maxV.y - minV.y > 0 {
+                    next.pivot = SCNMatrix4MakeTranslation(0, next.scale.y * minV.y, 0)
+                    next.setValue(NSNumber(value: minV.y), forKey: "arboreOriginalMinY")
                 } else {
-                    heavy.pivot = light.pivot
+                    next.pivot = current.pivot
                 }
+                // Hauteur intrinsèque mesurée AVANT le halo (pour le LOD distance).
+                next.arboreModelRawHeight = Double(max(0, maxV.y - minV.y))
 
-                buildHaloCache(for: heavy, source: wrapper)
+                buildHaloCache(for: next, source: wrapper)
                 if parentProps?.relocationPhase == .adjusting {
-                    applyOutline(to: heavy, color: Self.outlineDefaultColor)
+                    applyOutline(to: next, color: Self.outlineDefaultColor)
                 }
 
-                // Fondu croisé : on révèle le heavy, on masque le léger, puis on le retire.
-                let wasSelected = (selectedNode === light)
-                heavy.opacity = 0
-                parentNode.addChildNode(heavy)
-                // Pendant le fondu, light + heavy coexistent au même endroit. On retire
-                // le léger du hit-test (isPlantNode filtre sur le préfixe "plant_") pour
-                // qu'un tap ne sélectionne pas le node en cours de suppression. L'identité
-                // de swap/suppression passe par arboreInstanceId (KVC), pas par le name.
-                light.name = nil
+                // Fondu croisé : révèle le nouveau, masque l'ancien, puis le retire. On
+                // sort l'ancien du hit-test (name → nil) pour qu'un tap ne le sélectionne
+                // pas pendant le fondu (l'identité passe par arboreInstanceId, pas le name).
+                let wasSelected = (selectedNode === current)
+                next.opacity = 0
+                parentNode.addChildNode(next)
+                current.name = nil
 
                 SCNTransaction.begin()
                 SCNTransaction.animationDuration = 0.25
-                heavy.opacity = 1
-                light.opacity = 0
-                SCNTransaction.completionBlock = { [weak light] in light?.removeFromParentNode() }
+                next.opacity = 1
+                current.opacity = 0
+                SCNTransaction.completionBlock = { [weak current] in current?.removeFromParentNode() }
                 SCNTransaction.commit()
 
-                if wasSelected { selectNode(heavy) }
-
-                AppLog.arAnchor.notice("LOD swap → heavy anchor=\(instanceId.uuidString.prefix(8), privacy: .public)")
+                if wasSelected { selectNode(next) }
+                AppLog.arAnchor.notice("LOD swap → \(lod.rawValue, privacy: .public) anchor=\(instanceId.uuidString.prefix(8), privacy: .public)")
             }
 
-            /// Annule tous les upgrades heavy en cours (teardown / reset de scène).
+            /// Annule tous les swaps LOD en cours (teardown / reset de scène).
             func cancelAllHeavyUpgrades() {
-                for (_, task) in heavyUpgradeTasks { task.cancel() }
+                for (_, s) in heavyUpgradeTasks { s.task.cancel() }
                 heavyUpgradeTasks.removeAll()
+            }
+
+            // MARK: LOD evaluation (per-frame, throttlée ~4 Hz)
+
+            private struct LODCandidate {
+                let node: SCNNode
+                let parent: SCNNode
+                let instanceId: UUID
+                let filename: String
+                let upAxis: String?
+                let distance: Float
+                let height: Float
+                let currentlyHeavy: Bool
+                let isSelected: Bool
+                let lockedUntil: Double
+            }
+
+            /// Énumère les plantes à variante heavy avec distance/hauteur/LOD courant.
+            private func collectLODCandidates(cameraPosition: SIMD3<Float>) -> [LODCandidate] {
+                guard let arView else { return [] }
+                var out: [LODCandidate] = []
+                func consider(_ node: SCNNode, parent: SCNNode) {
+                    guard node.name?.hasPrefix("plant_") == true,
+                          node.arboreHasHeavy,
+                          let id = node.arboreInstanceId,
+                          let filename = node.arboreModelURLString, !filename.isEmpty else { return }
+                    let pos = node.simdWorldPosition
+                    let distance = simd_length(pos - cameraPosition)
+                    // Hauteur pré-halo × scale courant (zoom-aware) ; évite le +4% du halo.
+                    let height = Float(node.arboreModelRawHeight) * node.scale.y
+                    out.append(LODCandidate(
+                        node: node, parent: parent, instanceId: id, filename: filename,
+                        upAxis: plantUpAxisMap[node.arborePlantId ?? ""],
+                        distance: distance, height: height,
+                        currentlyHeavy: node.arboreCurrentLOD == PlantLODPolicy.LOD.heavy.rawValue,
+                        isSelected: node === selectedNode,
+                        lockedUntil: node.arboreLODLockedUntil))
+                }
+                for rootChild in arView.scene.rootNode.childNodes {
+                    consider(rootChild, parent: arView.scene.rootNode)
+                    for c in rootChild.childNodes { consider(c, parent: rootChild) }
+                }
+                return out
+            }
+
+            /// Évalue et applique le LOD de chaque plante (thermique → budget K → distance).
+            /// Sur le main thread, throttlée depuis renderer(_:updateAtTime:).
+            private func evaluateLOD(cameraPosition: SIMD3<Float>) {
+                let candidates = collectLODCandidates(cameraPosition: cameraPosition)
+                guard !candidates.isEmpty else { return }
+
+                let now = CACurrentMediaTime()
+                let thermal = ProcessInfo.processInfo.thermalState
+                let lowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+                let critical = (thermal == .critical)
+                let hot = critical || thermal == .serious || lowPower
+
+                // Cooldown : downgrade immédiat à chaud ; upgrades ré-autorisés seulement
+                // après un retour au frais soutenu (reco Apple — pas d'hystérésis native).
+                if hot { lodLastHotAt = now }
+                let upgradesAllowed = !hot && (lodLastHotAt < 0 || now - lodLastHotAt >= PlantLODPolicy.coolStableBeforeUpgrade)
+
+                // « Effectivement heavy » = déjà heavy OU heavy en cours de download. On lui
+                // applique la bande large d'hystérésis (pas d'annulation du download au moindre
+                // jitter) et la stickiness de budget.
+                func effectivelyHeavy(_ c: LODCandidate) -> Bool {
+                    c.currentlyHeavy || heavyUpgradeTasks[c.instanceId]?.target == .heavy
+                }
+
+                // Ensemble désiré-heavy (chaîne de précédence).
+                var desiredHeavy = Set<UUID>()
+                if !critical {
+                    let eligible = candidates.filter { c in
+                        c.isSelected || PlantLODPolicy.isWithinHeavy(distance: c.distance, height: c.height, currentlyHeavy: effectivelyHeavy(c))
+                    }.sorted { a, b in
+                        if a.isSelected != b.isSelected { return a.isSelected } // sélection prioritaire
+                        // Stickiness : un heavy en place garde un bonus de distance pour ne pas
+                        // se faire déloger du budget par une candidate à peine plus proche.
+                        let da = effectivelyHeavy(a) ? a.distance * (1 - PlantLODPolicy.budgetStickiness) : a.distance
+                        let db = effectivelyHeavy(b) ? b.distance * (1 - PlantLODPolicy.budgetStickiness) : b.distance
+                        return da < db
+                    }
+                    if hot {
+                        // .serious / Low Power : seule la plante sélectionnée peut être heavy.
+                        if let sel = eligible.first(where: { $0.isSelected }), effectivelyHeavy(sel) || upgradesAllowed {
+                            desiredHeavy.insert(sel.instanceId)
+                        }
+                    } else {
+                        let budget = PlantLODPolicy.heavyBudget(tier: DeviceCapabilities.tier)
+                        var granted = 0
+                        for c in eligible where granted < budget {
+                            // Garde un heavy existant ; n'AJOUTE un nouveau que si autorisé.
+                            if effectivelyHeavy(c) || upgradesAllowed {
+                                desiredHeavy.insert(c.instanceId)
+                                granted += 1
+                            }
+                        }
+                    }
+                }
+
+                // Application : upgrade / downgrade / annulation, avec debounce et garde
+                // sur le LOD cible déjà en vol (pour ne pas annuler/redémarrer à tort).
+                for c in candidates {
+                    let wantHeavy = desiredHeavy.contains(c.instanceId)
+                    let inFlightTarget = heavyUpgradeTasks[c.instanceId]?.target
+                    if wantHeavy {
+                        if !c.currentlyHeavy && inFlightTarget != .heavy && now >= c.lockedUntil {
+                            scheduleLODSwap(filename: c.filename, upAxis: c.upAxis, instanceId: c.instanceId, parentNode: c.parent, to: .heavy)
+                        }
+                    } else {
+                        // Annule un download HEAVY dont on ne veut plus (jamais un downgrade en cours).
+                        if inFlightTarget == .heavy {
+                            heavyUpgradeTasks[c.instanceId]?.task.cancel()
+                            heavyUpgradeTasks[c.instanceId] = nil
+                            let f = c.filename
+                            Task { await ModelCacheManager.shared.cancelDownload(for: f, lod: .heavy) }
+                        }
+                        if c.currentlyHeavy && heavyUpgradeTasks[c.instanceId]?.target != .light && now >= c.lockedUntil {
+                            scheduleLODSwap(filename: c.filename, upAxis: c.upAxis, instanceId: c.instanceId, parentNode: c.parent, to: .light)
+                        }
+                    }
+                }
             }
 
             /// Called on the main thread when SCNScene loading fails. Attempts a
@@ -4541,5 +4677,21 @@ extension SCNNode {
     var arboreHasHeavy: Bool {
         get { (value(forKey: "arboreHasHeavy") as? Bool) ?? false }
         set { setValue(newValue, forKey: "arboreHasHeavy") }
+    }
+    /// LOD courant effectivement affiché ("light" / "heavy"). Défaut "light".
+    var arboreCurrentLOD: String {
+        get { (value(forKey: "arboreCurrentLOD") as? String) ?? PlantLODPolicy.LOD.light.rawValue }
+        set { setValue(newValue, forKey: "arboreCurrentLOD") }
+    }
+    /// Debounce anti-yoyo : pas de nouveau swap LOD avant ce timestamp (CACurrentMediaTime).
+    var arboreLODLockedUntil: Double {
+        get { (value(forKey: "arboreLODLockedUntil") as? Double) ?? 0 }
+        set { setValue(newValue, forKey: "arboreLODLockedUntil") }
+    }
+    /// Hauteur intrinsèque (bbox non scalée, mesurée AVANT le halo) du modèle, pour
+    /// le calcul de distance LOD : hauteur_monde = arboreModelRawHeight × scale.y.
+    var arboreModelRawHeight: Double {
+        get { (value(forKey: "arboreModelRawHeight") as? Double) ?? 0 }
+        set { setValue(newValue, forKey: "arboreModelRawHeight") }
     }
 }

--- a/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/GardenARPlacementView.swift
@@ -2074,7 +2074,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                                     name: item.plant.name,
                                     modelURLString: item.plant.modelURL,
                                     upAxis: item.plant.upAxis,
-                                    autoSelect: false   // batch — no halo flicker
+                                    autoSelect: false,   // batch — no halo flicker
+                                    hasHeavy: item.plant.hasHeavy == true
                                 )
 
                                 // Light haptic per plant
@@ -2630,7 +2631,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                         transform: matrixToFloatArray(anchorTransform),
                         upAxis: plantUpAxisMap[plantId],
                         surfaceType: surfaceType,
-                        surfaceHeight: surfaceHeight
+                        surfaceHeight: surfaceHeight,
+                        hasHeavy: node.arboreHasHeavy
                     )
                 }
             }
@@ -3024,7 +3026,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                             surfaceType: p.surfaceType,
                             surfaceHeight: p.surfaceHeight,
                             instanceId: anchor.identifier,
-                            autoSelect: false
+                            autoSelect: false,
+                            hasHeavy: p.hasHeavy == true
                         )
                         self.instantiatePlantNode(into: node, pending: pending, anchorTransform: anchorTransform)
                     }
@@ -3130,7 +3133,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                                             modelURLString: p.modelURLString,
                                             upAxis: p.upAxis,
                                             surfaceType: p.surfaceType,
-                                            surfaceHeight: p.surfaceHeight
+                                            surfaceHeight: p.surfaceHeight,
+                                            hasHeavy: p.hasHeavy == true
                                         )
                                     }
                                 } catch {
@@ -3146,7 +3150,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                                                 modelURLString: p.modelURLString,
                                                 upAxis: p.upAxis,
                                                 surfaceType: p.surfaceType,
-                                                surfaceHeight: p.surfaceHeight
+                                                surfaceHeight: p.surfaceHeight,
+                                                hasHeavy: p.hasHeavy == true
                                             )
                                         }
                                     } else {
@@ -3591,6 +3596,7 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                     container.arboreInstanceId = pending.instanceId
                     container.arboreModelURLString = pending.modelURLString
                         ?? pending.modelURL.lastPathComponent
+                    container.arboreHasHeavy = pending.hasHeavy
 
                     let wrapper = SCNNode()
                     for child in scene.rootNode.childNodes { wrapper.addChildNode(child) }
@@ -3823,7 +3829,8 @@ struct GardenARPlacementContainerView: UIViewRepresentable {
                                 allowRetry: false,
                                 upAxis: pending.upAxis,
                                 surfaceType: pending.surfaceType,
-                                surfaceHeight: pending.surfaceHeight
+                                surfaceHeight: pending.surfaceHeight,
+                                hasHeavy: pending.hasHeavy
                             )
                         }
                     } catch {
@@ -4528,5 +4535,11 @@ extension SCNNode {
     var arboreModelURLString: String? {
         get { value(forKey: "arboreModelURLString") as? String }
         set { setValue(newValue, forKey: "arboreModelURLString") }
+    }
+    /// LOD : une version heavy existe pour cette plante (propagé à la sauvegarde
+    /// pour que la ré-ouverture du jardin re-déclenche l'upgrade).
+    var arboreHasHeavy: Bool {
+        get { (value(forKey: "arboreHasHeavy") as? Bool) ?? false }
+        set { setValue(newValue, forKey: "arboreHasHeavy") }
     }
 }

--- a/ArboreUi/ArboreUi/ARGarden/Quality/PlantLODPolicy.swift
+++ b/ArboreUi/ArboreUi/ARGarden/Quality/PlantLODPolicy.swift
@@ -1,0 +1,81 @@
+//
+//  PlantLODPolicy.swift
+//  ArboreUi
+//
+//  Politique LOD adaptative des modèles 3D de plantes en AR. Décide light vs
+//  heavy par une chaîne de précédence (les gates globaux ne peuvent que RÉDUIRE
+//  le détail) :
+//    1. Gate thermique (global)  — ProcessInfo.thermalState + Low Power Mode.
+//    2. Budget K de heavy (global) — selon DeviceCapabilities.tier.
+//    3. Distance / taille à l'écran (par plante) — avec hystérésis.
+//
+//  Valeurs par défaut issues de recherche (sources iOS thermal + LOD mobile AR ;
+//  cf docs/3d-lod-architecture.md). Constantes nommées, ajustables ici.
+//
+
+import Foundation
+
+enum PlantLODPolicy {
+
+    /// Niveau de détail courant d'un modèle (stocké sur le SCNNode en KVC).
+    enum LOD: String { case light, heavy }
+
+    // MARK: - Distance (on raisonne en taille à l'écran, pas en mètres absolus)
+
+    /// heavy tant que `distance < mult × hauteur` (≈ la plante couvre >30% de la
+    /// hauteur d'écran à ~60° de FOV vertical). Un seuil absolu en mètres serait
+    /// faux : un succulent de 30 cm et un ficus de 1,5 m n'ont pas le même seuil.
+    static let heavyDistanceHeightMultiplier: Float = 2.9
+    /// Hystérésis : le seuil de DOWNGRADE est 20% plus loin que celui d'UPGRADE,
+    /// pour éviter le yoyo quand on se tient juste à la frontière.
+    static let hysteresis: Float = 0.20
+    /// Clamp bas : à bras tendu une plante reste toujours heavy.
+    static let minSwapDistance: Float = 0.6
+    /// Clamp haut : au-delà, inutile de charger du heavy même pour une grande plante.
+    static let maxSwapDistance: Float = 4.5
+    /// Hauteur de repli si la bbox n'est pas exploitable.
+    static let fallbackPlantHeight: Float = 0.6
+
+    // MARK: - Budget (nombre max de modèles heavy simultanés)
+
+    /// K = nombre de heavy autorisés en même temps, selon le tier device.
+    /// Budget visible ~50k triangles ; un heavy ~20–40k tri → K≈1 sur legacy,
+    /// 2 sur modern (les flagships pourraient monter à 3, non distingués ici).
+    static func heavyBudget(tier: DeviceCapabilities.Tier) -> Int {
+        switch tier {
+        case .legacy: return 1
+        case .modern: return 2
+        }
+    }
+
+    // MARK: - Anti-yoyo (downgrade immédiat, upgrade lent — reco Apple)
+
+    /// Durée de thermique ≤ .fair SOUTENUE avant de ré-autoriser les upgrades
+    /// après une période de chauffe (pas d'hystérésis native côté API).
+    static let coolStableBeforeUpgrade: TimeInterval = 8.0
+    /// Délai minimum entre deux swaps d'une même plante.
+    static let swapDebounce: TimeInterval = 0.8
+    /// Cadence d'évaluation (≈ 4 Hz ; surtout pas 60).
+    static let evalInterval: TimeInterval = 0.25
+    /// Stickiness du budget : une plante déjà heavy ne se fait déloger par une
+    /// candidate plus proche que si celle-ci est >10% plus proche (anti ping-pong
+    /// entre plantes quasi-équidistantes).
+    static let budgetStickiness: Float = 0.10
+
+    // MARK: - Décision distance
+
+    /// Distance de bascule pour une plante de hauteur donnée (clampée).
+    static func swapDistance(forHeight height: Float) -> Float {
+        let h = height > 0 ? height : fallbackPlantHeight
+        return min(max(heavyDistanceHeightMultiplier * h, minSwapDistance), maxSwapDistance)
+    }
+
+    /// Éligible heavy par la distance, avec hystérésis selon le LOD courant :
+    /// - en light  : upgrade si `distance < seuil × (1 − hystérésis)`
+    /// - en heavy  : on garde heavy tant que `distance < seuil × (1 + hystérésis)`
+    static func isWithinHeavy(distance: Float, height: Float, currentlyHeavy: Bool) -> Bool {
+        let base = swapDistance(forHeight: height)
+        let threshold = currentlyHeavy ? base * (1 + hysteresis) : base * (1 - hysteresis)
+        return distance < threshold
+    }
+}

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -14,10 +14,11 @@ struct Plant: Identifiable, Codable {
     let generated: Bool?   // true = modèle 3D généré par IA (Meshy), nil/false = legacy
     let upAxis: String?    // "Y" (default, nil) ou "Z" (Blender exports qui doivent être redressés)
     let source: String?    // "botanic" = plante scrapée depuis botanic.com ; nil = legacy/beta
+    let sourceUrl: String? // URL botanic.com d'origine (conservée pour ré-scrape/màj)
 
     enum CodingKeys: String, CodingKey {
         case id
-        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source
+        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source, sourceUrl
     }
 
     // Décode avec fallback safe
@@ -44,6 +45,7 @@ struct Plant: Identifiable, Codable {
         self.generated = try container.decodeIfPresent(Bool.self, forKey: .generated)
         self.upAxis = try container.decodeIfPresent(String.self, forKey: .upAxis)
         self.source = try container.decodeIfPresent(String.self, forKey: .source)
+        self.sourceUrl = try container.decodeIfPresent(String.self, forKey: .sourceUrl)
     }
 
     // ✅ Helper pour reconstruire une plante minimale au moment du restore

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -16,10 +16,11 @@ struct Plant: Identifiable, Codable {
     let source: String?    // "botanic" = plante scrapée depuis botanic.com ; nil = legacy/beta
     let sourceUrl: String? // URL botanic.com d'origine (conservée pour ré-scrape/màj)
     let flags: PlantFlags? // drapeaux structurés pour la reco wizard ; nil = legacy (fallback mots-clés)
+    let hasHeavy: Bool?    // true = une version 3D haute définition existe (LOD : swap depuis le léger en AR)
 
     enum CodingKeys: String, CodingKey {
         case id
-        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source, sourceUrl, flags
+        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source, sourceUrl, flags, hasHeavy
     }
 
     // Décode avec fallback safe
@@ -48,6 +49,7 @@ struct Plant: Identifiable, Codable {
         self.source = try container.decodeIfPresent(String.self, forKey: .source)
         self.sourceUrl = try container.decodeIfPresent(String.self, forKey: .sourceUrl)
         self.flags = try container.decodeIfPresent(PlantFlags.self, forKey: .flags)
+        self.hasHeavy = try container.decodeIfPresent(Bool.self, forKey: .hasHeavy)
     }
 
     // ✅ Helper pour reconstruire une plante minimale au moment du restore

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -15,10 +15,11 @@ struct Plant: Identifiable, Codable {
     let upAxis: String?    // "Y" (default, nil) ou "Z" (Blender exports qui doivent être redressés)
     let source: String?    // "botanic" = plante scrapée depuis botanic.com ; nil = legacy/beta
     let sourceUrl: String? // URL botanic.com d'origine (conservée pour ré-scrape/màj)
+    let flags: PlantFlags? // drapeaux structurés pour la reco wizard ; nil = legacy (fallback mots-clés)
 
     enum CodingKeys: String, CodingKey {
         case id
-        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source, sourceUrl
+        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source, sourceUrl, flags
     }
 
     // Décode avec fallback safe
@@ -46,6 +47,7 @@ struct Plant: Identifiable, Codable {
         self.upAxis = try container.decodeIfPresent(String.self, forKey: .upAxis)
         self.source = try container.decodeIfPresent(String.self, forKey: .source)
         self.sourceUrl = try container.decodeIfPresent(String.self, forKey: .sourceUrl)
+        self.flags = try container.decodeIfPresent(PlantFlags.self, forKey: .flags)
     }
 
     // ✅ Helper pour reconstruire une plante minimale au moment du restore
@@ -64,6 +66,42 @@ struct Plant: Identifiable, Codable {
         let data = try? JSONSerialization.data(withJSONObject: json, options: [])
         let decoded = (data.flatMap { try? JSONDecoder().decode(Plant.self, from: $0) })
         return decoded ?? PlantFallback(id: id, name: name, type: type, modelURL: modelURL).asPlant()
+    }
+}
+
+// MARK: - Recommendation flags
+
+/// Structured booleans driving the wizard recommendation (filter + scoring).
+/// Tolerant decode: any missing key defaults to false.
+struct PlantFlags: Codable {
+    let toxicToPets: Bool
+    let toxicToChildren: Bool
+    let easyCare: Bool
+    let shadeTolerant: Bool
+    let fullSunTolerant: Bool
+    let droughtTolerant: Bool
+    let humidityLoving: Bool
+    let flowering: Bool
+    let climbing: Bool
+    let trailing: Bool
+    let compact: Bool
+    let airPurifying: Bool
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        func f(_ k: CodingKeys) -> Bool { (try? c.decode(Bool.self, forKey: k)) ?? false }
+        toxicToPets = f(.toxicToPets)
+        toxicToChildren = f(.toxicToChildren)
+        easyCare = f(.easyCare)
+        shadeTolerant = f(.shadeTolerant)
+        fullSunTolerant = f(.fullSunTolerant)
+        droughtTolerant = f(.droughtTolerant)
+        humidityLoving = f(.humidityLoving)
+        flowering = f(.flowering)
+        climbing = f(.climbing)
+        trailing = f(.trailing)
+        compact = f(.compact)
+        airPurifying = f(.airPurifying)
     }
 }
 

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -13,10 +13,11 @@ struct Plant: Identifiable, Codable {
     let translations: [String: PlantTranslation]   // fr / en / es / de
     let generated: Bool?   // true = modèle 3D généré par IA (Meshy), nil/false = legacy
     let upAxis: String?    // "Y" (default, nil) ou "Z" (Blender exports qui doivent être redressés)
+    let source: String?    // "botanic" = plante scrapée depuis botanic.com ; nil = legacy/beta
 
     enum CodingKeys: String, CodingKey {
         case id
-        case name, type, imageURLs, description, modelURL, translations, generated, upAxis
+        case name, type, imageURLs, description, modelURL, translations, generated, upAxis, source
     }
 
     // Décode avec fallback safe
@@ -42,6 +43,7 @@ struct Plant: Identifiable, Codable {
 
         self.generated = try container.decodeIfPresent(Bool.self, forKey: .generated)
         self.upAxis = try container.decodeIfPresent(String.self, forKey: .upAxis)
+        self.source = try container.decodeIfPresent(String.self, forKey: .source)
     }
 
     // ✅ Helper pour reconstruire une plante minimale au moment du restore

--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -18,17 +18,17 @@ struct WizardPlantFilter {
         // 1. Style → keywords in name, type, description
         if !matchesStyle(plant: plant, translation: translation) { return false }
 
-        // 2. Exposure → sun.lightType
-        if !matchesExposure(translation: translation) { return false }
+        // 2. Exposure → flags.shade/fullSun (fallback: sun.lightType)
+        if !matchesExposure(plant: plant, translation: translation) { return false }
 
-        // 3. Maintenance → care.difficulty + water.frequency
-        if !matchesMaintenance(translation: translation) { return false }
+        // 3. Maintenance → flags.easyCare (fallback: care.difficulty + water.frequency)
+        if !matchesMaintenance(plant: plant, translation: translation) { return false }
 
-        // 4. Safety → exclude toxic plants
-        if !matchesSafety(translation: translation) { return false }
+        // 4. Safety → flags.toxicToPets/Children (fallback: toxic keywords)
+        if !matchesSafety(plant: plant, translation: translation) { return false }
 
-        // 5. Soil → soilAndPot.substrate
-        if !matchesSoil(translation: translation) { return false }
+        // 5. Soil → flags.drought/humidity (fallback: soilAndPot.substrate)
+        if !matchesSoil(plant: plant, translation: translation) { return false }
 
         return true
     }
@@ -118,8 +118,23 @@ struct WizardPlantFilter {
 
     // MARK: - Exposure Matching
 
-    private func matchesExposure(translation: PlantTranslation) -> Bool {
+    private func matchesExposure(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let exposure = wizard.exposure, !exposure.isEmpty else { return true }
+        let expL = exposure.lowercased()
+
+        // Prefer structured flags when available.
+        if let flags = plant.flags {
+            if expL.contains("soleil direct") || expL.contains("6h") || expL == "fullsun" {
+                return flags.fullSunTolerant || !(flags.shadeTolerant && !flags.fullSunTolerant)
+            }
+            if expL.contains("mi-ombre") || expL == "partialshade" {
+                return !(flags.fullSunTolerant && !flags.shadeTolerant)
+            }
+            if expL.contains("ombrag") || expL == "shade" {
+                return flags.shadeTolerant
+            }
+            return true
+        }
 
         let plantLight = (translation.sun?.lightType ?? "").lowercased()
         let plantDuration = (translation.sun?.durationPerDay ?? "").lowercased()
@@ -160,8 +175,18 @@ struct WizardPlantFilter {
 
     // MARK: - Maintenance Matching
 
-    private func matchesMaintenance(translation: PlantTranslation) -> Bool {
+    private func matchesMaintenance(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let maintenance = wizard.maintenance, !maintenance.isEmpty else { return true }
+        let maintL = maintenance.lowercased()
+
+        // Prefer structured flags when available.
+        if let flags = plant.flags {
+            if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
+                return flags.easyCare
+            }
+            // "Exigeant" / unknown → accept all.
+            return true
+        }
 
         let plantDifficulty = (translation.care?.difficulty ?? "").lowercased()
         let plantWater = (translation.water?.frequency ?? "").lowercased()
@@ -199,11 +224,22 @@ struct WizardPlantFilter {
 
     // MARK: - Safety Matching
 
-    private func matchesSafety(translation: PlantTranslation) -> Bool {
+    private func matchesSafety(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let safety = wizard.safety, !safety.isEmpty else { return true }
 
         // If "Aucune contrainte" is selected, no filtering needed
         if safety.contains("Aucune contrainte") || safety.contains("none") {
+            return true
+        }
+
+        let wantsPetSafe = safety.contains("Éviter les plantes toxiques pour les animaux") || safety.contains("pets")
+        let wantsChildSafe = safety.contains("Éviter les plantes dangereuses pour les enfants") || safety.contains("children")
+
+        // Prefer structured flags when available — robust (the keyword fallback
+        // below false-positives on "non toxique" / "non-toxic" descriptions).
+        if let flags = plant.flags {
+            if wantsPetSafe && flags.toxicToPets { return false }
+            if wantsChildSafe && flags.toxicToChildren { return false }
             return true
         }
 
@@ -243,8 +279,19 @@ struct WizardPlantFilter {
 
     // MARK: - Soil Matching
 
-    private func matchesSoil(translation: PlantTranslation) -> Bool {
+    private func matchesSoil(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let soil = wizard.soil, !soil.isEmpty else { return true }
+        let soilL = soil.lowercased()
+
+        // Prefer structured flags when available (dry vs water-retentive axis).
+        if let flags = plant.flags {
+            if soilL.contains("je ne sais pas") || soilL.contains("unknown") { return true }
+            if soilL.contains("sec") || soilL == "dry" { return flags.droughtTolerant }
+            if soilL.contains("rocailleux") || soilL == "rocky" { return flags.droughtTolerant }
+            if soilL.contains("retient") || soilL == "waterretentive" { return flags.humidityLoving || !flags.droughtTolerant }
+            if soilL.contains("riche") || soilL == "rich" { return !flags.droughtTolerant }
+            return true
+        }
 
         let plantSoil = (translation.soilAndPot?.substrate ?? "").lowercased()
         let plantDrainage = (translation.soilAndPot?.drainage ?? "").lowercased()

--- a/ArboreUi/ArboreUi/Services/GardenSuggestionEngine.swift
+++ b/ArboreUi/ArboreUi/Services/GardenSuggestionEngine.swift
@@ -139,7 +139,7 @@ final class GardenSuggestionEngine {
         }
 
         // --- Exposure axis ---
-        let exposureScore = scoreExposure(translation: translation, exposure: wizard.exposure)
+        let exposureScore = scoreExposure(plant: plant, translation: translation, exposure: wizard.exposure)
         if exposureScore > 0.7 {
             reasons.append("Luminosité adaptée")
         } else if exposureScore < 0.3 {
@@ -147,19 +147,19 @@ final class GardenSuggestionEngine {
         }
 
         // --- Soil axis ---
-        let soilScore = scoreSoil(translation: translation, soil: wizard.soil)
+        let soilScore = scoreSoil(plant: plant, translation: translation, soil: wizard.soil)
         if soilScore > 0.7 {
             reasons.append("Sol compatible")
         }
 
         // --- Maintenance axis ---
-        let maintenanceScore = scoreMaintenance(translation: translation, maintenance: wizard.maintenance)
+        let maintenanceScore = scoreMaintenance(plant: plant, translation: translation, maintenance: wizard.maintenance)
         if maintenanceScore > 0.7 {
             reasons.append("Entretien adapté")
         }
 
         // --- Safety axis ---
-        let safetyScore = scoreSafety(translation: translation, safety: wizard.safety)
+        let safetyScore = scoreSafety(plant: plant, translation: translation, safety: wizard.safety)
         if safetyScore < 0.5 {
             reasons.append("⚠️ Plante potentiellement toxique")
         }
@@ -239,8 +239,23 @@ final class GardenSuggestionEngine {
 
     // MARK: - Exposure Scoring
 
-    private func scoreExposure(translation: PlantTranslation, exposure: String?) -> Double {
+    private func scoreExposure(plant: Plant, translation: PlantTranslation, exposure: String?) -> Double {
         guard let exposure = exposure, !exposure.isEmpty else { return 0.8 }
+
+        if let flags = plant.flags {
+            let exp = exposure.lowercased()
+            if exp.contains("soleil direct") || exp.contains("6h") || exp == "fullsun" {
+                return flags.fullSunTolerant ? 1.0 : (flags.shadeTolerant ? 0.2 : 0.6)
+            }
+            if exp.contains("mi-ombre") || exp == "partialshade" {
+                if flags.shadeTolerant && !flags.fullSunTolerant { return 1.0 }
+                return (flags.fullSunTolerant && !flags.shadeTolerant) ? 0.5 : 0.9
+            }
+            if exp.contains("ombrag") || exp == "shade" {
+                return flags.shadeTolerant ? 1.0 : 0.1
+            }
+            return 0.7
+        }
 
         let plantLight = (translation.sun?.lightType ?? "").lowercased()
         let plantDuration = (translation.sun?.durationPerDay ?? "").lowercased()
@@ -290,8 +305,20 @@ final class GardenSuggestionEngine {
 
     // MARK: - Soil Scoring
 
-    private func scoreSoil(translation: PlantTranslation, soil: String?) -> Double {
+    private func scoreSoil(plant: Plant, translation: PlantTranslation, soil: String?) -> Double {
         guard let soil = soil, !soil.isEmpty else { return 0.8 }
+
+        if let flags = plant.flags {
+            let s = soil.lowercased()
+            if s.contains("je ne sais pas") || s.contains("unknown") { return 0.7 }
+            if s.contains("sec") || s == "dry" { return flags.droughtTolerant ? 1.0 : 0.2 }
+            if s.contains("rocailleux") || s == "rocky" { return flags.droughtTolerant ? 1.0 : 0.4 }
+            if s.contains("retient") || s == "waterretentive" {
+                return flags.humidityLoving ? 1.0 : (flags.droughtTolerant ? 0.2 : 0.6)
+            }
+            if s.contains("riche") || s == "rich" { return flags.droughtTolerant ? 0.3 : 1.0 }
+            return 0.6
+        }
 
         let plantSoil = (translation.soilAndPot?.substrate ?? "").lowercased()
         let plantDrainage = (translation.soilAndPot?.drainage ?? "").lowercased()
@@ -341,8 +368,16 @@ final class GardenSuggestionEngine {
 
     // MARK: - Maintenance Scoring
 
-    private func scoreMaintenance(translation: PlantTranslation, maintenance: String?) -> Double {
+    private func scoreMaintenance(plant: Plant, translation: PlantTranslation, maintenance: String?) -> Double {
         guard let maintenance = maintenance, !maintenance.isEmpty else { return 0.8 }
+
+        if let flags = plant.flags {
+            let maint = maintenance.lowercased()
+            if maint.contains("très facile") || maint == "veryeasy" { return flags.easyCare ? 1.0 : 0.3 }
+            if maint.contains("facile") || maint == "easy" { return flags.easyCare ? 1.0 : 0.5 }
+            if maint.contains("exigeant") || maint == "demanding" { return flags.easyCare ? 0.6 : 1.0 }
+            return 0.7
+        }
 
         let plantDifficulty = (translation.care?.difficulty ?? "").lowercased()
         let plantWater = (translation.water?.frequency ?? "").lowercased()
@@ -380,11 +415,22 @@ final class GardenSuggestionEngine {
 
     // MARK: - Safety Scoring
 
-    private func scoreSafety(translation: PlantTranslation, safety: [String]?) -> Double {
+    private func scoreSafety(plant: Plant, translation: PlantTranslation, safety: [String]?) -> Double {
         guard let safety = safety, !safety.isEmpty else { return 1.0 }
 
         // "Aucune contrainte" → no filtering
         if safety.contains("Aucune contrainte") || safety.contains("none") {
+            return 1.0
+        }
+
+        let hasPetFilter = safety.contains(where: { $0.contains("animaux") || $0.contains("pets") })
+        let hasChildFilter = safety.contains(where: { $0.contains("enfants") || $0.contains("children") })
+
+        // Prefer structured flags — robust (keyword fallback below false-positives
+        // on "non toxique" / "non-toxic" descriptions).
+        if let flags = plant.flags {
+            if hasPetFilter && flags.toxicToPets { return 0.0 }
+            if hasChildFilter && flags.toxicToChildren { return 0.0 }
             return 1.0
         }
 
@@ -398,10 +444,7 @@ final class GardenSuggestionEngine {
         let isToxic = toxicKeywords.contains { combined.contains($0) }
 
         if isToxic {
-            // Heavy penalty for toxic plants when safety is required
-            let hasPetFilter = safety.contains(where: { $0.contains("animaux") || $0.contains("pets") })
-            let hasChildFilter = safety.contains(where: { $0.contains("enfants") || $0.contains("children") })
-
+            // Heavy penalty for toxic plants when safety is required (legacy fallback)
             if hasPetFilter || hasChildFilter {
                 return 0.0 // Hard exclude
             }

--- a/ArboreUi/ArboreUi/Services/ModelCacheManager.swift
+++ b/ArboreUi/ArboreUi/Services/ModelCacheManager.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// Niveau de détail d'un modèle 3D (LOD).
+/// - light : modèle optimisé, servi par défaut (catalogue + placement AR rapide)
+/// - heavy : specimen haute définition, chargé en fond puis swappé en AR
+enum ModelLOD: String {
+    case light
+    case heavy
+
+    /// URL distante. Le heavy passe par `?lod=heavy` sur la même route `/models/<file>`
+    /// (un sous-chemin /models/heavy ferait paniquer httprouter côté backend).
+    func remoteURLString(base: String, filename: String) -> String {
+        let url = "\(base)/models/\(filename)"
+        return self == .heavy ? "\(url)?lod=heavy" : url
+    }
+
+    /// Sous-dossier de cache. Le heavy est isolé dans Documents/Models/heavy/ pour
+    /// qu'il puisse garder le même nom de fichier que le light sans aucune collision.
+    var cacheSubdirectory: String? {
+        self == .heavy ? "heavy" : nil
+    }
+}
+
 /// Gère le téléchargement et le cache des modèles 3D USDZ depuis le backend
 actor ModelCacheManager {
     static let shared = ModelCacheManager()
@@ -21,14 +42,21 @@ actor ModelCacheManager {
     ///   - modelURL: Le nom du fichier du modèle (ex: "Monstera_Deliciosa.usdz")
     ///   - forceDownload: Si true, forcer un nouveau téléchargement même si un cache existe
     /// - Returns: L'URL locale du fichier téléchargé
-    func getModelURL(for modelURL: String, forceDownload: Bool = false) async throws -> URL {
+    func getModelURL(for modelURL: String, lod: ModelLOD = .light, forceDownload: Bool = false) async throws -> URL {
         guard !modelURL.isEmpty else {
             throw ModelCacheError.invalidModelURL
         }
 
-        // Extraire le nom du fichier
+        // Nom de fichier d'origine pour la requête distante ; le heavy est rangé dans
+        // un sous-dossier dédié sur disque (même nom, zéro collision avec le light).
         let filename = (modelURL as NSString).lastPathComponent
-        let localURL = cacheDirectory.appendingPathComponent(filename)
+        let lodDir: URL = {
+            guard let sub = lod.cacheSubdirectory else { return cacheDirectory }
+            let dir = cacheDirectory.appendingPathComponent(sub, isDirectory: true)
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            return dir
+        }()
+        let localURL = lodDir.appendingPathComponent(filename)
 
         let fileExists = FileManager.default.fileExists(atPath: localURL.path)
 
@@ -44,7 +72,9 @@ actor ModelCacheManager {
             return localURL
         }
 
-        let taskKey = forceDownload ? "force:\(filename)" : filename
+        // La clé inclut le LOD pour que light/heavy d'un même fichier ne partagent
+        // pas la même tâche en cours.
+        let taskKey = "\(lod.rawValue):\(forceDownload ? "force:" : "")\(filename)"
         if forceDownload {
             print("⬇️ Forcing download for: \(filename)")
         }
@@ -57,7 +87,7 @@ actor ModelCacheManager {
 
         // Créer une nouvelle tâche de téléchargement
         let task = Task<URL, Error> {
-            try await downloadModel(filename: filename, to: localURL)
+            try await downloadModel(filename: filename, lod: lod, to: localURL)
         }
 
         downloadTasks[taskKey] = task
@@ -72,12 +102,25 @@ actor ModelCacheManager {
         }
     }
 
-    /// Télécharge un modèle depuis le backend
-    private func downloadModel(filename: String, to localURL: URL) async throws -> URL {
-        print("⬇️ Downloading model: \(filename)")
+    /// Annule un téléchargement en cours (heavy par défaut). No-op si aucun n'est actif.
+    /// `URLSession.download` honore l'annulation coopérative → le transfert s'interrompt
+    /// et `task.value` lève `CancellationError`, capturée par le `catch` de getModelURL.
+    func cancelDownload(for modelURL: String, lod: ModelLOD = .heavy, forceDownload: Bool = false) {
+        let filename = (modelURL as NSString).lastPathComponent
+        let taskKey = "\(lod.rawValue):\(forceDownload ? "force:" : "")\(filename)"
+        if let task = downloadTasks[taskKey] {
+            task.cancel()
+            downloadTasks[taskKey] = nil
+            print("🛑 Cancelled \(lod.rawValue) download for: \(filename)")
+        }
+    }
 
-        // Construire l'URL du backend
-        guard let backendURL = URL(string: "\(NetworkManager.shared.baseURL)/models/\(filename)") else {
+    /// Télécharge un modèle depuis le backend
+    private func downloadModel(filename: String, lod: ModelLOD = .light, to localURL: URL) async throws -> URL {
+        print("⬇️ Downloading model: \(filename) [\(lod.rawValue)]")
+
+        // Construire l'URL du backend (heavy → ?lod=heavy)
+        guard let backendURL = URL(string: lod.remoteURLString(base: NetworkManager.shared.baseURL, filename: filename)) else {
             throw ModelCacheError.invalidBackendURL
         }
 

--- a/ArboreUi/ArboreUi/Views/GardenLocalStore.swift
+++ b/ArboreUi/ArboreUi/Views/GardenLocalStore.swift
@@ -81,6 +81,10 @@ struct PersistedPlant: Codable {
     // Optional for backward compatibility with old saved JSONs.
     let surfaceType: String?     // "floor" | "elevated" | nil
     let surfaceHeight: Float?    // Y of the surface at save-time, in world coords
+    // LOD : indique si une version 3D haute définition existe pour cette plante,
+    // pour ré-déclencher le swap heavy à la ré-ouverture du jardin. Optionnel →
+    // les anciennes sauvegardes (sans la clé) décodent à nil (= pas d'upgrade).
+    let hasHeavy: Bool?
 
     init(
         plantID: String,
@@ -92,7 +96,8 @@ struct PersistedPlant: Codable {
         transform: [Float],
         upAxis: String? = nil,
         surfaceType: String? = nil,
-        surfaceHeight: Float? = nil
+        surfaceHeight: Float? = nil,
+        hasHeavy: Bool? = nil
     ) {
         self.plantID = plantID
         self.plantName = plantName
@@ -104,6 +109,7 @@ struct PersistedPlant: Codable {
         self.upAxis = upAxis
         self.surfaceType = surfaceType
         self.surfaceHeight = surfaceHeight
+        self.hasHeavy = hasHeavy
     }
 }
 
@@ -170,7 +176,8 @@ extension PersistedARScene {
                 transform: plant.transform,
                 upAxis: plant.upAxis,
                 surfaceType: plant.surfaceType,
-                surfaceHeight: plant.surfaceHeight
+                surfaceHeight: plant.surfaceHeight,
+                hasHeavy: plant.hasHeavy
             )
         }
 

--- a/ArboreUi/ArboreUi/Views/PlantCard.swift
+++ b/ArboreUi/ArboreUi/Views/PlantCard.swift
@@ -68,15 +68,13 @@ struct PlantCard: View {
         )
         .shadow(color: ArboreDesign.Colors.shadow, radius: 8, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
-            // Les plantes botanic affichent leur propre badge ; sinon badge BETA
-            // pour les modèles 3D générés par IA.
-            if plant.source == "botanic" {
-                botanicBadge
-                    .padding(10)
-            } else if plant.generated == true {
-                betaBadge
-                    .padding(10)
+            // Plantes botanic : badge BOTANIC + BETA (modèle 3D image-to-3D, qualité
+            // variable assumée). Plantes legacy générées par IA : BETA seul.
+            HStack(spacing: 6) {
+                if plant.source == "botanic" { botanicBadge }
+                if plant.generated == true { betaBadge }
             }
+            .padding(10)
         }
         .task(id: plant.id) {
             await loadRemoteThumbnailIfNeeded()

--- a/ArboreUi/ArboreUi/Views/PlantCard.swift
+++ b/ArboreUi/ArboreUi/Views/PlantCard.swift
@@ -68,7 +68,12 @@ struct PlantCard: View {
         )
         .shadow(color: ArboreDesign.Colors.shadow, radius: 8, x: 0, y: 4)
         .overlay(alignment: .topTrailing) {
-            if plant.generated == true {
+            // Les plantes botanic affichent leur propre badge ; sinon badge BETA
+            // pour les modèles 3D générés par IA.
+            if plant.source == "botanic" {
+                botanicBadge
+                    .padding(10)
+            } else if plant.generated == true {
                 betaBadge
                     .padding(10)
             }
@@ -80,6 +85,24 @@ struct PlantCard: View {
 
     private var betaBadge: some View {
         Text("BETA")
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.8)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(ArboreDesign.Colors.primaryGreen)
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(Color.white.opacity(0.45), lineWidth: 0.5)
+                    )
+            )
+            .shadow(color: Color.black.opacity(0.22), radius: 2, x: 0, y: 1)
+    }
+
+    private var botanicBadge: some View {
+        Text("BOTANIC")
             .font(.system(size: 10, weight: .semibold))
             .tracking(0.8)
             .foregroundStyle(.white)

--- a/Plant3DGenerator/.gitignore
+++ b/Plant3DGenerator/.gitignore
@@ -1,6 +1,12 @@
 .env
 output/
+opti_output/
+_legacy/
+_thumb_map.json
+_regen_outliers.json
+arbore-3d-models.zip
 __pycache__/
 *.pyc
 .venv/
 venv/
+node_modules/

--- a/Plant3DGenerator/build_backup_zip.sh
+++ b/Plant3DGenerator/build_backup_zip.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Build a backup .zip of ALL botanic plant 3D assets in the deploy architecture:
+#   models/            light USDZ (served by default — catalogue + AR placement)
+#   models/heavy/      heavy USDZ (real specimen — LOD swap during AR viewing)
+#   models/thumbnails/ PNG catalogue thumbnails
+# Files are named by plant (human-readable). Uses hardlinks to avoid doubling
+# disk usage while staging. Originals untouched.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+MANIFEST="$REPO/BotanicScraper/data/manifest.json"
+THUMB_MAP="$HERE/_thumb_map.json"
+STAGE="${1:-$HERE/arbore-3d-models}"
+ZIP_OUT="${2:-$HERE/arbore-3d-models.zip}"
+
+rm -rf "$STAGE" "$ZIP_OUT"
+mkdir -p "$STAGE/models/heavy" "$STAGE/models/thumbnails"
+
+# stage light + heavy by model filename (only the included manifest plants)
+python3 - "$MANIFEST" "$HERE" "$STAGE" "$THUMB_MAP" <<'PY'
+import json, os, sys, shutil
+manifest, gen_dir, stage, thumb_map = sys.argv[1:5]
+plants = [p for p in json.load(open(manifest))["plants"] if p["include"]]
+opti = os.path.join(gen_dir, "opti_output")
+heavy = os.path.join(gen_dir, "output")
+tmap = {m["model"]: m["id"] for m in json.load(open(thumb_map))}
+thumb_src = os.path.join(os.path.dirname(gen_dir), "ArboreBackend", "models", "thumbnails")
+
+def link(src, dst):
+    if os.path.exists(src):
+        try: os.link(src, dst)        # hardlink (same FS, no extra space)
+        except OSError: shutil.copy2(src, dst)
+        return True
+    return False
+
+light_ok = heavy_ok = thumb_ok = miss = 0
+seen = set()
+for p in plants:
+    mf = p["modelFilename"]
+    if mf in seen: continue
+    seen.add(mf)
+    if link(os.path.join(opti, mf), os.path.join(stage, "models", mf)): light_ok += 1
+    else: miss += 1; print("  ⚠️ no light:", mf)
+    if link(os.path.join(heavy, mf), os.path.join(stage, "models", "heavy", mf)): heavy_ok += 1
+    # thumbnail: stored on backend as <plantId>.png → copy as <ModelName>.png
+    pid = tmap.get(mf)
+    if pid:
+        png = os.path.join(thumb_src, pid + ".png")
+        if link(png, os.path.join(stage, "models", "thumbnails", mf[:-5] + ".png")): thumb_ok += 1
+
+print(f"botanic staged — light:{light_ok} heavy:{heavy_ok} thumbnails:{thumb_ok} missing-light:{miss}")
+
+# legacy (unique prod models not covered by botanic): light=_legacy/light,
+# heavy=_legacy/heavy (original), thumbnails=_legacy/thumbnails (by model name)
+leg_dir = os.path.join(gen_dir, "_legacy")
+ll = lh = lt = 0
+import glob as _glob
+for lf in sorted(_glob.glob(os.path.join(leg_dir, "light", "*.usdz"))):
+    name = os.path.basename(lf)
+    stem = name[:-5]
+    if link(lf, os.path.join(stage, "models", name)): ll += 1
+    if link(os.path.join(leg_dir, "heavy", name), os.path.join(stage, "models", "heavy", name)): lh += 1
+    if link(os.path.join(leg_dir, "thumbnails", stem + ".png"), os.path.join(stage, "models", "thumbnails", stem + ".png")): lt += 1
+print(f"legacy staged  — light:{ll} heavy:{lh} thumbnails:{lt}")
+print(f"TOTAL catalogue: {light_ok + ll} plants (botanic {light_ok} + legacy {ll})")
+PY
+
+# README + id mapping for the team
+cp "$THUMB_MAP" "$STAGE/plantId_to_model.json" 2>/dev/null || true
+cat > "$STAGE/README.txt" <<EOF
+Arbore — botanic plant 3D assets (backup)
+=========================================
+Deploy architecture (rsync to VPS ArboreBackend/models/):
+  models/             LIGHT usdz  — served by default (catalogue + initial AR placement)
+  models/heavy/       HEAVY usdz  — real high-detail specimen, loaded in background during
+                                    AR viewing then swapped in (LOD), then light is freed
+  models/thumbnails/  PNG         — catalogue card thumbnails
+
+Notes:
+- Files named by plant. The backend serves thumbnails as <plantId>.png; see
+  plantId_to_model.json for the model->id mapping (ids are from arbore_test).
+- LIGHT = decimated (gltf-transform) for most; text-to-3D lowpoly for the few
+  feathery plants the decimator couldn't shrink. HEAVY = original Meshy image-to-3D.
+Generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+echo "=== sizes ==="
+du -sh "$STAGE/models" "$STAGE/models/heavy" "$STAGE/models/thumbnails"
+echo "=== zipping (this is large) ==="
+( cd "$STAGE/.." && zip -r -q "$ZIP_OUT" "$(basename "$STAGE")" )
+echo "✅ $ZIP_OUT  ($(du -sh "$ZIP_OUT" | awk '{print $1}'))"

--- a/Plant3DGenerator/generate_from_images.py
+++ b/Plant3DGenerator/generate_from_images.py
@@ -125,6 +125,8 @@ def main() -> None:
                    help="skip texture prompts (saves 10 credits/plant)")
     p.add_argument("--all", action="store_true", help="process every manifest plant (default: first)")
     p.add_argument("--limit", type=int, default=0, help="cap number of plants")
+    p.add_argument("--workers", type=int, default=5,
+                   help="concurrent generations (keep <= your Meshy tier's concurrent-task limit)")
     p.add_argument("--dry-run", action="store_true", help="list jobs + credit estimate, no API calls")
     args = p.parse_args()
 
@@ -133,6 +135,18 @@ def main() -> None:
         sys.exit("❌ MESHY_API_KEY not set (copy .env.example → .env)")
 
     jobs = load_jobs(args)
+    # Dedup by output stem so name-collisions (e.g. two "Areca" SKUs → Areca.usdz)
+    # don't generate the same model twice under concurrency.
+    seen_stems: set[str] = set()
+    deduped = []
+    for j in jobs:
+        if j["stem"] in seen_stems:
+            continue
+        seen_stems.add(j["stem"])
+        deduped.append(j)
+    if len(deduped) != len(jobs):
+        print(f"🔁 deduped {len(jobs) - len(deduped)} duplicate model name(s)")
+    jobs = deduped
     if not jobs:
         sys.exit("❌ no jobs to run")
     if not args.image and not args.all:
@@ -141,8 +155,9 @@ def main() -> None:
     if args.limit:
         jobs = jobs[: args.limit]
 
-    # 30 credits base + 10 if a texture prompt is sent.
-    per = 30 if args.no_texture_prompt else 40
+    # image-to-3D is 30 credits; a texture_prompt is free (only a texture_image_url
+    # guidance would add 10). Confirmed: the test Monstera consumed 30.
+    per = 30
     print(f"📋 {len(jobs)} plant(s):")
     for j in jobs:
         print(f"   • {j['name']} → {j['stem']}.usdz")
@@ -153,10 +168,20 @@ def main() -> None:
         return
 
     client = MeshyImageClient(api_key)
+    workers = max(1, args.workers)
+    print(f"⚙️  generating with {workers} concurrent worker(s)")
     ok = 0
-    for j in jobs:
-        if generate_one(client, j, no_texture_prompt=args.no_texture_prompt):
-            ok += 1
+    if workers == 1:
+        for j in jobs:
+            if generate_one(client, j, no_texture_prompt=args.no_texture_prompt):
+                ok += 1
+    else:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = [ex.submit(generate_one, client, j, no_texture_prompt=args.no_texture_prompt) for j in jobs]
+            for fut in futures:
+                if fut.result():
+                    ok += 1
     print(f"🏁 done — {ok}/{len(jobs)} succeeded")
     sys.exit(0 if ok == len(jobs) else 1)
 

--- a/Plant3DGenerator/generate_from_images.py
+++ b/Plant3DGenerator/generate_from_images.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Headless Image-to-3D generator.
+
+Turns real plant photos into 3D models via Meshy image-to-3D (v1). Reads a
+manifest produced by the (local) BotanicScraper, or a single --image/--name
+pair. Downloads GLB + USDZ into output/ and patches the USDZ for iOS ARView
+(same subdivisionScheme fix as the text-to-3D pipeline).
+
+Examples:
+  # one-off from a public image URL
+  python generate_from_images.py --image https://…/monstera.png --name "Monstera deliciosa"
+
+  # batch from the scraper manifest (estimate first)
+  python generate_from_images.py --manifest ../BotanicScraper/data/manifest.json --all --dry-run
+  python generate_from_images.py --manifest ../BotanicScraper/data/manifest.json --all
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from meshy_image_client import MeshyImageClient, image_to_data_uri
+from pipeline import safe_filename
+from usdz_patch import patch_usdz_subdivision
+
+SCRIPT_DIR = Path(__file__).parent
+load_dotenv(SCRIPT_DIR / ".env")
+
+OUTPUT_DIR = SCRIPT_DIR / "output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def load_jobs(args) -> list[dict]:
+    """Normalize inputs into a list of {name, image, texture_prompt, stem}."""
+    if args.image:
+        name = args.name or "plant"
+        return [{
+            "name": name,
+            "image": args.image,
+            "texture_prompt": args.texture_prompt or "",
+            "stem": safe_filename(name),
+        }]
+
+    if not args.manifest:
+        sys.exit("❌ pass --manifest <path> or --image <url|file> --name <latin>")
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = (Path.cwd() / manifest_path).resolve()
+    if not manifest_path.exists():
+        sys.exit(f"❌ manifest not found: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    base = manifest_path.parent  # data/ — local image paths are relative to a plant dir
+    jobs = []
+    for p in manifest.get("plants", []):
+        if not p.get("include", True):
+            continue
+        meshy = p.get("meshy", {})
+        image = meshy.get("imageRemote")
+        # Fall back to a local file (encoded as data URI) if no public URL.
+        if not image and meshy.get("imageLocal"):
+            local = base / p["slug"] / meshy["imageLocal"]
+            if local.exists():
+                image = image_to_data_uri(local)
+        if not image:
+            print(f"⚠️  no image for {p.get('name')}, skipping")
+            continue
+        stem = Path(p.get("modelFilename") or f"{safe_filename(p['name'])}.usdz").stem
+        jobs.append({
+            "name": p["name"],
+            "image": image,
+            "texture_prompt": meshy.get("texturePrompt", ""),
+            "stem": stem,
+        })
+    return jobs
+
+
+def generate_one(client: MeshyImageClient, job: dict, *, no_texture_prompt: bool) -> bool:
+    name, stem = job["name"], job["stem"]
+    usdz_out = OUTPUT_DIR / f"{stem}.usdz"
+    if usdz_out.exists():
+        print(f"⏭️  {stem}.usdz exists, skipping")
+        return True
+
+    ts = time.strftime("%H:%M:%S")
+    src = job["image"][:48] + ("…" if len(job["image"]) > 48 else "")
+    print(f"[{ts}] {name:<28} → image-to-3D ({src})", flush=True)
+    try:
+        task_id = client.create(
+            job["image"],
+            texture_prompt="" if no_texture_prompt else job.get("texture_prompt", ""),
+        )
+
+        def on_progress(status, progress, _data):
+            print(f"    {stem}: {status} {progress}%", flush=True)
+
+        data = client.poll(task_id, on_progress=on_progress)
+        urls = data.get("model_urls") or {}
+        if urls.get("glb"):
+            client.download(urls["glb"], OUTPUT_DIR / f"{stem}.glb")
+        if urls.get("usdz"):
+            client.download(urls["usdz"], usdz_out)
+            patch_usdz_subdivision(usdz_out)
+        print(f"✅ {stem} — {data.get('consumed_credits', '?')} credits", flush=True)
+        return urls.get("usdz") is not None
+    except Exception as e:  # noqa: BLE001 — log and continue the batch
+        print(f"❌ {stem} failed: {e}", flush=True)
+        return False
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Meshy image-to-3D generator (headless)")
+    p.add_argument("--manifest", help="BotanicScraper data/manifest.json")
+    p.add_argument("--image", help="single image URL or local file path")
+    p.add_argument("--name", help="latin/common name for the single image")
+    p.add_argument("--texture-prompt", default="", help="texture prompt for the single image")
+    p.add_argument("--no-texture-prompt", action="store_true",
+                   help="skip texture prompts (saves 10 credits/plant)")
+    p.add_argument("--all", action="store_true", help="process every manifest plant (default: first)")
+    p.add_argument("--limit", type=int, default=0, help="cap number of plants")
+    p.add_argument("--dry-run", action="store_true", help="list jobs + credit estimate, no API calls")
+    args = p.parse_args()
+
+    api_key = os.getenv("MESHY_API_KEY")
+    if not api_key and not args.dry_run:
+        sys.exit("❌ MESHY_API_KEY not set (copy .env.example → .env)")
+
+    jobs = load_jobs(args)
+    if not jobs:
+        sys.exit("❌ no jobs to run")
+    if not args.image and not args.all:
+        jobs = jobs[:1]
+        print("🧪 single-plant mode (pass --all to process every manifest plant)")
+    if args.limit:
+        jobs = jobs[: args.limit]
+
+    # 30 credits base + 10 if a texture prompt is sent.
+    per = 30 if args.no_texture_prompt else 40
+    print(f"📋 {len(jobs)} plant(s):")
+    for j in jobs:
+        print(f"   • {j['name']} → {j['stem']}.usdz")
+    print(f"💰 ~{per * len(jobs)} credits estimated")
+
+    if args.dry_run:
+        print("🏁 dry-run, exiting")
+        return
+
+    client = MeshyImageClient(api_key)
+    ok = 0
+    for j in jobs:
+        if generate_one(client, j, no_texture_prompt=args.no_texture_prompt):
+            ok += 1
+    print(f"🏁 done — {ok}/{len(jobs)} succeeded")
+    sys.exit(0 if ok == len(jobs) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Plant3DGenerator/meshy_image_client.py
+++ b/Plant3DGenerator/meshy_image_client.py
@@ -1,0 +1,99 @@
+"""Thin wrapper around the Meshy **Image-to-3D** REST API (v1, single-stage).
+
+Unlike text-to-3D (v2, preview→refine, see meshy_client.py), image-to-3D is a
+single call: you submit one image (public URL or base64 data URI) and Meshy
+returns a textured model directly. We use it to turn a real botanic.com product
+photo into a 3D plant model.
+
+Docs: https://docs.meshy.ai/en/api/image-to-3d
+Reuses the exponential-backoff retry helper from meshy_client.
+"""
+from __future__ import annotations
+
+import base64
+import mimetypes
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+import requests
+
+from meshy_client import _request_with_retry  # shared 429/5xx backoff
+
+BASE_URL = "https://api.meshy.ai/openapi/v1/image-to-3d"
+
+
+def image_to_data_uri(path: Path) -> str:
+    """Encode a local image as a base64 data URI accepted by `image_url`."""
+    mime = mimetypes.guess_type(str(path))[0] or "image/png"
+    data = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{data}"
+
+
+class MeshyImageClient:
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError("api_key is required")
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        })
+
+    def create(self, image: str, *, ai_model: str = "meshy-6",
+               should_texture: bool = True, enable_pbr: bool = True,
+               texture_prompt: str = "", target_polycount: int = 30000,
+               topology: str = "triangle",
+               formats: Optional[list] = None) -> str:
+        """Create an image-to-3D task. `image` is a public URL or data URI.
+
+        Returns the task id. 30 credits base (+10 if texture_prompt is given).
+        """
+        payload = {
+            "image_url": image,
+            "ai_model": ai_model,
+            "should_texture": should_texture,
+            "enable_pbr": enable_pbr,
+            "target_polycount": target_polycount,
+            "topology": topology,
+            "target_formats": formats or ["glb", "usdz"],
+        }
+        if texture_prompt:
+            payload["texture_prompt"] = texture_prompt
+        r = _request_with_retry("POST", BASE_URL, session=self.session,
+                                json=payload, timeout=60)
+        r.raise_for_status()
+        return r.json()["result"]
+
+    def get_task(self, task_id: str) -> dict:
+        r = _request_with_retry("GET", f"{BASE_URL}/{task_id}",
+                                session=self.session, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def poll(self, task_id: str, *, interval: int = 5, timeout: int = 900,
+             on_progress: Optional[Callable[[str, int, dict], None]] = None) -> dict:
+        start = time.time()
+        last = -1
+        while True:
+            if time.time() - start > timeout:
+                raise TimeoutError(f"task {task_id} timed out after {timeout}s")
+            data = self.get_task(task_id)
+            status = data.get("status")
+            progress = data.get("progress", 0)
+            if on_progress and progress != last:
+                on_progress(status, progress, data)
+                last = progress
+            if status == "SUCCEEDED":
+                return data
+            if status in ("FAILED", "CANCELED", "EXPIRED"):
+                err = data.get("task_error") or {"message": "unknown"}
+                raise RuntimeError(f"task {task_id} {status}: {err}")
+            time.sleep(interval)
+
+    @staticmethod
+    def download(url: str, out_path: Path) -> int:
+        r = requests.get(url, timeout=180)
+        r.raise_for_status()
+        out_path.write_bytes(r.content)
+        return len(r.content)

--- a/Plant3DGenerator/optimize_models.py
+++ b/Plant3DGenerator/optimize_models.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Optimize Meshy-generated 3D models for mobile AR.
+
+Meshy image-to-3D returns very dense meshes (~800k+ triangles) and large
+textures, so a single .usdz can be 30–130 MB — far too heavy to download/render
+on iOS. This decimates the mesh and downsizes textures, writing optimized .usdz
+files to opti_output/ WITHOUT touching the originals in output/.
+
+Pipeline per model (from the source GLB):
+  gltf-transform weld → simplify → resize (unpacked .gltf, textures as files)
+  → usdcat .gltf → .usda → inject subdivisionScheme="none" (iOS ARView)
+  → usdzip --arkitAsset → opti_output/<name>.usdz
+
+Validated: Monstera 29 MB → 3 MB (~9x), visually near-identical.
+
+  python optimize_models.py [--ratio 0.1] [--error 0.01] [--texture-size 1024]
+                            [--workers 4] [--limit N] [--only NAME] [--force]
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+SRC_DIR = SCRIPT_DIR / "output"
+OUT_DIR = SCRIPT_DIR / "opti_output"
+GLTF = SCRIPT_DIR / "node_modules" / ".bin" / "gltf-transform"
+
+_MESH_RE = re.compile(r'(def Mesh "[^"]+"\s*\n\s*\{\s*\n)')
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    res = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=600)
+    if res.returncode != 0:
+        raise RuntimeError(f"{cmd[0]} {cmd[1] if len(cmd) > 1 else ''} failed: "
+                           f"{(res.stderr or res.stdout)[-300:]}")
+
+
+def _inject_subdivision(usda_path: Path) -> None:
+    t = usda_path.read_text()
+    if "subdivisionScheme" in t:
+        return
+    t = _MESH_RE.sub(lambda m: m.group(1) + '        uniform token subdivisionScheme = "none"\n', t)
+    usda_path.write_text(t)
+
+
+def optimize_one(glb: Path, args) -> tuple[str, float, float, str]:
+    name = glb.stem
+    out = OUT_DIR / f"{name}.usdz"
+    src_mb = glb.stat().st_size / 1e6
+    if out.exists() and not args.force:
+        return (name, src_mb, out.stat().st_size / 1e6, "skip")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            w = Path(td)
+            _run([str(GLTF), "weld", str(glb), str(w / "1.glb")])
+            _run([str(GLTF), "simplify", str(w / "1.glb"), str(w / "2.glb"),
+                  "--ratio", str(args.ratio), "--error", str(args.error),
+                  "--lock-border", "false"])
+            # resize, emitting an UNPACKED .gltf so textures land as files usdcat can read
+            _run([str(GLTF), "resize", str(w / "2.glb"), str(w / "m.gltf"),
+                  "--width", str(args.texture_size), "--height", str(args.texture_size)])
+            _run(["usdcat", "m.gltf", "-o", "m.usda"], cwd=w)
+            _inject_subdivision(w / "m.usda")
+            _run(["usdzip", "--arkitAsset", "m.usda", "out.usdz"], cwd=w)
+            OUT_DIR.mkdir(exist_ok=True)
+            shutil.move(str(w / "out.usdz"), str(out))
+        return (name, src_mb, out.stat().st_size / 1e6, "ok")
+    except Exception as e:  # noqa: BLE001
+        return (name, src_mb, 0.0, f"FAIL: {e}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Optimize Meshy 3D models for mobile AR")
+    p.add_argument("--ratio", type=float, default=0.1, help="simplify target vertex ratio (lower = smaller)")
+    p.add_argument("--error", type=float, default=0.01, help="simplify max error (higher = smaller)")
+    p.add_argument("--texture-size", type=int, default=1024)
+    p.add_argument("--workers", type=int, default=4)
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--only", default="", help="optimize a single model by stem (substring)")
+    p.add_argument("--force", action="store_true")
+    args = p.parse_args()
+
+    if not GLTF.exists():
+        sys.exit("❌ gltf-transform not installed — run: npm install (in Plant3DGenerator/)")
+
+    glbs = sorted(SRC_DIR.glob("*.glb"))
+    if args.only:
+        glbs = [g for g in glbs if args.only.lower() in g.stem.lower()]
+    if args.limit:
+        glbs = glbs[: args.limit]
+    if not glbs:
+        sys.exit("❌ no source GLB found in output/")
+
+    print(f"⚙️  optimizing {len(glbs)} model(s) → opti_output/ (ratio={args.ratio}, tex={args.texture_size}, {args.workers} workers)")
+    results = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for r in ex.map(lambda g: optimize_one(g, args), glbs):
+            name, src, dst, status = r
+            results.append(r)
+            if status == "ok":
+                print(f"✅ {name:42} {src:6.1f} → {dst:5.2f} MB  (÷{src/dst:.1f})" if dst else f"✅ {name}")
+            elif status == "skip":
+                print(f"⏭️  {name:42} exists ({dst:.2f} MB)")
+            else:
+                print(f"❌ {name:42} {status}")
+
+    ok = [r for r in results if r[3] == "ok"]
+    if ok:
+        tot_src = sum(r[1] for r in ok)
+        tot_dst = sum(r[2] for r in ok)
+        print(f"\n🏁 {len(ok)} optimized — total {tot_src:.0f} MB → {tot_dst:.0f} MB "
+              f"(÷{tot_src/tot_dst:.1f}), avg {tot_dst/len(ok):.1f} MB")
+    fails = [r for r in results if r[3].startswith("FAIL")]
+    if fails:
+        print(f"⚠️  {len(fails)} failed: {[r[0] for r in fails][:5]}")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/Plant3DGenerator/optimize_usdz_textures.py
+++ b/Plant3DGenerator/optimize_usdz_textures.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Texture-only USDZ optimizer (no GLB needed).
+
+For models whose weight is in 4K PBR textures rather than mesh (legacy lowpoly
+plants, text-to-3D lowpoly outputs), this just downsizes the embedded textures
+and repackages — mesh untouched. usdzip keeps the ARKit packaging; the usdc
+(with subdivisionScheme=none) is preserved as-is.
+
+  python optimize_usdz_textures.py --in <dir> --out <dir> [--size 1024]
+                                   [--workers 4] [--force]
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+IMG_EXT = {".jpg", ".jpeg", ".png"}
+
+
+def optimize_one(usdz: Path, out_dir: Path, size: int, force: bool) -> tuple[str, float, float, str]:
+    out = out_dir / usdz.name
+    src_mb = usdz.stat().st_size / 1e6
+    if out.exists() and not force:
+        return (usdz.name, src_mb, out.stat().st_size / 1e6, "skip")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            w = Path(td)
+            with zipfile.ZipFile(usdz) as zf:
+                zf.extractall(w)
+            # resize every embedded texture (in place) to max `size` px
+            for img in list(w.rglob("*")):
+                if img.suffix.lower() in IMG_EXT:
+                    subprocess.run(["sips", "-Z", str(size), str(img)],
+                                   capture_output=True, timeout=60)
+            roots = list(w.rglob("*.usdc")) + list(w.rglob("*.usda"))
+            if not roots:
+                return (usdz.name, src_mb, 0.0, "no-usd-root")
+            root = roots[0]
+            out_dir.mkdir(parents=True, exist_ok=True)
+            tmp_out = w / "out.usdz"
+            subprocess.run(["usdzip", "--arkitAsset", root.name, str(tmp_out)],
+                           cwd=w, capture_output=True, text=True, timeout=180, check=True)
+            shutil.move(str(tmp_out), str(out))
+        return (usdz.name, src_mb, out.stat().st_size / 1e6, "ok")
+    except Exception as e:  # noqa: BLE001
+        return (usdz.name, src_mb, 0.0, f"FAIL:{e}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--in", dest="indir", required=True)
+    p.add_argument("--out", dest="outdir", required=True)
+    p.add_argument("--size", type=int, default=1024)
+    p.add_argument("--workers", type=int, default=4)
+    p.add_argument("--force", action="store_true")
+    args = p.parse_args()
+
+    src = sorted(Path(args.indir).glob("*.usdz"))
+    out_dir = Path(args.outdir)
+    if not src:
+        sys.exit(f"❌ no usdz in {args.indir}")
+    print(f"🎨 texture-optimizing {len(src)} usdz @ {args.size}px → {out_dir}")
+    results = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for r in ex.map(lambda f: optimize_one(f, out_dir, args.size, args.force), src):
+            name, s, d, status = r
+            results.append(r)
+            if status == "ok":
+                print(f"✅ {name:42} {s:5.1f} → {d:4.1f} MB (÷{s/d:.1f})")
+            elif status == "skip":
+                print(f"⏭️  {name:42} exists")
+            else:
+                print(f"❌ {name:42} {status}")
+    ok = [r for r in results if r[3] == "ok"]
+    if ok:
+        ts, td = sum(r[1] for r in ok), sum(r[2] for r in ok)
+        print(f"\n🏁 {len(ok)} done — {ts:.0f} → {td:.0f} MB (÷{ts/td:.1f}), avg {td/len(ok):.1f} MB")
+    sys.exit(1 if any(r[3].startswith('FAIL') for r in results) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/Plant3DGenerator/package-lock.json
+++ b/Plant3DGenerator/package-lock.json
@@ -1,0 +1,2792 @@
+{
+  "name": "plant3d-optimizer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plant3d-optimizer",
+      "dependencies": {
+        "@gltf-transform/cli": "^4.4.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@donmccurdy/caporal": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@donmccurdy/caporal/-/caporal-0.0.10.tgz",
+      "integrity": "sha512-VdaJjOqYFYcDTM5We2x8cL+B+U9UFQvq0iW2ypqEGX31SDf2oYFjEg7INEJorBwJJnFNXV8jXoYGzJyLeYl1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^8.1.0",
+        "@types/lodash": "^4.14.197",
+        "@types/node": "20.5.6",
+        "@types/table": "5.0.0",
+        "@types/wrap-ansi": "^8.0.1",
+        "chalk": "3.0.0",
+        "glob": "^10.3.3",
+        "lodash": "^4.17.21",
+        "table": "5.4.6",
+        "winston": "3.10.0",
+        "wrap-ansi": "^8.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gltf-transform/cli": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/cli/-/cli-4.4.0.tgz",
+      "integrity": "sha512-BPcdZT693PeO3lwoiDF6Sfk+fBmJCOThtRnX7gT14Wmr9AVbRngRmqUk9vfrVRgICyD8dPz80YIXEi2xrzXZyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@donmccurdy/caporal": "~0.0.10",
+        "@gltf-transform/core": "^4.4.0",
+        "@gltf-transform/extensions": "^4.4.0",
+        "@gltf-transform/functions": "^4.4.0",
+        "@types/language-tags": "~1.0.4",
+        "@types/micromatch": "~4.0.10",
+        "@types/node-fetch": "~2.6.13",
+        "@types/prompts": "^2.4.9",
+        "@types/tmp": "~0.2.6",
+        "cli-table3": "~0.6.5",
+        "csv-stringify": "~6.6.0",
+        "draco3dgltf": "~1.5.7",
+        "gltf-validator": "~2.0.0-dev.3.10",
+        "keyframe-resample": "~0.1.0",
+        "ktx-parse": "^1.1.0",
+        "language-tags": "^2.1.0",
+        "listr2": "~8.3.3",
+        "meshoptimizer": "~1.0.1",
+        "micromatch": "~4.0.8",
+        "mikktspace": "~1.1.1",
+        "node-fetch": "~3.3.2",
+        "prompts": "^2.4.2",
+        "sharp": "~0.34.5",
+        "tmp": "~0.2.5",
+        "watlas": "^1.0.1"
+      },
+      "bin": {
+        "gltf-transform": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/core": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-4.4.0.tgz",
+      "integrity": "sha512-cOPxOhHFFz5hwmix+li1+Nnq5qMV/QD3fTCsVlApxxFACtFdjkt2R/juseD4gvZ7D2c/yl6OilKH0pvI735YyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "property-graph": "^4.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/extensions": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/extensions/-/extensions-4.4.0.tgz",
+      "integrity": "sha512-ZwEgFkkqnUR7d4m6roK9BycxxdoqJNtVyo7w5ShJ9syKBoQiXw2QrTSLwXaUAImSrEIl9Jh/wZTtvSVyviQuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.4.0",
+        "ktx-parse": "^1.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@gltf-transform/functions": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/functions/-/functions-4.4.0.tgz",
+      "integrity": "sha512-CaSTAVAd2NXNWsxdgvq090rKHqy7AQlcNWV4ec7xtQyS8WEv3S3gVN27ikWmdB8nWEsXUbOIDhtPMLbXI6xDJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@gltf-transform/core": "^4.4.0",
+        "@gltf-transform/extensions": "^4.4.0",
+        "ktx-parse": "^1.1.0",
+        "ndarray": "^1.0.19",
+        "ndarray-lanczos": "^0.3.0",
+        "ndarray-pixels": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/language-tags": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/language-tags/-/language-tags-1.0.4.tgz",
+      "integrity": "sha512-20PQbifv3v/djCT+KlXybv0KqO5ofoR1qD1wkinN59kfggTPVTWGmPFgL/1yWuDyRcsQP/POvkqK+fnl5nOwTg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ndarray": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.14.tgz",
+      "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.5.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+      "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/@types/table": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/table/-/table-5.0.0.tgz",
+      "integrity": "sha512-fQLtGLZXor264zUPWI95WNDsZ3QV43/c0lJpR/h1hhLJumXRmHNsrvBfEzW2YMhb0EWCsn4U6h82IgwsajAuTA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-8.0.2.tgz",
+      "integrity": "sha512-mdaFibQzYYqJF8Sc9By84eBLtDQD9Hnko0yXuezHBU5f5KdtQk+j5hPRQc1j4ayzdqGddKON6PjeuzxD5U1hPg==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.6.0.tgz",
+      "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==",
+      "license": "MIT"
+    },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/draco3dgltf": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.5.7.tgz",
+      "integrity": "sha512-LeqcpmoHIyYUi0z70/H3tMkGj8QhqVxq6FJGPjlzR24BNkQ6jyMheMvFKJBI0dzGZrEOUyQEmZ8axM1xRrbRiw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gltf-validator": {
+      "version": "2.0.0-dev.3.10",
+      "resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.10.tgz",
+      "integrity": "sha512-odJ4k0tRkGXiDGn78yDBg+fBbAIvBnXxh3RwAta0emSxGtyagFE8B4xELB1oYe3S5RD8Ci3uZAsZaascH2LAEQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/keyframe-resample": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keyframe-resample/-/keyframe-resample-0.1.0.tgz",
+      "integrity": "sha512-z1au6Q6qCWP734q44t/5SyGwNydC7MvOWo2ZETAz7ZqAgtcyb5EGO7jwgk3DEH7CaDtb0DkGec9iwVpeDWX5dA==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ktx-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-1.1.0.tgz",
+      "integrity": "sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==",
+      "license": "MIT"
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-2.1.0.tgz",
+      "integrity": "sha512-D4CgpyCt+61f6z2jHjJS1OmZPviAWM57iJ9OKdFFWSNgS7Udj9QVWqyGs/cveVNF57XpZmhSvMdVIV5mjLA7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mikktspace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mikktspace/-/mikktspace-1.1.1.tgz",
+      "integrity": "sha512-w+n5O2YLFsv/aRi3QUF0jxR+mEsl2J08ZkRItJHE08MWqiDIy8amyZN9vetBfbLhlWGMb8G3mzSPwtKHvBF7hQ==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-lanczos": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ndarray-lanczos/-/ndarray-lanczos-0.3.0.tgz",
+      "integrity": "sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.11",
+        "ndarray": "^1.0.19"
+      }
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==",
+      "license": "MIT",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
+    "node_modules/ndarray-pixels": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pixels/-/ndarray-pixels-5.0.1.tgz",
+      "integrity": "sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ndarray": "^1.0.14",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/property-graph": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-4.1.0.tgz",
+      "integrity": "sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==",
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/table/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/watlas": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/watlas/-/watlas-1.0.1.tgz",
+      "integrity": "sha512-TmB++BFqEQY19cPNby5iszACZd8t6uauB7YdObkqhWarhed79OMPS8wufoDSo0p85A/8QW/aqZwEJf+nD4emSw==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/Plant3DGenerator/package.json
+++ b/Plant3DGenerator/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "plant3d-optimizer",
+  "private": true,
+  "dependencies": { "@gltf-transform/cli": "^4.4.0" }
+}

--- a/Plant3DGenerator/regen_outliers.py
+++ b/Plant3DGenerator/regen_outliers.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Re-generate the feathery/fragmented plants that mesh-decimation couldn't
+shrink (ferns, asparagus, pilea, spider plant, sedum) as clean LOW-POLY models
+via text-to-3D, writing them straight into opti_output/ as the lightweight LOD.
+
+The dense image-to-3D originals stay untouched in output/ (the "heavy" LOD).
+Reads _regen_outliers.json: [{stem, species, prompt}, ...].
+
+  python regen_outliers.py [--workers 4] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from meshy_client import MeshyClient
+from pipeline import PipelineRunner, make_job
+
+SCRIPT_DIR = Path(__file__).parent
+load_dotenv(SCRIPT_DIR / ".env")
+OPTI_DIR = SCRIPT_DIR / "opti_output"
+OPTI_DIR.mkdir(exist_ok=True)
+
+
+def regen_one(client: MeshyClient, t: dict) -> tuple[str, str]:
+    stem = t["stem"]
+    out = OPTI_DIR / f"{stem}.usdz"
+    job = make_job(common=stem, latin=t["species"], hint=t.get("prompt", ""))
+    job.job_id = stem  # so files are named opti_output/<stem>.{glb,usdz}
+    ts = time.strftime("%H:%M:%S")
+    print(f"[{ts}] {stem:42} text-to-3D lowpoly ({t['species']})", flush=True)
+    try:
+        runner = PipelineRunner(client, OPTI_DIR)
+        runner.run(job, preview_only=False)
+        if job.stages["refine"].status == "done" and out.exists():
+            mb = out.stat().st_size / 1e6
+            print(f"✅ {stem:42} → {mb:.1f} MB", flush=True)
+            return (stem, "ok")
+        err = job.stages["refine"].error or job.stages["preview"].error or "unknown"
+        print(f"❌ {stem:42} {err}", flush=True)
+        return (stem, "fail")
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ {stem:42} {e}", flush=True)
+        return (stem, "fail")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--workers", type=int, default=4)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    targets = json.loads((SCRIPT_DIR / "_regen_outliers.json").read_text())
+    print(f"📋 {len(targets)} outlier(s) → opti_output/ (text-to-3D lowpoly)")
+    for t in targets:
+        print(f"   • {t['stem']} ({t['species']})")
+    print(f"💰 ~{30 * len(targets)} credits estimated")
+    if args.dry_run:
+        print("🏁 dry-run")
+        return
+
+    api_key = os.getenv("MESHY_API_KEY")
+    if not api_key:
+        sys.exit("❌ MESHY_API_KEY not set")
+    client = MeshyClient(api_key)
+
+    ok = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for _, status in ex.map(lambda t: regen_one(client, t), targets):
+            if status == "ok":
+                ok += 1
+    print(f"🏁 done — {ok}/{len(targets)} regenerated into opti_output/")
+    sys.exit(0 if ok == len(targets) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Plant3DGenerator/render_thumbnails.py
+++ b/Plant3DGenerator/render_thumbnails.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Render a PNG catalogue thumbnail for each plant from its LIGHT 3D model and
+stage it where the backend serves thumbnails (ArboreBackend/models/thumbnails/
+<plantId>.png). This way the iOS catalogue shows server PNGs instantly and never
+has to download a USDZ just to make a thumbnail.
+
+Reads _thumb_map.json: [{id, model, outlier}, ...] (plantId + opti_output model).
+
+  python render_thumbnails.py [--only-outliers] [--skip-outliers] [--size 1024]
+                              [--workers 3] [--force]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+OPTI_DIR = SCRIPT_DIR / "opti_output"
+THUMB_DIR = SCRIPT_DIR.parent / "ArboreBackend" / "models" / "thumbnails"
+
+
+def render_one(entry: dict, size: int, force: bool) -> tuple[str, str]:
+    pid, model = entry["id"], entry["model"]
+    src = OPTI_DIR / model
+    out = THUMB_DIR / f"{pid}.png"
+    if out.exists() and not force:
+        return (model, "skip")
+    if not src.exists():
+        return (model, "no-model")
+    try:
+        subprocess.run(
+            ["usdrecord", "--imageWidth", str(size), "--frames", "0:0", str(src), str(out).replace(".png", ".#.png")],
+            capture_output=True, text=True, timeout=180,
+        )
+        # usdrecord writes <name>.0.png — normalize to <id>.png
+        framed = THUMB_DIR / f"{pid}.0.png"
+        if framed.exists():
+            framed.replace(out)
+        return (model, "ok" if out.exists() else "fail")
+    except subprocess.TimeoutExpired:
+        return (model, "timeout")
+    except Exception as e:  # noqa: BLE001
+        return (model, f"fail:{e}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--size", type=int, default=1024)
+    p.add_argument("--workers", type=int, default=3)
+    p.add_argument("--only-outliers", action="store_true")
+    p.add_argument("--skip-outliers", action="store_true")
+    p.add_argument("--force", action="store_true")
+    args = p.parse_args()
+
+    entries = json.loads((SCRIPT_DIR / "_thumb_map.json").read_text())
+    if args.only_outliers:
+        entries = [e for e in entries if e.get("outlier")]
+    elif args.skip_outliers:
+        entries = [e for e in entries if not e.get("outlier")]
+
+    THUMB_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"🖼️  rendering {len(entries)} thumbnail(s) @ {args.size}px → {THUMB_DIR}")
+    ok = skip = fail = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for model, status in ex.map(lambda e: render_one(e, args.size, args.force), entries):
+            if status == "ok":
+                ok += 1
+            elif status == "skip":
+                skip += 1
+            else:
+                fail += 1
+                print(f"  ⚠️ {model}: {status}")
+    print(f"🏁 thumbnails — ok:{ok} skip:{skip} fail:{fail}")
+    sys.exit(1 if fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/3d-lod-architecture.md
+++ b/docs/3d-lod-architecture.md
@@ -1,0 +1,125 @@
+# Architecture LOD des modèles 3D (catalogue → léger → lourd)
+
+## Objectif
+
+Les modèles Meshy bruts pèsent 30–130 MB (trop lourd pour le mobile). On sert
+désormais **3 niveaux de détail** par plante :
+
+| Niveau | Format | Taille | Quand |
+|---|---|---|---|
+| **PNG** | thumbnail | ~0,5 MB | Catalogue (cartes) — jamais de 3D |
+| **LIGHT** | `.usdz` optimisé | ~2–6 MB | Placement AR initial (téléchargement + affichage rapides) |
+| **HEAVY** | `.usdz` specimen | 12–130 MB | Chargé en fond pendant la visu AR, **swap** puis le léger est libéré |
+
+Résultat : le catalogue est instantané (PNG), le placement AR est rapide (léger),
+et l'utilisateur finit par voir le vrai specimen haute définition sans attente.
+
+## État actuel (audité)
+
+- **Catalogue** : `PlantCard.swift` charge `{baseURL}/models/thumbnails/{plant.id}.png`
+  (cache disque `PlantThumbnailCache`, fallback génération on-device via
+  `PlantThumbnailGenerator` qui télécharge le USDZ). → Le browsing ne charge pas
+  de 3D. ✅
+- **Modèle 3D** : `Plant.getModelURL()` → `ModelCacheManager` télécharge le USDZ
+  (cache disque par nom de fichier, `URLSession.shared.download`). Utilisé en AR
+  et pour la génération de thumbnail.
+- **Backend** : `GET /models/:filename` sert le USDZ depuis `models/` ;
+  `GET /models/thumbnails/:filename` sert les PNG depuis `THUMBNAILS_DIR`.
+  `Plant.modelURL` = nom de fichier.
+
+## Architecture cible
+
+### Stockage VPS (déployé par rsync, hors git)
+```
+ArboreBackend/models/
+├── <Name>.usdz            LIGHT (servi par défaut)
+├── heavy/<Name>.usdz      HEAVY (vrai specimen)
+└── thumbnails/<id>.png    PNG catalogue
+```
+Light et heavy **partagent le même nom de fichier** → pas besoin d'une 2e URL en
+base, juste un préfixe de route.
+
+### A. Backend (`ArboreBackend/main.go`)
+1. Nouvelle route `GET /models/heavy/:filename` — identique à `/models/:filename`
+   mais sert depuis `models/heavy/` (réutiliser le handler existant en
+   paramétrant le sous-dossier ; même validation regex du filename).
+2. (optionnel) Exposer `hasHeavy` sur le Plant : soit un champ `HasHeavy *bool`,
+   soit dérivé au runtime (`os.Stat(models/heavy/<modelURL>)`). Recommandé :
+   champ booléen renseigné à l'import (évite un `os.Stat` par plante).
+3. `Plant.modelURL` reste le **nom du fichier léger** (inchangé).
+
+### B. Schéma (`Plant`)
+- Ajouter `HasHeavy *bool` (`json/bson:"hasHeavy,omitempty"`) — committable, comme
+  `source`/`flags`. nil/false = pas de heavy (l'app reste sur le léger).
+- iOS `Plant.swift` : `let hasHeavy: Bool?`. Web : `hasHeavy?: boolean`.
+
+### C. iOS — le cœur du LOD
+
+**`ModelCacheManager`** : ajouter un paramètre de niveau.
+```swift
+enum ModelLOD { case light, heavy }
+func getModelURL(for filename: String, lod: ModelLOD = .light,
+                 forceDownload: Bool = false) async throws -> URL
+// light → {baseURL}/models/<filename> ; heavy → {baseURL}/models/heavy/<filename>
+// cache disque séparé (suffixe _heavy), téléchargement heavy annulable (Task).
+```
+
+**Vue de placement AR** (RealityKit — `ARViewContainerMeasure` / la vue qui pose
+la plante) :
+1. Au placement : `getModelURL(lod:.light)` → `ModelEntity` → ajouter à un
+   `AnchorEntity` à la position du hit-test. Garder une réf `placed[entityID]`.
+2. Si `plant.hasHeavy == true`, lancer une `Task` de fond :
+   `getModelURL(lod:.heavy)` → charger le `ModelEntity` lourd.
+3. À la réussite, sur le main actor : copier le `transform` du léger sur le lourd,
+   `anchor.addChild(heavy)` puis `light.removeFromParent()` → le `ModelEntity`
+   léger est désalloué → RealityKit libère son mesh/textures.
+4. **Annulation** : si la plante est retirée / la scène change avant la fin,
+   `task.cancel()` (et annuler le `URLSession` download).
+5. Mémoire : `AppDelegate` libère déjà les caches RealityKit sur memory warning ;
+   après swap, ne garder de réf forte que sur le lourd. Optionnel : éviction du
+   fichier léger du cache disque sous pression mémoire.
+
+**Garde-fous** : si `hasHeavy` faux ou download heavy échoue → on **reste sur le
+léger** (jamais de régression visuelle). Le swap ne doit pas “sauter” : matcher
+exactement transform + échelle (les 2 USDZ ont le même `upAxis` et sont cadrés
+pareil par Meshy/optimisation).
+
+### D. Thumbnails
+Déjà **pré-rendus** pour les 124 plantes (`render_thumbnails.py`). À déployer dans
+`models/thumbnails/<id>.png`. ⚠️ Nommés par `plant.id` → re-render avec les `_id`
+**prod** au moment de l'import prod (les ids test ≠ prod). Bénéfice : aucun device
+ne subit la grosse 1ère génération.
+
+### E. Déploiement (rsync, local → prod, overwrite)
+```bash
+# code (schéma + route) via git/deploy.sh ; modèles via rsync (hors git)
+rsync -avz Plant3DGenerator/opti_output/     fedora@VPS:…/ArboreBackend/models/
+rsync -avz Plant3DGenerator/output/ _legacy/heavy/  fedora@VPS:…/ArboreBackend/models/heavy/
+rsync -avz <thumbnails prod>                 fedora@VPS:…/ArboreBackend/models/thumbnails/
+```
+- Clé SSH : `~/.ssh/epitech` (`fedora@79.137.92.154`).
+- `models/*.usdz` + `thumbnails/` sont **gitignorés** (déjà fait).
+
+### F. Réconciliation données prod (priorité botanic)
+À l'import prod : pour les **12 plantes en doublon** (Monstera, Pilea, Ficus…),
+**supprimer le doc + modèle legacy** et garder la version botanic (règle “botanic
+prioritaire”). Les 26 legacy uniques restent. Net : 38 legacy → 26 conservées + 98
+botanic = **124 plantes** en prod.
+
+## Séquencement
+1. Schéma `hasHeavy` (backend Go + iOS + web) — commit dans PR #288.
+2. Route backend `/models/heavy/:filename`.
+3. iOS : `ModelCacheManager` LOD + swap RealityKit dans la vue AR + annulation.
+4. Merger/déployer PR #288 (code).
+5. rsync des modèles (light/heavy) + re-render thumbnails avec ids prod.
+6. Import prod des 98 botanic + suppression des 12 legacy en doublon.
+7. QA : catalogue (PNG), placement AR (léger rapide → swap lourd), mémoire OK.
+
+## Risques / notes
+- **Swap visible** : si le cadrage léger/lourd diffère légèrement, l'utilisateur
+  peut voir un “pop”. Mitiger : fondu (opacité) sur 0,2 s au swap.
+- **Réseau lent** : le heavy peut ne jamais finir — c'est OK, le léger reste.
+- **Mémoire** : ne jamais garder léger **et** lourd longtemps ; libérer le léger
+  juste après le swap.
+- **Legacy heavy** : pour les 26 legacy, “heavy” = textures 4K (même mesh lowpoly)
+  → le swap améliore surtout la résolution de texture, pas la géométrie. OK.

--- a/docs/3d-lod-architecture.md
+++ b/docs/3d-lod-architecture.md
@@ -123,3 +123,28 @@ botanic = **124 plantes** en prod.
   juste après le swap.
 - **Legacy heavy** : pour les 26 legacy, “heavy” = textures 4K (même mesh lowpoly)
   → le swap améliore surtout la résolution de texture, pas la géométrie. OK.
+
+## LOD adaptatif (thermique + budget + distance)
+
+`PlantLODPolicy.swift` + l'évaluateur dans `GardenARPlacementView` (`evaluateLOD`,
+throttlé ~4 Hz depuis `renderer(_:updateAtTime:)`) décident light/heavy par une
+**chaîne de précédence** (les gates globaux ne peuvent que *réduire* le détail) :
+
+1. **Thermique (global)** — `ProcessInfo.thermalState` + Low Power Mode :
+   `.nominal`/`.fair` → budget plein ; `.serious`/LowPower → tout light sauf la
+   plante sélectionnée + annule les downloads heavy ; `.critical` → tout light.
+   Downgrade immédiat à chaud ; re-upgrade seulement après ≥ 8 s au frais
+   (`coolStableBeforeUpgrade`, cooldown — pas d'hystérésis native côté API).
+2. **Budget K (global)** — `DeviceCapabilities.tier` : K=1 (legacy) / 2 (modern).
+   Seules les K plus proches + la sélectionnée passent heavy ; le surplus est
+   downgradé. Stickiness 10% pour éviter le ping-pong entre plantes équidistantes.
+3. **Distance (par plante)** — en **taille à l'écran** : heavy tant que
+   `distance < 2,9 × hauteur` (≈ >30% de l'écran), hystérésis 20%, clamp [0,6 ; 4,5] m.
+
+Le swap est **réversible** (`swapModel(to:)` light↔heavy) ; un download heavy en
+cours est traité comme heavy (bande large) pour ne pas être annulé au moindre
+jitter, et son LOD cible est tracké pour ne jamais annuler/redémarrer à tort.
+Tout est **fail-safe** (toute erreur laisse le modèle courant). Valeurs par défaut
+issues de recherche (Apple thermal guidance + LOD mobile AR). ⚠️ Comportement AR
+à valider on-device. Complète le système `ARGarden/Quality/` existant (qui gère
+`environmentTexturing` + bannière) sans le dupliquer.

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -74,6 +74,7 @@ export interface Plant {
   source?: string; // "botanic" = scrapé depuis botanic.com ; sinon legacy/beta
   sourceUrl?: string; // URL botanic.com d'origine (conservée pour ré-scrape/màj)
   flags?: PlantFlags; // drapeaux structurés pour la reco wizard
+  hasHeavy?: boolean; // true = version 3D haute définition disponible (LOD)
   [key: string]: unknown;
 }
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -72,6 +72,7 @@ export interface Plant {
   name?: string;
   generated?: boolean;
   source?: string; // "botanic" = scrapé depuis botanic.com ; sinon legacy/beta
+  sourceUrl?: string; // URL botanic.com d'origine (conservée pour ré-scrape/màj)
   [key: string]: unknown;
 }
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -73,7 +73,23 @@ export interface Plant {
   generated?: boolean;
   source?: string; // "botanic" = scrapé depuis botanic.com ; sinon legacy/beta
   sourceUrl?: string; // URL botanic.com d'origine (conservée pour ré-scrape/màj)
+  flags?: PlantFlags; // drapeaux structurés pour la reco wizard
   [key: string]: unknown;
+}
+
+export interface PlantFlags {
+  toxicToPets?: boolean;
+  toxicToChildren?: boolean;
+  easyCare?: boolean;
+  shadeTolerant?: boolean;
+  fullSunTolerant?: boolean;
+  droughtTolerant?: boolean;
+  humidityLoving?: boolean;
+  flowering?: boolean;
+  climbing?: boolean;
+  trailing?: boolean;
+  compact?: boolean;
+  airPurifying?: boolean;
 }
 
 export interface Garden {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -70,6 +70,8 @@ export interface Plant {
   id?: string;
   _id?: string;
   name?: string;
+  generated?: boolean;
+  source?: string; // "botanic" = scrapé depuis botanic.com ; sinon legacy/beta
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Contexte
Première brique de l'enrichissement du catalogue de plantes via botanic.com. Cette PR ne contient **que** les parties génériques et committables ; le scraper botanic lui-même reste local (non poussé).

## Changements

### Champ `Source` sur Plant (backend + iOS + web)
- `ArboreBackend/main.go` : nouveau champ optionnel `Source *string` (`json/bson:"source,omitempty"`) sur la struct `Plant`. Passthrough des handlers existants, pas de logique modifiée.
- `ArboreUi/.../Models/Plant.swift` : `source: String?` décodé en safe (decodeIfPresent).
- `ArboreUi/.../Views/PlantCard.swift` : badge **BOTANIC** affiché quand `source == "botanic"`, à la place du badge BETA pour ces plantes.
- `web/lib/api.ts` : `source?: string` ajouté au type `Plant`.
- Champ optionnel + `omitempty` → aucun document existant invalidé, pas de migration.

### Générateur Meshy image-to-3D (Plant3DGenerator)
- `meshy_image_client.py` : client pour l'API Meshy **image-to-3D v1** (single-stage). Réutilise le backoff exponentiel partagé de `meshy_client.py`.
- `generate_from_images.py` : CLI qui transforme une photo de plante en modèle 3D texturé, télécharge GLB+USDZ et applique le patch USDZ `subdivisionScheme` existant (compat iOS ARView). Supporte `--dry-run` (estimation crédits), `--manifest`, ou `--image/--name` one-off.

## Test
- `go build ./...` OK sur ArboreBackend.
- `generate_from_images.py --dry-run` OK (estimation ~40 crédits/plante).
- Génération image-to-3D réelle validée sur une plante.