### PR TITLE
fix(plant3d): SceneKit-correct USDZ materials (AR grey-plant fix)

### DIFF
--- a/ArboreBackend/models/README.md
+++ b/ArboreBackend/models/README.md
@@ -1,50 +1,81 @@
 # Models Directory
 
-This directory contains 3D USDZ model files served by the backend.
+3D plant assets (USDZ) and catalog thumbnails served by the backend. These
+files are **large and gitignored** — they are deployed to the VPS out-of-band
+(rsync), not committed (see [Git](#git)).
 
-## Current Models
+## Layout (LOD)
 
-- `Cactus.usdz` (3.3 MB)
-- `Dyspis_Lutescens.usdz` (3.3 MB)
-- `Livistona_Chinensis.usdz` (3.9 MB)
-- `Monstera_Deliciosa.usdz` (42 MB)
-- `Pilea.usdz` (2.9 MB)
-- `Pothos.usdz` (2.0 MB)
+| Path | Content | Served by |
+|---|---|---|
+| `models/<Name>.usdz` | **LIGHT** model — optimized, served by default | `GET /models/:filename` |
+| `models/heavy/<Name>.usdz` | **HEAVY** model — high-detail variant (same filename) | `GET /models/:filename?lod=heavy` |
+| `models/thumbnails/<plantId>.png` | Catalog thumbnail (PNG) | `GET /models/thumbnails/:filename` (public) |
 
-**Total: ~57 MB**
+The iOS app places the LIGHT model instantly, then cross-fade-swaps the HEAVY
+one in when the adaptive LOD policy allows (`Plant.hasHeavy`). See
+[`docs/fr/3d-lod-architecture.md`](../../docs/fr/3d-lod-architecture.md).
 
-## API Endpoint
+## ⚠️ SceneKit material requirement (must read before adding models)
 
-Models are served via the protected endpoint:
+The iOS AR view loads models with **SceneKit** (`SCNScene(url:)`). SceneKit's
+USD importer **does not follow** a connected texture file input:
 
 ```
-GET /models/:filename
+# ❌ renders GREY in AR — SceneKit won't resolve the connection
+asset inputs:file.connect = </…/Material0.inputs:baseColorTexture>
+
+# ✅ binds correctly — direct asset path on the UsdUVTexture
+asset inputs:file = @0/baseColor_1.jpg@
 ```
 
-**Requirements:**
-- Valid API Key (X-API-Key header)
-- Firebase Authentication token (Authorization Bearer header)
+A glTF → USD round-trip (the mesh/texture optimizer) produces the connected
+form, which is why such plants showed colored thumbnails (RealityKit / Hydra
+follow connections) but grey AR models. Fixed in **issue #292**.
 
-**Example:**
+- **New models** are handled automatically: `Plant3DGenerator/optimize_models.py`
+  rebinds textures to the direct form right after the glTF → USD step.
+- **Already-built `.usdz`** can be repaired with:
+  - `Plant3DGenerator/fix_scenekit_materials.py` (needs `usdcat`/`usdzip`, e.g. macOS/Xcode), or
+  - `Plant3DGenerator/fix_scenekit_materials_pxr.py` (`pip install usd-core`, no CLI — runs anywhere, in place):
+    ```bash
+    python3 fix_scenekit_materials_pxr.py --inplace --dir <models_dir> --backup <backup_dir>
+    ```
+
+## API endpoint
+
+```
+GET /models/:filename            # light (default)
+GET /models/:filename?lod=heavy  # high-detail variant from models/heavy/
+```
+
+**Requirements:** valid `X-API-Key` header **and** Firebase `Authorization: Bearer`
+token (thumbnails under `GET /models/thumbnails/:filename` are public).
+
 ```bash
 curl -H "X-API-Key: YOUR_API_KEY" \
      -H "Authorization: Bearer YOUR_FIREBASE_TOKEN" \
-     http://localhost:8080/models/Monstera_Deliciosa.usdz
+     "http://localhost:8080/models/Monstera_Deliciosa.usdz"
 ```
 
-## Adding New Models
+## Adding new models
 
-1. Place `.usdz` files in this directory
-2. Update the plant's `modelURL` field in MongoDB to match the filename
-3. The iOS app will automatically download and cache the model
+1. Generate/optimize the `.usdz` (see `Plant3DGenerator/`) — the optimizer
+   emits SceneKit-correct materials.
+2. Place the LIGHT `.usdz` here and the HEAVY one in `models/heavy/` (same filename).
+3. Set the plant's `modelURL` (and `hasHeavy` if a heavy variant exists) in MongoDB.
+4. Deploy the files to the VPS (rsync). The iOS app downloads and caches them.
+
+> Note: the app caches downloaded models by filename (`ModelCacheManager`).
+> Replacing a model's content keeps the same filename, so devices that already
+> cached the old version need a cache reset (app reinstall) to pick it up.
 
 ## Security
 
-- Only `.usdz` files are allowed
-- Path traversal attacks are prevented
-- Authentication required (API Key + Firebase token)
+- Only `.usdz` files are allowed; path-traversal is blocked.
+- Authentication required (API Key + Firebase token) for models.
 
 ## Git
 
-USDZ files are excluded from git (.gitignore) due to their large size.
-Deploy them separately to your production server.
+USDZ models and PNG thumbnails are **excluded from git** (`.gitignore`) due to
+their size. Deploy them separately to the production server (rsync).

--- a/Plant3DGenerator/fix_scenekit_materials.py
+++ b/Plant3DGenerator/fix_scenekit_materials.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Fix glTF-roundtrip USDZ so SceneKit (ARSCNView) binds plant textures.
+
+`optimize_models.py` runs `gltf-transform ... -> usdcat (glTF->USD)`, which emits
+materials where every UsdUVTexture reads its image via
+    asset inputs:file.connect = </.../MaterialX.inputs:<channel>Texture>
+i.e. the real asset path is declared once on the Material's *interface input*
+and the shaders read it through a connection. SceneKit's USD importer (Model I/O,
+used by SCNScene(url:) for .usdz in the AR placement view) does NOT follow that
+connection, so it falls back to its default GREY material. RealityKit, Hydra and
+`usdrecord` (the backend thumbnail PNGs) DO follow it — which is why such plants
+look correct in the catalog but grey in AR.
+
+This rewrites each `asset inputs:file.connect = <Mat.inputs:KEY>` into the
+resolved direct `asset inputs:file = @path@`, leaving everything else untouched
+(geometry, UV `UsdTransform2d` V-flip, colorspaces, the NodeGraph wrapper, the
+embedded textures). Toolchain: usdcat + usdzip only (no pxr needed), mirroring
+the existing usdz_patch.py.
+
+Usage:
+  python3 fix_scenekit_materials.py <in.usdz> <out.usdz>      # one file
+  python3 fix_scenekit_materials.py --check <file.usdz>       # report only
+  python3 fix_scenekit_materials.py --dir <in_dir> <out_dir>  # batch
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+# `asset inputs:file.connect = </m/Materials/Material0.inputs:baseColorTexture>`
+_CONNECT_RE = re.compile(
+    r'^(?P<indent>\s*)asset inputs:file\.connect\s*=\s*<(?P<path>[^>]+)\.inputs:(?P<key>\w+)>\s*$'
+)
+# `asset inputs:baseColorTexture = @0/baseColor_1.jpg@`  (Material interface input)
+_IFACE_RE = re.compile(r'^\s*asset inputs:(?P<key>\w+)\s*=\s*(?P<val>@[^@]+@)\s*$')
+_MAT_RE = re.compile(r'def Material "(?P<name>[^"]+)"')
+
+
+def _fix_usda(text: str) -> tuple[str, int, int]:
+    """Return (new_text, n_fixed, n_unresolved)."""
+    # 1) Map (material_name, interface_key) -> @asset@
+    iface: dict[tuple[str, str], str] = {}
+    cur_mat: str | None = None
+    for line in text.splitlines():
+        mm = _MAT_RE.search(line)
+        if mm:
+            cur_mat = mm.group("name")
+            continue
+        im = _IFACE_RE.match(line)
+        if im and cur_mat and im.group("key").endswith("Texture"):
+            iface[(cur_mat, im.group("key"))] = im.group("val")
+
+    # 2) Rewrite each file.connect to the resolved direct asset path.
+    out: list[str] = []
+    fixed = unresolved = 0
+    for line in text.splitlines():
+        cm = _CONNECT_RE.match(line)
+        if cm:
+            mat = cm.group("path").rstrip("/").split("/")[-1]
+            key = cm.group("key")
+            val = iface.get((mat, key))
+            if val is None:  # fallback: unique key across materials
+                cands = {v for (m, k), v in iface.items() if k == key}
+                val = next(iter(cands)) if len(cands) == 1 else None
+            if val is not None:
+                out.append(f'{cm.group("indent")}asset inputs:file = {val}')
+                fixed += 1
+                continue
+            unresolved += 1
+        out.append(line)
+    new_text = "\n".join(out) + ("\n" if text.endswith("\n") else "")
+    return new_text, fixed, unresolved
+
+
+def _count_connects(usdz: Path) -> int:
+    try:
+        r = subprocess.run(["usdcat", str(usdz)], capture_output=True, text=True, timeout=180)
+        return r.stdout.count("inputs:file.connect")
+    except Exception:
+        return -1
+
+
+def fix_usdz(src: Path, dst: Path) -> tuple[bool, str]:
+    if not shutil.which("usdcat") or not shutil.which("usdzip"):
+        return False, "usdcat/usdzip not found"
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            w = Path(td)
+            with zipfile.ZipFile(src) as zf:
+                zf.extractall(w)
+            roots = sorted(list(w.rglob("*.usdc")) + list(w.rglob("*.usda")))
+            if not roots:
+                return False, "no usd root"
+            total_fixed = total_unresolved = 0
+            for usd in roots:
+                usda = usd.with_suffix(".fix.usda")
+                subprocess.run(["usdcat", str(usd), "-o", str(usda)],
+                               check=True, capture_output=True, timeout=120)
+                text = usda.read_text()
+                new_text, fixed, unresolved = _fix_usda(text)
+                total_fixed += fixed
+                total_unresolved += unresolved
+                if fixed:
+                    usda.write_text(new_text)
+                    subprocess.run(["usdcat", str(usda), "-o", str(usd)],
+                                   check=True, capture_output=True, timeout=120)
+                usda.unlink(missing_ok=True)
+            if total_fixed == 0:
+                return False, f"nothing to fix (already direct?), unresolved={total_unresolved}"
+            root = roots[0]
+            tmp_out = w / "out.usdz"
+            subprocess.run(["usdzip", "--arkitAsset", root.name, str(tmp_out)],
+                           cwd=w, check=True, capture_output=True, text=True, timeout=180)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(tmp_out), str(dst))
+        return True, f"fixed {total_fixed} texture binding(s), unresolved={total_unresolved}"
+    except subprocess.CalledProcessError as e:
+        return False, f"{e.cmd[0]} failed: {(e.stderr or b'').decode()[-200:] if isinstance(e.stderr, bytes) else e.stderr}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    a = sys.argv[1:]
+    if a and a[0] == "--check":
+        for f in a[1:]:
+            print(f"{f}: {_count_connects(Path(f))} inputs:file.connect")
+        return 0
+    if a and a[0] == "--dir":
+        in_dir, out_dir = Path(a[1]), Path(a[2])
+        workers = 6
+        if "--workers" in a:
+            workers = int(a[a.index("--workers") + 1])
+        files = sorted(in_dir.glob("*.usdz"))
+        # Classify (parallel): a model needs fixing iff its USD has file.connect.
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            counts = list(ex.map(_count_connects, files))
+        bad = [f for f, c in zip(files, counts) if c > 0]
+        good = [f for f, c in zip(files, counts) if c == 0]
+        err = [f for f, c in zip(files, counts) if c < 0]
+        print(f"{len(files)} usdz → {len(bad)} need fixing, {len(good)} already direct, {len(err)} unreadable")
+        if err:
+            print("⚠️  unreadable: " + ", ".join(f.name for f in err))
+        # Fix the grey ones (parallel). out_dir ends up containing ONLY fixed models.
+        def _do(f):
+            return f, fix_usdz(f, out_dir / f.name)
+        nok = 0
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            for f, (ok, msg) in ex.map(_do, bad):
+                print(("✅ " if ok else "❌ ") + f"{f.name:50} {msg}")
+                nok += ok
+        print(f"🏁 fixed {nok}/{len(bad)} (out_dir has only the fixed models)")
+        return 0 if nok == len(bad) else 1
+    if len(a) != 2:
+        print(__doc__)
+        return 2
+    ok, msg = fix_usdz(Path(a[0]), Path(a[1]))
+    print(("✅ " if ok else "❌ ") + msg)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Plant3DGenerator/fix_scenekit_materials_pxr.py
+++ b/Plant3DGenerator/fix_scenekit_materials_pxr.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""SceneKit material rebinder for glTF-roundtrip USDZ — pxr (USD) version.
+
+Same fix as fix_scenekit_materials.py, but uses ONLY the `pxr` module
+(`pip install usd-core`) — no usdcat/usdzip CLI — so it runs on a server
+without Xcode/USD CLI (e.g. the Fedora VPS), in place, with no file transfer.
+
+It rewrites every UsdUVTexture `inputs:file` that is *connected* to a Material
+interface input into a *direct* asset value, so SceneKit's USD importer binds
+the texture (these plants render grey in AR otherwise). Geometry, UV transforms,
+colorspaces and embedded textures are untouched.
+
+Usage:
+  python3 fix_pxr.py --check <a.usdz> [b.usdz ...]
+  python3 fix_pxr.py <in.usdz> <out.usdz>
+  python3 fix_pxr.py --inplace --dir <dir> [--backup <dir>] [--workers N]
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from pxr import Usd, UsdShade, UsdUtils  # noqa: E402
+
+
+def _count_connected_textures(usdz: Path) -> int:
+    try:
+        stage = Usd.Stage.Open(str(usdz))
+    except Exception:
+        return -1
+    if not stage:
+        return -1
+    n = 0
+    for prim in stage.Traverse():
+        sh = UsdShade.Shader(prim)
+        if not sh or sh.GetIdAttr().Get() != "UsdUVTexture":
+            continue
+        inp = sh.GetInput("file")
+        if inp and inp.GetAttr().GetConnections():
+            n += 1
+    return n
+
+
+def _rewrite_extracted(work: Path) -> int:
+    roots = sorted(list(work.rglob("*.usdc")) + list(work.rglob("*.usda")))
+    fixed = 0
+    for root in roots:
+        stage = Usd.Stage.Open(str(root))
+        if not stage:
+            continue
+        changed = False
+        for prim in stage.Traverse():
+            sh = UsdShade.Shader(prim)
+            if not sh or sh.GetIdAttr().Get() != "UsdUVTexture":
+                continue
+            inp = sh.GetInput("file")
+            if not inp:
+                continue
+            attr = inp.GetAttr()
+            conns = attr.GetConnections()
+            if not conns:
+                continue
+            src = stage.GetAttributeAtPath(conns[0])
+            val = src.Get() if src else None
+            if val is None:
+                continue
+            attr.ClearConnections()
+            attr.Set(val)          # set the resolved @asset@ path directly
+            fixed += 1
+            changed = True
+        if changed:
+            stage.GetRootLayer().Save()
+    return fixed
+
+
+def fix_usdz(src: Path, dst: Path) -> tuple[bool, str]:
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            w = Path(td)
+            with zipfile.ZipFile(src) as zf:
+                zf.extractall(w)
+            roots = sorted(list(w.rglob("*.usdc")) + list(w.rglob("*.usda")))
+            if not roots:
+                return False, "no usd root"
+            n = _rewrite_extracted(w)
+            if n == 0:
+                return False, "nothing to fix (already direct?)"
+            out_tmp = w / "_out.usdz"
+            # CreateNewARKitUsdzPackage resolves relative deps against CWD; run from w.
+            import os
+            cwd = os.getcwd()
+            try:
+                os.chdir(w)
+                ok = UsdUtils.CreateNewARKitUsdzPackage(roots[0].name, "_out.usdz")
+            finally:
+                os.chdir(cwd)
+            if not ok or not out_tmp.exists():
+                return False, "usdz repackage failed"
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(out_tmp), str(dst))
+        return True, f"fixed {n} texture binding(s)"
+    except Exception as e:  # noqa: BLE001
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    a = sys.argv[1:]
+    if a and a[0] == "--check":
+        for f in a[1:]:
+            print(f"{f}: {_count_connected_textures(Path(f))} connected UsdUVTexture(s)")
+        return 0
+    if "--inplace" in a and "--dir" in a:
+        d = Path(a[a.index("--dir") + 1])
+        backup = Path(a[a.index("--backup") + 1]) if "--backup" in a else d.parent / (d.name + "_greybak")
+        workers = int(a[a.index("--workers") + 1]) if "--workers" in a else 6
+        files = sorted(d.glob("*.usdz"))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            counts = dict(zip(files, ex.map(_count_connected_textures, files)))
+        bad = [f for f in files if counts[f] > 0]
+        good = [f for f in files if counts[f] == 0]
+        err = [f for f in files if counts[f] < 0]
+        backup.mkdir(parents=True, exist_ok=True)
+        print(f"{len(files)} usdz → {len(bad)} to fix, {len(good)} already direct, {len(err)} unreadable")
+        if err:
+            print("⚠️  unreadable: " + ", ".join(f.name for f in err))
+
+        def _do(f: Path):
+            shutil.copy2(f, backup / f.name)                 # backup grey original
+            ok, msg = fix_usdz(f, f.with_suffix(".usdz.tmpfix"))
+            if ok:
+                shutil.move(str(f.with_suffix(".usdz.tmpfix")), str(f))
+            return f, ok, msg
+
+        nok = 0
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            for f, ok, msg in ex.map(_do, bad):
+                print(("✅ " if ok else "❌ ") + f"{f.name:50} {msg}")
+                nok += ok
+        print(f"🏁 fixed {nok}/{len(bad)} in place; backups in {backup}")
+        return 0 if nok == len(bad) else 1
+    if len(a) != 2:
+        print(__doc__)
+        return 2
+    ok, msg = fix_usdz(Path(a[0]), Path(a[1]))
+    print(("✅ " if ok else "❌ ") + msg)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Plant3DGenerator/fix_scenekit_materials_pxr.py
+++ b/Plant3DGenerator/fix_scenekit_materials_pxr.py
@@ -90,14 +90,10 @@ def fix_usdz(src: Path, dst: Path) -> tuple[bool, str]:
             if n == 0:
                 return False, "nothing to fix (already direct?)"
             out_tmp = w / "_out.usdz"
-            # CreateNewARKitUsdzPackage resolves relative deps against CWD; run from w.
-            import os
-            cwd = os.getcwd()
-            try:
-                os.chdir(w)
-                ok = UsdUtils.CreateNewARKitUsdzPackage(roots[0].name, "_out.usdz")
-            finally:
-                os.chdir(cwd)
+            # Absolute paths, NO os.chdir: chdir is process-wide and races under
+            # ThreadPoolExecutor. CreateNewARKitUsdzPackage resolves the layer's
+            # relative texture deps against the layer's own directory.
+            ok = UsdUtils.CreateNewARKitUsdzPackage(str(roots[0]), str(out_tmp))
             if not ok or not out_tmp.exists():
                 return False, "usdz repackage failed"
             dst.parent.mkdir(parents=True, exist_ok=True)

--- a/Plant3DGenerator/optimize_models.py
+++ b/Plant3DGenerator/optimize_models.py
@@ -8,7 +8,8 @@ files to opti_output/ WITHOUT touching the originals in output/.
 
 Pipeline per model (from the source GLB):
   gltf-transform weld → simplify → resize (unpacked .gltf, textures as files)
-  → usdcat .gltf → .usda → inject subdivisionScheme="none" (iOS ARView)
+  → usdcat .gltf → .usda → rebind textures to direct asset paths for SceneKit
+    (#292) → inject subdivisionScheme="none" (iOS ARView)
   → usdzip --arkitAsset → opti_output/<name>.usdz
 
 Validated: Monstera 29 MB → 3 MB (~9x), visually near-identical.
@@ -33,6 +34,49 @@ OUT_DIR = SCRIPT_DIR / "opti_output"
 GLTF = SCRIPT_DIR / "node_modules" / ".bin" / "gltf-transform"
 
 _MESH_RE = re.compile(r'(def Mesh "[^"]+"\s*\n\s*\{\s*\n)')
+
+# SceneKit (SCNScene(url:) in the iOS AR view) does NOT follow
+# `asset inputs:file.connect = <Material.inputs:XxxTexture>`, so the glTF->USD
+# output below renders grey in AR. Rewrite each connected texture file input to
+# a direct `asset inputs:file = @path@`. See issue #292 and
+# fix_scenekit_materials.py (standalone tool for already-built models).
+_TEX_CONNECT_RE = re.compile(
+    r'^(?P<indent>\s*)asset inputs:file\.connect\s*=\s*<(?P<path>[^>]+)\.inputs:(?P<key>\w+)>\s*$'
+)
+_TEX_IFACE_RE = re.compile(r'^\s*asset inputs:(?P<key>\w+)\s*=\s*(?P<val>@[^@]+@)\s*$')
+_MAT_DEF_RE = re.compile(r'def Material "(?P<name>[^"]+)"')
+
+
+def _rebind_scenekit_textures(usda_path: Path) -> int:
+    """Rewrite connected UsdUVTexture file inputs to direct asset paths (#292)."""
+    text = usda_path.read_text()
+    iface: dict[tuple[str, str], str] = {}
+    cur = None
+    for line in text.splitlines():
+        m = _MAT_DEF_RE.search(line)
+        if m:
+            cur = m.group("name")
+            continue
+        im = _TEX_IFACE_RE.match(line)
+        if im and cur and im.group("key").endswith("Texture"):
+            iface[(cur, im.group("key"))] = im.group("val")
+    out, n = [], 0
+    for line in text.splitlines():
+        cm = _TEX_CONNECT_RE.match(line)
+        if cm:
+            mat = cm.group("path").rstrip("/").split("/")[-1]
+            val = iface.get((mat, cm.group("key")))
+            if val is None:
+                cands = {v for (mm, k), v in iface.items() if k == cm.group("key")}
+                val = next(iter(cands)) if len(cands) == 1 else None
+            if val is not None:
+                out.append(f'{cm.group("indent")}asset inputs:file = {val}')
+                n += 1
+                continue
+        out.append(line)
+    if n:
+        usda_path.write_text("\n".join(out) + ("\n" if text.endswith("\n") else ""))
+    return n
 
 
 def _run(cmd: list[str], cwd: Path | None = None) -> None:
@@ -67,6 +111,7 @@ def optimize_one(glb: Path, args) -> tuple[str, float, float, str]:
             _run([str(GLTF), "resize", str(w / "2.glb"), str(w / "m.gltf"),
                   "--width", str(args.texture_size), "--height", str(args.texture_size)])
             _run(["usdcat", "m.gltf", "-o", "m.usda"], cwd=w)
+            _rebind_scenekit_textures(w / "m.usda")  # direct texture binding for SceneKit (#292)
             _inject_subdivision(w / "m.usda")
             _run(["usdzip", "--arkitAsset", "m.usda", "out.usdz"], cwd=w)
             OUT_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
Fixes the **grey plants in AR** bug (issue #292).

## Root cause
The iOS AR view loads models with SceneKit (`SCNScene(url:)`), whose USD importer does **not** follow `asset inputs:file.connect = <Material.inputs:XxxTexture>`. The mesh/texture optimizer's glTF → USD round-trip (`optimize_models.py`) emitted exactly that connected form → grey AR models (catalog thumbnails stayed colored because RealityKit / Hydra follow the connection).

## Changes
- **`Plant3DGenerator/optimize_models.py`** — rebinds connected texture inputs to direct `asset inputs:file = @path@` right after the glTF → USD step, so **future models are SceneKit-correct** by construction.
- **`Plant3DGenerator/fix_scenekit_materials.py`** — standalone repair (usdcat/usdzip CLI).
- **`Plant3DGenerator/fix_scenekit_materials_pxr.py`** — standalone repair using only `pxr` (`pip install usd-core`), `--inplace --dir` with per-file backup; thread-safe.
- **`ArboreBackend/models/README.md`** — documents the LOD layout and the SceneKit direct-binding requirement + repair tools.

## Already deployed
The **124 light** models served on the VPS were patched in place (grey originals backed up in `~/model-backups/grey-batch`); the 124 heavy were already direct. Confirmed on-device (build 22): patched model renders in color.

## Note
`ModelCacheManager` caches USDZ by filename on-device → users who already placed a plant keep the grey one cached until app reinstall.

Refs #292.
