### PR TITLE
feat(backend): rate limit Gemini proxies per user (#303)

### DIFF
--- a/ArboreBackend/go.mod
+++ b/ArboreBackend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/stretchr/testify v1.11.1
 	go.mongodb.org/mongo-driver v1.17.3
+	golang.org/x/time v0.14.0
 	google.golang.org/api v0.262.0
 )
 
@@ -86,7 +87,6 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/appengine/v2 v2.0.6 // indirect
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -2046,9 +2046,10 @@ func main() {
 		protected.PUT("/gardens/:id", updateGarden)
 		protected.DELETE("/gardens/:id", deleteGarden)
 
-		// Gemini Chat & Scanner Proxies
-		protected.POST("/chat", handleGeminiChat)
-		protected.POST("/diagnose", handleGeminiDiagnose)
+		// Gemini Chat & Scanner Proxies — rate limité par uid pour borner le coût
+		// Gemini et bloquer un client qui boucle (issue #303, cf. ratelimit.go).
+		protected.POST("/chat", chatRateLimiter.middleware(), handleGeminiChat)
+		protected.POST("/diagnose", diagnoseRateLimiter.middleware(), handleGeminiDiagnose)
 
 		// Consents (RGPD)
 		protected.POST("/consents", recordConsent)

--- a/ArboreBackend/ratelimit.go
+++ b/ArboreBackend/ratelimit.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// userRateLimiter maintient un token-bucket par utilisateur (uid Firebase) pour
+// une route donnée. Objectif : empêcher qu'un compte authentifié ne boucle les
+// proxies Gemini (/chat, /diagnose) et ne génère un coût illimité (issue #303).
+//
+// Limites en mémoire process : suffisant tant qu'il n'y a qu'une instance backend.
+// Note : la map croît d'une entrée par uid vu ; acceptable à l'échelle de la beta.
+// Un éviction des buckets inactifs pourra être ajoutée si le volume grossit.
+type userRateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*rate.Limiter
+	r       rate.Limit
+	burst   int
+}
+
+func newUserRateLimiter(r rate.Limit, burst int) *userRateLimiter {
+	return &userRateLimiter{buckets: make(map[string]*rate.Limiter), r: r, burst: burst}
+}
+
+func (u *userRateLimiter) limiterFor(uid string) *rate.Limiter {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	l, ok := u.buckets[uid]
+	if !ok {
+		l = rate.NewLimiter(u.r, u.burst)
+		u.buckets[uid] = l
+	}
+	return l
+}
+
+// middleware renvoie un handler Gin qui limite par uid (posé par
+// FirebaseAuthMiddleware). À utiliser uniquement sur des routes du groupe
+// protégé, où l'uid est garanti présent.
+func (u *userRateLimiter) middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		uid := c.GetString("uid")
+		if uid == "" {
+			// Filet de sécurité : ne devrait pas arriver dans le groupe protégé.
+			uid = "ip:" + c.ClientIP()
+		}
+		if !u.limiterFor(uid).Allow() {
+			c.Header("Retry-After", "60")
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": "Trop de requêtes. Réessaie dans un instant.",
+				"code":  "RATE_LIMITED",
+			})
+			return
+		}
+		c.Next()
+	}
+}
+
+// Limiteurs des proxies Gemini. Valeurs de première passe (par utilisateur) :
+// assez larges pour un usage normal, assez strictes pour borner le coût Gemini
+// et bloquer un client qui boucle. À ajuster selon l'usage réel.
+var (
+	// Chat : ~30 requêtes/heure, avec une petite rafale pour une conversation fluide.
+	chatRateLimiter = newUserRateLimiter(rate.Every(time.Hour/30), 10)
+	// Diagnostic photo (plus coûteux) : ~15 requêtes/heure.
+	diagnoseRateLimiter = newUserRateLimiter(rate.Every(time.Hour/15), 5)
+)

--- a/ArboreBackend/ratelimit_test.go
+++ b/ArboreBackend/ratelimit_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// La rafale (burst) est autorisée, puis les requêtes suivantes sont refusées
+// tant qu'aucun token ne s'est régénéré.
+func TestUserRateLimiter_BurstThenBlock(t *testing.T) {
+	// 1 token/heure, burst 3 : 3 passent, la 4e est refusée.
+	rl := newUserRateLimiter(rate.Every(time.Hour), 3)
+	uid := "user-a"
+
+	for i := 0; i < 3; i++ {
+		if !rl.limiterFor(uid).Allow() {
+			t.Fatalf("requête %d devrait passer (dans la rafale)", i+1)
+		}
+	}
+	if rl.limiterFor(uid).Allow() {
+		t.Fatal("la 4e requête devrait être refusée (rafale épuisée)")
+	}
+}
+
+// Chaque uid a son propre bucket : épuiser celui d'un utilisateur n'affecte pas
+// un autre.
+func TestUserRateLimiter_PerUserIsolation(t *testing.T) {
+	rl := newUserRateLimiter(rate.Every(time.Hour), 1)
+
+	if !rl.limiterFor("user-a").Allow() {
+		t.Fatal("1re requête de user-a devrait passer")
+	}
+	if rl.limiterFor("user-a").Allow() {
+		t.Fatal("2e requête de user-a devrait être refusée")
+	}
+	// user-b n'a jamais consommé : sa 1re requête doit passer.
+	if !rl.limiterFor("user-b").Allow() {
+		t.Fatal("1re requête de user-b devrait passer (bucket indépendant)")
+	}
+}
+
+// limiterFor renvoie le même *rate.Limiter pour un uid donné (le bucket est
+// réutilisé, pas recréé à chaque appel).
+func TestUserRateLimiter_ReusesBucket(t *testing.T) {
+	rl := newUserRateLimiter(rate.Every(time.Hour), 5)
+	a := rl.limiterFor("user-a")
+	b := rl.limiterFor("user-a")
+	if a != b {
+		t.Fatal("limiterFor devrait réutiliser le même bucket pour un uid donné")
+	}
+}


### PR DESCRIPTION
## Contexte

Premier lot du durcissement des proxies Gemini (issue #303). Les routes `/chat` et `/diagnose` proxifient l'API Gemini côté serveur : sans limite, un compte authentifié peut boucler les appels et faire exploser le coût Gemini.

## Changements

- **`ratelimit.go`** — `userRateLimiter` : un token bucket (`golang.org/x/time/rate`) par `uid` Firebase, protégé par mutex. Middleware Gin qui renvoie **429 + `Retry-After`** quand le bucket est vide.
- **`main.go`** — middleware branché sur les deux routes du groupe protégé :
  - `/chat` → ~30 req/h, burst 10 (conversation fluide)
  - `/diagnose` → ~15 req/h, burst 5 (diagnostic photo, plus coûteux)
- **`ratelimit_test.go`** — rafale puis blocage, isolation par uid, réutilisation du bucket.
- `golang.org/x/time` promue en dépendance directe (déjà présente en indirect).

## Notes

- Limites **en mémoire process** : suffisant tant qu'il n'y a qu'une instance backend. La map croît d'une entrée par uid vu (acceptable à l'échelle de la beta ; éviction possible plus tard).
- Reste dans #303 pour un lot suivant : cap de taille de payload (`MaxBytesReader` / `MaxMultipartMemory`), timeouts `http.Server`, propagation du `context`.

## Tests

`go build`, `go vet`, `go test -run TestUserRateLimiter` ✅