### PR TITLE
fix(ci,infra): green golangci-lint and fix web healthcheck false unhealthy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,8 @@ linters:
         - intervalles
         - interm
         - incluse
+        - naturels
+        - inventer
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1532,8 +1532,9 @@ func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
 	maxAttempts := 4
 
 	for attempt < maxAttempts {
-		// nolint:no_ctx_http_request // Simple HTTP call with a timeout is sufficient here
-		req, err := http.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+		// Hôte codé en dur (generativelanguage.googleapis.com) : seul le nom du
+		// modèle vient de l'env, donc pas de SSRF réel → gosec en faux positif.
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer(bodyBytes)) //nolint:gosec // hôte constant Google, pas de SSRF
 		if err != nil {
 			return nil, fmt.Errorf("erreur lors de la création de la requête Gemini: %w", err)
 		}
@@ -1541,14 +1542,14 @@ func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
 		req.Header.Set("x-goog-api-key", apiKey)
 
 		client := &http.Client{Timeout: 60 * time.Second}
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) //nolint:gosec // hôte constant Google, pas de SSRF
 		if err != nil {
 			lastErr = err
 			attempt++
 			time.Sleep(time.Duration(attempt*attempt) * time.Second)
 			continue
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		respData, err = io.ReadAll(resp.Body)
 		if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,10 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
+      # 127.0.0.1 (et pas localhost) : dans le conteneur, localhost résout
+      # d'abord en IPv6 [::1] où Next.js n'écoute pas (bind 0.0.0.0 IPv4) →
+      # faux "unhealthy". Forcer l'IPv4 rend le check fiable.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
       interval: 30s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Suite de #308. Deux correctifs indépendants demandés après le déploiement du rate limiting.

## 1. `backend` (golangci-lint) repasse au vert

Le job `backend` échouait sur **6 issues préexistantes** (introduites avec le proxy Gemini, pas par #308) :

- **errcheck** — `resp.Body.Close()` non vérifié → `defer func() { _ = resp.Body.Close() }()`.
- **gosec G704** (SSRF via taint) sur `http.NewRequest` / `client.Do` — l'hôte est **codé en dur** (`generativelanguage.googleapis.com`), seul le nom du modèle vient de l'env : **faux positif** → `//nolint:gosec` ciblé + commentaire. Retire au passage le `//nolint:no_ctx_http_request` (linter inconnu, la CI le signalait).
- **misspell** ×3 — `naturels`, `inventer` (français) ajoutés aux `ignore-rules` de `.golangci.yml`, comme les autres mots FR déjà présents.

`golangci-lint 2.11.3` (version identique à la CI) : **0 issues** en local.

## 2. Healthcheck web : faux `unhealthy`

`arbore-web` s'affichait `unhealthy` à chaque deploy alors qu'il sert bien (200 en IPv4). Cause : le healthcheck faisait `wget http://localhost:3000/` **dans** le conteneur, où `localhost` résout d'abord en IPv6 `[::1]` — mais Next.js écoute sur `0.0.0.0` (IPv4). → passage à `127.0.0.1:3000`.

## Tests

`go build`, `go vet`, `golangci-lint run` (0 issues) ✅