### PR TITLE
feat(backend): harden Gemini proxies and HTTP server (#303)

### DIFF
--- a/ArboreBackend/httphardening.go
+++ b/ArboreBackend/httphardening.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Durcissement des proxies Gemini et du serveur HTTP (issue #303).
+
+// maxGeminiBodyBytes borne la taille du corps JSON accepté par /chat et
+// /diagnose. Les deux routes reçoivent une image encodée en base64 dans le
+// JSON ; 16 Mo laissent passer une photo de téléphone tout en empêchant qu'un
+// client fasse gonfler la RAM avec un corps arbitrairement gros.
+const maxGeminiBodyBytes int64 = 16 << 20 // 16 Mo
+
+// limitRequestBody place le corps de la requête derrière un http.MaxBytesReader :
+// toute lecture au-delà de maxBytes échoue, ce qui borne la mémoire consommée
+// par le parsing du corps (le handler renvoie alors 400).
+func limitRequestBody(maxBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		c.Next()
+	}
+}
+
+// backoffOrCancel attend d, sauf si le contexte est annulé entre-temps (client
+// déconnecté ou timeout serveur). Évite de continuer à patienter puis à rappeler
+// Gemini pour une requête que plus personne n'attend — et donc de payer l'appel.
+func backoffOrCancel(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// newServer construit le http.Server avec des timeouts explicites. Sans eux, une
+// connexion lente (Slowloris) ou inactive peut immobiliser des ressources
+// indéfiniment. WriteTimeout est large car un appel Gemini + ses retries peut
+// durer plusieurs dizaines de secondes.
+func newServer(addr string, h http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           h,
+		ReadHeaderTimeout: 15 * time.Second,  // anti-Slowloris
+		ReadTimeout:       60 * time.Second,  // lecture du corps (aussi bornée par MaxBytesReader)
+		WriteTimeout:      300 * time.Second, // large : appels Gemini + retries
+		IdleTimeout:       120 * time.Second,
+	}
+}

--- a/ArboreBackend/httphardening_test.go
+++ b/ArboreBackend/httphardening_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// backoffOrCancel attend la durée demandée quand le contexte est valide.
+func TestBackoffOrCancel_CompletesWhenNotCancelled(t *testing.T) {
+	start := time.Now()
+	if err := backoffOrCancel(context.Background(), 15*time.Millisecond); err != nil {
+		t.Fatalf("attendu nil, obtenu %v", err)
+	}
+	if time.Since(start) < 10*time.Millisecond {
+		t.Fatal("aurait dû patienter la durée demandée")
+	}
+}
+
+// backoffOrCancel rend la main immédiatement avec l'erreur du contexte s'il est
+// déjà annulé (client parti), sans attendre la durée.
+func TestBackoffOrCancel_ReturnsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if err := backoffOrCancel(ctx, 10*time.Second); err == nil {
+		t.Fatal("attendu l'erreur du contexte annulé")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("n'aurait pas dû attendre la durée quand le contexte est annulé")
+	}
+}
+
+func newBodyLimitEngine(maxBytes int64) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/x", limitRequestBody(maxBytes), func(c *gin.Context) {
+		if _, err := io.ReadAll(c.Request.Body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+// Un corps plus gros que la limite fait échouer la lecture (le handler renvoie 400).
+func TestLimitRequestBody_RejectsOversized(t *testing.T) {
+	r := newBodyLimitEngine(10)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, 100)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("attendu 400 pour un corps trop gros, obtenu %d", w.Code)
+	}
+}
+
+// Un corps dans la limite passe normalement.
+func TestLimitRequestBody_AllowsWithinLimit(t *testing.T) {
+	r := newBodyLimitEngine(1000)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, 100)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("attendu 200 pour un corps dans la limite, obtenu %d", w.Code)
+	}
+}

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1505,7 +1505,7 @@ type DiagnoseRequest struct {
 	Colorimetry ColorimetryDTO `json:"colorimetry"`
 }
 
-func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
+func callGeminiAPI(ctx context.Context, payload map[string]interface{}) ([]byte, error) {
 	apiKey := os.Getenv("GEMINI_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("GEMINI_API_KEY non configurée dans l'environnement")
@@ -1534,7 +1534,7 @@ func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
 	for attempt < maxAttempts {
 		// Hôte codé en dur (generativelanguage.googleapis.com) : seul le nom du
 		// modèle vient de l'env, donc pas de SSRF réel → gosec en faux positif.
-		req, err := http.NewRequest("POST", url, bytes.NewBuffer(bodyBytes)) //nolint:gosec // hôte constant Google, pas de SSRF
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(bodyBytes)) //nolint:gosec // hôte constant Google, pas de SSRF
 		if err != nil {
 			return nil, fmt.Errorf("erreur lors de la création de la requête Gemini: %w", err)
 		}
@@ -1546,7 +1546,9 @@ func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
 		if err != nil {
 			lastErr = err
 			attempt++
-			time.Sleep(time.Duration(attempt*attempt) * time.Second)
+			if berr := backoffOrCancel(ctx, time.Duration(attempt*attempt)*time.Second); berr != nil {
+				return nil, berr
+			}
 			continue
 		}
 		defer func() { _ = resp.Body.Close() }()
@@ -1562,7 +1564,9 @@ func callGeminiAPI(payload map[string]interface{}) ([]byte, error) {
 			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respData))
 			if resp.StatusCode == 429 || resp.StatusCode == 503 || resp.StatusCode >= 500 {
 				attempt++
-				time.Sleep(time.Duration(attempt*attempt) * time.Second)
+				if berr := backoffOrCancel(ctx, time.Duration(attempt*attempt)*time.Second); berr != nil {
+					return nil, berr
+				}
 				continue
 			}
 			return nil, lastErr
@@ -1669,7 +1673,7 @@ func handleGeminiChat(c *gin.Context) {
 		"contents": contents,
 	}
 
-	respData, err := callGeminiAPI(payload)
+	respData, err := callGeminiAPI(c.Request.Context(), payload)
 	if err != nil {
 		// Ne jamais propager err.Error() au client : l'erreur peut contenir l'URL de
 		// l'appel sortant et d'autres détails internes. Log serveur uniquement.
@@ -1776,7 +1780,7 @@ Les valeurs numériques sont entre 0 et 1.
 		},
 	}
 
-	respData, err := callGeminiAPI(payload)
+	respData, err := callGeminiAPI(c.Request.Context(), payload)
 	if err != nil {
 		// Idem chat : aucune fuite de l'erreur brute (peut contenir l'URL sortante).
 		log.Printf("❌ callGeminiAPI (diagnose) a échoué: %v", err)
@@ -1940,7 +1944,7 @@ func main() {
 	}))
 
 	// Augmenter la limite de taille pour les uploads de fichiers (1GB max)
-	router.MaxMultipartMemory = 1 << 30 // 1 GB
+	router.MaxMultipartMemory = 32 << 20 // 32 Mo (buffer mémoire du parsing multipart)
 
 	// === ROUTE PUBLIQUE (Health Check) ===
 	router.GET("/health", func(c *gin.Context) {
@@ -2049,8 +2053,8 @@ func main() {
 
 		// Gemini Chat & Scanner Proxies — rate limité par uid pour borner le coût
 		// Gemini et bloquer un client qui boucle (issue #303, cf. ratelimit.go).
-		protected.POST("/chat", chatRateLimiter.middleware(), handleGeminiChat)
-		protected.POST("/diagnose", diagnoseRateLimiter.middleware(), handleGeminiDiagnose)
+		protected.POST("/chat", chatRateLimiter.middleware(), limitRequestBody(maxGeminiBodyBytes), handleGeminiChat)
+		protected.POST("/diagnose", diagnoseRateLimiter.middleware(), limitRequestBody(maxGeminiBodyBytes), handleGeminiDiagnose)
 
 		// Consents (RGPD)
 		protected.POST("/consents", recordConsent)
@@ -2094,8 +2098,10 @@ func main() {
 		protected.POST("/models/thumbnails/:plantId", uploadPlantThumbnail)
 	}
 
+	srv := newServer(":8080", router)
 	fmt.Println("🚀 Serveur démarré sur http://localhost:8080")
-	if err := router.Run(":8080"); err != nil {
+	// Pas d'arrêt gracieux ici : ListenAndServe ne renvoie qu'en cas d'erreur réelle.
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal("❌ Erreur lors du démarrage du serveur :", err) // nolint:misspell
 	}
 


### PR DESCRIPTION
Deuxième et dernier lot du durcissement des proxies Gemini (issue #303), après le rate limiting (#308).

## Changements

- **Cap du corps des routes Gemini** — middleware `limitRequestBody` avec `http.MaxBytesReader` à **16 Mo** sur `/chat` et `/diagnose` (corps JSON contenant une image base64). Au-delà, la lecture échoue → 400, la RAM par requête est bornée.
- **`MaxMultipartMemory` 1 Go → 32 Mo** — buffer mémoire du parsing multipart (uploads photo/thumbnail). 1 Go permettait à une seule requête de bufferiser 1 Go en RAM.
- **Timeouts serveur explicites** — `newServer()` construit un `http.Server` (`ReadHeaderTimeout` 15s anti-Slowloris, `ReadTimeout` 60s, `WriteTimeout` 300s large pour Gemini+retries, `IdleTimeout` 120s) au lieu de `router.Run` (aucun timeout par défaut).
- **Propagation du `context`** — `callGeminiAPI` prend `c.Request.Context()` et utilise `http.NewRequestWithContext`. Le backoff des retries devient interruptible (`backoffOrCancel`) : si le client se déconnecte, l'appel Gemini en cours est annulé → pas de coût pour une requête abandonnée.

## Tests

- `backoffOrCancel` : patiente quand le contexte est valide, rend la main immédiatement s'il est annulé.
- `limitRequestBody` : corps trop gros → 400, corps dans la limite → 200.
- Non-régression rate limiter (#308) : OK.

`go build`, `go vet`, `golangci-lint run` (0 issue), `go test` ✅

Clôt le volet hardening de #303.