### PR TITLE
feat(backend): validate and normalize Gemini diagnose output (#312)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,8 @@ linters:
         - inventer
         - tournement
         - absolue
+        - pointeur
+        - normalis
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/diagnose_normalize.go
+++ b/ArboreBackend/diagnose_normalize.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Normalisation de la réponse de diagnostic Gemini (issue #312) : on ne renvoie
+// jamais au client la sortie brute du modèle, mais une structure typée, bornée
+// et sûre, respectant le contrat du décodeur iOS
+// (GeminiDiagnosticResponse dans PlantHealthScanner.swift).
+
+const (
+	maxDiseases          = 10
+	maxRecommendations   = 12
+	maxDiseaseNameLen    = 120
+	maxRecommendationLen = 500
+	maxSpeciesLen        = 120
+)
+
+// Structs de SORTIE — clés camelCase exactes attendues par le client (décodage
+// sans convertFromSnakeCase). `name` est un string non-pointeur : toujours émis
+// et jamais null (côté iOS il est non-optionnel). Les tableaux sont initialisés
+// pour n'être jamais null.
+type diagnoseDiseaseOut struct {
+	Name       string  `json:"name"`
+	Severity   float64 `json:"severity"`
+	Confidence float64 `json:"confidence"`
+}
+
+type diagnoseOut struct {
+	Species         *string              `json:"species"`
+	OverallHealth   float64              `json:"overallHealth"`
+	Diseases        []diagnoseDiseaseOut `json:"diseases"`
+	Recommendations []string             `json:"recommendations"`
+	IsUncertain     bool                 `json:"isUncertain"`
+}
+
+// Structs d'ENTRÉE — pointeurs pour distinguer « absent » de « valeur zéro ».
+type diagnoseInDisease struct {
+	Name       *string  `json:"name"`
+	Severity   *float64 `json:"severity"`
+	Confidence *float64 `json:"confidence"`
+}
+
+type diagnoseIn struct {
+	Species         *string             `json:"species"`
+	OverallHealth   *float64            `json:"overallHealth"`
+	Diseases        []diagnoseInDisease `json:"diseases"`
+	Recommendations []string            `json:"recommendations"`
+	IsUncertain     *bool               `json:"isUncertain"`
+}
+
+// clampUnit borne une valeur dans [0,1].
+func clampUnit(f float64) float64 {
+	switch {
+	case f < 0:
+		return 0
+	case f > 1:
+		return 1
+	default:
+		return f
+	}
+}
+
+// normalizeDiagnose décode la réponse brute du modèle et renvoie une structure
+// bornée et sûre : valeurs numériques clampées dans [0,1], tableaux bornés et
+// jamais null, maladies sans nom écartées, défauts prudents.
+func normalizeDiagnose(raw []byte) (diagnoseOut, error) {
+	var in diagnoseIn
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return diagnoseOut{}, err
+	}
+
+	out := diagnoseOut{
+		Diseases:        []diagnoseDiseaseOut{},
+		Recommendations: []string{},
+		IsUncertain:     true, // défaut prudent si le modèle l'omet
+	}
+
+	// species : assaini, null si vide.
+	if in.Species != nil {
+		if s := sanitizeLine(*in.Species, maxSpeciesLen); s != "" {
+			out.Species = &s
+		}
+	}
+
+	if in.OverallHealth != nil {
+		out.OverallHealth = clampUnit(*in.OverallHealth)
+	}
+
+	if in.IsUncertain != nil {
+		out.IsUncertain = *in.IsUncertain
+	}
+
+	for _, d := range in.Diseases {
+		if len(out.Diseases) >= maxDiseases {
+			break
+		}
+		name := ""
+		if d.Name != nil {
+			name = sanitizeLine(*d.Name, maxDiseaseNameLen)
+		}
+		if name == "" {
+			continue // maladie sans nom : écartée (name non-optionnel côté iOS)
+		}
+		disease := diagnoseDiseaseOut{Name: name}
+		if d.Severity != nil {
+			disease.Severity = clampUnit(*d.Severity)
+		}
+		if d.Confidence != nil {
+			disease.Confidence = clampUnit(*d.Confidence)
+		}
+		out.Diseases = append(out.Diseases, disease)
+	}
+
+	for _, r := range in.Recommendations {
+		if len(out.Recommendations) >= maxRecommendations {
+			break
+		}
+		if rec := strings.TrimSpace(truncateRunes(r, maxRecommendationLen)); rec != "" {
+			out.Recommendations = append(out.Recommendations, rec)
+		}
+	}
+
+	return out, nil
+}

--- a/ArboreBackend/diagnose_normalize_test.go
+++ b/ArboreBackend/diagnose_normalize_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeDiagnose_ClampsNumericValues(t *testing.T) {
+	raw := `{"overallHealth":1.5,"diseases":[{"name":"Oïdium","severity":-0.2,"confidence":2.0}]}`
+	out, err := normalizeDiagnose([]byte(raw))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if out.OverallHealth != 1.0 {
+		t.Fatalf("overallHealth non clampé: %v", out.OverallHealth)
+	}
+	if len(out.Diseases) != 1 {
+		t.Fatalf("attendu 1 maladie, obtenu %d", len(out.Diseases))
+	}
+	if out.Diseases[0].Severity != 0 || out.Diseases[0].Confidence != 1 {
+		t.Fatalf("severity/confidence non clampés: %+v", out.Diseases[0])
+	}
+}
+
+func TestNormalizeDiagnose_DropsNamelessDiseases(t *testing.T) {
+	raw := `{"diseases":[{"name":"Rouille"},{"severity":0.5},{"name":"","confidence":0.3},{"name":"  "}]}`
+	out, err := normalizeDiagnose([]byte(raw))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if len(out.Diseases) != 1 || out.Diseases[0].Name != "Rouille" {
+		t.Fatalf("seule la maladie nommée devait rester: %+v", out.Diseases)
+	}
+}
+
+func TestNormalizeDiagnose_DefaultsAndNeverNullArrays(t *testing.T) {
+	out, err := normalizeDiagnose([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if !out.IsUncertain {
+		t.Fatal("isUncertain devrait défaut à true quand absent")
+	}
+	if out.Species != nil {
+		t.Fatalf("species devrait être null quand absent, obtenu %v", *out.Species)
+	}
+	// Les tableaux ne doivent jamais être null dans le JSON émis.
+	b, _ := json.Marshal(out)
+	s := string(b)
+	if !strings.Contains(s, `"diseases":[]`) || !strings.Contains(s, `"recommendations":[]`) {
+		t.Fatalf("tableaux null émis: %s", s)
+	}
+}
+
+func TestNormalizeDiagnose_EmptySpeciesBecomesNull(t *testing.T) {
+	out, err := normalizeDiagnose([]byte(`{"species":"   "}`))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if out.Species != nil {
+		t.Fatalf("species vide devrait devenir null, obtenu %q", *out.Species)
+	}
+}
+
+func TestNormalizeDiagnose_BoundsCounts(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`{"diseases":[`)
+	for i := 0; i < 25; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`{"name":"m"}`)
+	}
+	sb.WriteString(`],"recommendations":[`)
+	for i := 0; i < 25; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"reco"`)
+	}
+	sb.WriteString(`]}`)
+
+	out, err := normalizeDiagnose([]byte(sb.String()))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if len(out.Diseases) != maxDiseases {
+		t.Fatalf("diseases non borné: %d", len(out.Diseases))
+	}
+	if len(out.Recommendations) != maxRecommendations {
+		t.Fatalf("recommendations non borné: %d", len(out.Recommendations))
+	}
+}
+
+func TestNormalizeDiagnose_SanitizesDiseaseName(t *testing.T) {
+	raw := `{"diseases":[{"name":"Taches\nnoires"}]}`
+	out, err := normalizeDiagnose([]byte(raw))
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if len(out.Diseases) != 1 || strings.Contains(out.Diseases[0].Name, "\n") {
+		t.Fatalf("nom de maladie non assaini: %+v", out.Diseases)
+	}
+	if out.Diseases[0].Name != "Taches noires" {
+		t.Fatalf("nom inattendu: %q", out.Diseases[0].Name)
+	}
+}
+
+func TestNormalizeDiagnose_InvalidJSON(t *testing.T) {
+	if _, err := normalizeDiagnose([]byte(`{not json`)); err == nil {
+		t.Fatal("attendu une erreur pour du JSON invalide")
+	}
+}
+
+// La maladie normalisée émet toujours un name non-null (contrainte iOS).
+func TestNormalizeDiagnose_DiseaseNameAlwaysEmitted(t *testing.T) {
+	out, _ := normalizeDiagnose([]byte(`{"diseases":[{"name":"Mildiou","severity":0.4}]}`))
+	b, _ := json.Marshal(out)
+	if !strings.Contains(string(b), `"name":"Mildiou"`) {
+		t.Fatalf("name non émis correctement: %s", b)
+	}
+	if strings.Contains(string(b), `"name":null`) {
+		t.Fatalf("name null émis: %s", b)
+	}
+}

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -1846,14 +1846,16 @@ Les valeurs numériques sont entre 0 et 1.
 
 	jsonString := rawText[firstBrace : lastBrace+1]
 
-	var diagnoseResponse map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonString), &diagnoseResponse); err != nil {
+	// Normalisation : structure typée, valeurs bornées, tableaux jamais null,
+	// maladies sans nom écartées — cf. contrat iOS (issue #312).
+	normalized, err := normalizeDiagnose([]byte(jsonString))
+	if err != nil {
 		log.Printf("❌ diagnose: parsing du JSON de diagnostic impossible: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Réponse de diagnostic illisible."})
 		return
 	}
 
-	c.JSON(http.StatusOK, diagnoseResponse)
+	c.JSON(http.StatusOK, normalized)
 }
 
 // ---------- LOAD ENV ----------


### PR DESCRIPTION
Ferme #312. Le backend ne renvoie plus la sortie brute du modèle sur `/diagnose`, mais une structure **typée, bornée et normalisée**.

## Contrat iOS respecté

Vérifié sur `GeminiDiagnosticResponse` (`PlantHealthScanner.swift`) + `NetworkManager` (`JSONDecoder` par défaut, **pas** de `convertFromSnakeCase`) :
- Clés camelCase exactes conservées (`species`, `overallHealth`, `diseases`, `recommendations`, `isUncertain`, `name`, `severity`, `confidence`).
- ⚠️ `diseases[].name` non-optionnel côté Swift → **toujours émis, jamais null** ; les maladies sans nom sont **écartées**.
- `species` en `*string` (null autorisé) ; `diseases`/`recommendations` **jamais null** (tableau vide au minimum).

→ Rétrocompatible : aucun changement de clé ni de type.

## Normalisation (`normalizeDiagnose`)

- Décodage dans un intermédiaire à pointeurs (distingue « absent » de « zéro »).
- **Clamp** `overallHealth` / `severity` / `confidence` dans `[0,1]`.
- Bornes : max 10 maladies, 12 recommandations ; `name`/`recommendation`/`species` assainis et tronqués.
- Défauts prudents : `isUncertain=true` si absent, `species=null` si vide.

## Tests

8 tests unitaires de normalisation (clamp, bornes, drop sans nom, défauts, tableaux jamais null, JSON invalide) + les tests handler `/diagnose` de #313 restent verts.

`go build`, `go vet`, `golangci-lint` (0 issue), `go test ./...` ✅