### PR TITLE
docs: document Gemini proxies and their hardening (FR + EN)

### DIFF
--- a/docs/en/architecture/03-components-backend.md
+++ b/docs/en/architecture/03-components-backend.md
@@ -1,6 +1,6 @@
 # C4 — Level 3: Backend Components
 
-This view opens up the **Backend API** container (Go 1.24 + Gin) and exposes its main modules. The code is organized around a `main.go` file (~1,680 lines) bundling type declarations, handlers, and bootstrap, supplemented by a `middleware/` subfolder for authentication and a few specialized files (`config.go`, `crypto.go`, `apple_revocation.go`, `unsplash.go`, `setdefault.go`).
+This view opens up the **Backend API** container (Go 1.24 + Gin) and exposes its main modules. The code is organized around a `main.go` file (~2,140 lines) bundling type declarations, handlers, and bootstrap, supplemented by a `middleware/` subfolder for authentication and a few specialized files (`config.go`, `crypto.go`, `apple_revocation.go`, `unsplash.go`, `setdefault.go`), plus files dedicated to the **Gemini proxies** (`ratelimit.go`, `httphardening.go`, `promptsafety.go`, `diagnose_normalize.go`).
 
 For the container overview, see [`02-containers.md`](02-containers.md). For the iOS and web components, see [`03-components-ios.md`](03-components-ios.md) and [`03-components-web.md`](03-components-web.md).
 
@@ -15,7 +15,7 @@ flowchart TB
         public["Public routes<br/>/health · GET /models/thumbnails/:filename"]
         apikey["API-key-only group<br/>(APIKeyMiddleware) · GET /config"]
         protected["Protected group<br/>(APIKeyMiddleware + FirebaseAuthMiddleware)"]
-        handlers["HTTP handlers<br/>users · plants · gardens · consents · models"]
+        handlers["HTTP handlers<br/>users · plants · gardens · consents · models · AI assistant"]
         access["Data access + external clients<br/>(MongoDB driver · crypto · unsplash · apple)"]
 
         apikey --> handlers
@@ -28,6 +28,7 @@ flowchart TB
     ai_gen["[Container]<br/>AI Generator (FastAPI)"]
     unsplash["[System Ext]<br/>Unsplash API"]
     apple["[System Ext]<br/>Apple ID (SIWA)"]
+    gemini["[System Ext]<br/>Google Gemini API"]
 
     client --> public
     client --> apikey
@@ -37,13 +38,14 @@ flowchart TB
     access --> ai_gen
     access --> unsplash
     access --> apple
+    handlers --> gemini
 
     classDef ext   fill:#999,stroke:#666,color:#fff
     classDef layer fill:#1168BD,stroke:#0B4884,color:#fff
     classDef cont  fill:#2E7D32,stroke:#1B5E20,color:#fff
     class public,apikey,protected,handlers,access layer
     class client,ai_gen cont
-    class mongo,firebase_admin,unsplash,apple ext
+    class mongo,firebase_admin,unsplash,apple,gemini ext
 ```
 
 The backend exposes **three distinct access levels**, defined in `main()`: **public** routes (no middleware), an **API-key-only** group, and a **protected** group (API key *then* Firebase token). This discipline is enforced by how the `router.Group(...)` calls are composed in `main.go`.
@@ -130,6 +132,30 @@ All of these handlers receive the `uid` via `c.Get("uid")` after passing through
 
 > Unlike the thumbnail PNG (public), `GET /models/:filename` is in the **protected** group: viewing a 3D model requires both an API key **and** a Firebase token.
 
+#### AI Assistant domain (`/chat`, `/diagnose`)
+
+These two routes are **proxies** to the **Google Gemini** API: the backend relays the call server-side so the Gemini key is **never** exposed to the client. The system prompt is sent via the `systemInstruction` field (separate from user content).
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `POST /chat` | `handleGeminiChat` | Conversational gardening assistant (history + message + optional image). Plain-text reply (markdown stripped). |
+| `POST /diagnose` | `handleGeminiDiagnose` | Phytopathological diagnosis from a photo + colorimetric data. **Normalized JSON** reply (see below). |
+
+The outbound call (`callGeminiAPI`) carries the key in the `x-goog-api-key` header (never in the URL, which would leak into `*url.Error`), with backoff retries and **request `context` propagation**: a disconnected client cancels the in-flight Gemini call (`http.NewRequestWithContext`). The raw error is never returned to the client (server log + generic `502`).
+
+### Gemini proxy hardening (#303, #312)
+
+Grouped into dedicated files, applied only to `/chat` and `/diagnose`:
+
+| File | Role |
+|---|---|
+| `ratelimit.go` — `userRateLimiter` | **Per-`uid` rate limiting** (token bucket, `golang.org/x/time/rate`). `/chat` ~30 req/h (burst 10), `/diagnose` ~15 req/h (burst 5). Exceeded → `429` + `Retry-After`. Bounds the Gemini cost and blocks a looping client. |
+| `httphardening.go` — `limitRequestBody` | **Body cap** at 16 MB (`http.MaxBytesReader`) on both routes (JSON body with base64 image). |
+| `httphardening.go` — `newServer` | **Explicit server timeouts** (`ReadHeaderTimeout` 15s anti-Slowloris, `ReadTimeout` 60s, `WriteTimeout` 300s, `IdleTimeout` 120s) — replaces `router.Run`. `MaxMultipartMemory` lowered from 1 GB to 32 MB. |
+| `httphardening.go` — `backoffOrCancel` | Retry backoff **interruptible** by the `context` (no waiting or re-calling Gemini for an abandoned request). |
+| `promptsafety.go` | **Anti-prompt-injection**: a priority safety clause added to the system prompts (user content is data, never an instruction); bounded inputs (message, history); `plantName` sanitized (single line, no control characters) and framed as untrusted data instead of being interpolated raw. |
+| `diagnose_normalize.go` — `normalizeDiagnose` | **Output schema validation** for the diagnosis: typed decoding, numeric values clamped to `[0,1]`, bounded arrays never `null`, nameless diseases dropped, safe defaults. Honors the iOS decoder contract (`diseases[].name` always emitted, camelCase keys). |
+
 ## Support modules and external clients
 
 | File / function | Role |
@@ -158,12 +184,14 @@ All of these handlers receive the `uid` via `c.Get("uid")` after passing through
 | `APPLE_SIWA_CLIENT_ID` | Apple OAuth `client_id`. Native iOS flow = bundle ID `com.arboreteam.arbore`. | configuration |
 | `APPLE_SIWA_KEY_PATH` / `APPLE_SIWA_PRIVATE_KEY` | SIWA `.p8` private key (PKCS8 EC), by path or PEM content. | 🔒 secret |
 | `UNSPLASH_ACCESS_KEY` | Unsplash API key (catalog photos). | 🔒 secret |
+| `GEMINI_API_KEY` | Google Gemini API key for the `/chat` and `/diagnose` proxies. Carried in the `x-goog-api-key` header. | 🔒 secret |
+| `GEMINI_MODEL` | Gemini model used. Code default: `gemini-2.5-flash`. | configuration |
 | `AI_GENERATOR_URL` | AI Generator URL. Code default: `http://localhost:8001`; in prod: internal Docker URL. Endpoint `/generate`. | configuration |
 | `THUMBNAILS_DIR` | PNG thumbnails directory. | configuration |
 | `THUMBNAIL_UPLOAD_ALLOWED_UIDS` | UIDs allowed to upload thumbnails. | configuration |
 | `GIN_MODE` | `release` in prod, `debug` locally. | configuration |
 
-> **Note on `OPENAI_API_KEY`**: present in `.env.example` but **consumed by the AI Generator**, never by the Go backend. **Note on `PORT`**: present in `.env.example` but inert — the server listens hard-coded on `:8080` (`router.Run(":8080")`); `PORT` only affects host-side port mapping (docker-compose).
+> **Note on `OPENAI_API_KEY`**: present in `.env.example` but **consumed by the AI Generator**, never by the Go backend. **Note on `PORT`**: present in `.env.example` but inert — the server listens hard-coded on `:8080` (`http.Server` built by `newServer` with explicit timeouts, see Gemini hardening); `PORT` only affects host-side port mapping (docker-compose).
 
 ## Key points
 
@@ -171,6 +199,7 @@ All of these handlers receive the `uid` via `c.Get("uid")` after passing through
 - **No ORM**: the official MongoDB driver is used directly with `bson.M{...}`. Maximum readability, no structural protection against field-name typos.
 - **Self-only authz everywhere**: the `users`/`gardens` handlers filter by the `uid` extracted from the token, never by the `uid` from the body or URL (see [ADR 0005](../decisions/0005-self-authz-pattern.md)).
 - **Defense in depth**: API key (constant time) **and** Firebase token (verified, email-verified, not banned) on all business traffic.
+- **Hardened AI proxies**: the Gemini routes (`/chat`, `/diagnose`) never relay the key to the client, are rate-limited per `uid`, bounded in body size and time, protected against prompt injection, and their diagnosis output is validated/normalized before return (#303, #312).
 - **Secrets encrypted at rest**: the Apple refresh token is AES-256-GCM encrypted (`crypto.go`) before being written to the database.
 - **Configuration via the environment only**: `MONGODB_URI` is mandatory (`log.Fatal` if absent) — no Mongo credential is hard-coded.
 - **HTTPS**: public access is over HTTPS via Cloudflare (see [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md)); Cloudflare → origin TLS hardening is tracked on the operations side.

--- a/docs/en/testing/backend.md
+++ b/docs/en/testing/backend.md
@@ -1,6 +1,6 @@
 # Backend Tests (back)
 
-The Go backend tests live at the package root (`ArboreBackend/*_test.go`) and in `middleware/`. They use Gin's test mode and `github.com/stretchr/testify/assert`. No real MongoDB is required: the handlers are **re-implemented as mocked Gin routers** that mirror the real authorization logic, which keeps the tests fast and hermetic.
+The Go backend tests live at the package root (`ArboreBackend/*_test.go`) and in `middleware/`. They use Gin's test mode. No real MongoDB is required: depending on the case, handlers are either **re-implemented as mocked Gin routers** (authorization logic) or **called directly** through an injectable seam (Gemini proxies, where the network call is replaced by a fake response). The tests stay fast and hermetic.
 
 ## Inventory
 
@@ -11,6 +11,11 @@ The Go backend tests live at the package root (`ArboreBackend/*_test.go`) and in
 | `ArboreBackend/crypto_test.go` | AES-256-GCM (`encryptWith`/`decryptWith`): round-trip, the ciphertext does not contain the plaintext, wrong key → failure, tampered tag → failure, blob too short → failure. |
 | `ArboreBackend/apple_revocation_test.go` | Sign in with Apple revocation: `generateClientSecret()` (ES256 JWT with kid/iss/sub/aud), `exchangeAuthorizationCode` against an `httptest` server (verified form fields, returned refresh_token, Apple error path), `revokeRefreshToken` (token + `token_type_hint=refresh_token`). The `appleTokenURL`/`appleRevokeURL` package variables are swapped to the test server. |
 | `ArboreBackend/middleware/firebase_auth_test.go` | `isReleaseMode()`, `InitFirebase()` (fatal in release if the credential is missing/invalid, OK in debug), fail-closed semantics (`firebaseAuth == nil` in release → 503, in debug → passes through with uid `unauthenticated`), missing header → 401, invalid format → 401. |
+| `ArboreBackend/ratelimit_test.go` | Per-`uid` rate limiter (`userRateLimiter`): burst allowed then blocked, per-user isolation, bucket reuse. |
+| `ArboreBackend/httphardening_test.go` | Body cap (`limitRequestBody`: too large → 400, within limit → 200) and **interruptible** backoff (`backoffOrCancel`: waits, or returns immediately if the context is cancelled). |
+| `ArboreBackend/promptsafety_test.go` | Anti-injection helpers: `truncateRunes` (rune-safe truncation) and `sanitizeLine` (control-character removal, whitespace collapsing, truncation). |
+| `ArboreBackend/gemini_handlers_test.go` | The `/chat` and `/diagnose` handlers called **for real** via the `geminiCaller` seam (fake Gemini response injected): empty message → 400, markdown stripped, bounded history + anti-injection clause present, image required, JSON extraction (raw and embedded in prose), upstream errors → 502, `plantName` sanitized and framed. |
+| `ArboreBackend/diagnose_normalize_test.go` | Diagnosis normalization (`normalizeDiagnose`): clamp to `[0,1]`, bounds (max diseases / recommendations), nameless diseases dropped, defaults (`isUncertain=true`, `species` null when empty), arrays never `null`, invalid JSON → error. |
 
 ## What these tests guarantee
 
@@ -18,6 +23,7 @@ The Go backend tests live at the package root (`ArboreBackend/*_test.go`) and in
 - **Ownership-based authorization (self-authz)**: a user can neither read, modify, nor delete another user's gardens / photos; responses avoid disclosing the existence of other users' resources.
 - **Encryption at rest**: the Apple refresh token is protected with AES-256-GCM and resists tampering.
 - **Apple compliance**: the ES256 `client_secret` generation and the token exchanges/revocations follow Apple's protocol.
+- **AI proxy hardening**: per-`uid` rate limiting, body cap and interruptible backoff, bounded inputs and anti-injection clause, and diagnosis output-schema normalization (clamped values, iOS contract honored).
 
 ## Running
 

--- a/docs/fr/architecture/03-components-backend.md
+++ b/docs/fr/architecture/03-components-backend.md
@@ -1,6 +1,6 @@
 # C4 — Niveau 3 : Composants Backend
 
-Cette vue ouvre le container **Backend API** (Go 1.24 + Gin) et expose ses modules principaux. Le code est organisé autour d'un fichier `main.go` (~1 680 lignes) regroupant déclarations de types, handlers et bootstrap, complété par un sous-dossier `middleware/` pour l'authentification et quelques fichiers spécialisés (`config.go`, `crypto.go`, `apple_revocation.go`, `unsplash.go`, `setdefault.go`).
+Cette vue ouvre le container **Backend API** (Go 1.24 + Gin) et expose ses modules principaux. Le code est organisé autour d'un fichier `main.go` (~2 140 lignes) regroupant déclarations de types, handlers et bootstrap, complété par un sous-dossier `middleware/` pour l'authentification et quelques fichiers spécialisés (`config.go`, `crypto.go`, `apple_revocation.go`, `unsplash.go`, `setdefault.go`), ainsi que les fichiers dédiés aux **proxies Gemini** (`ratelimit.go`, `httphardening.go`, `promptsafety.go`, `diagnose_normalize.go`).
 
 Pour la vue d'ensemble des containers, consulter [`02-containers.md`](02-containers.md). Pour les composants côté iOS et web, consulter [`03-components-ios.md`](03-components-ios.md) et [`03-components-web.md`](03-components-web.md).
 
@@ -15,7 +15,7 @@ flowchart TB
         public["Routes publiques<br/>/health · GET /models/thumbnails/:filename"]
         apikey["Groupe API-key-only<br/>(APIKeyMiddleware) · GET /config"]
         protected["Groupe protégé<br/>(APIKeyMiddleware + FirebaseAuthMiddleware)"]
-        handlers["Handlers HTTP<br/>users · plants · gardens · consents · models"]
+        handlers["Handlers HTTP<br/>users · plants · gardens · consents · models · assistant IA"]
         access["Accès données + clients externes<br/>(driver MongoDB · crypto · unsplash · apple)"]
 
         apikey --> handlers
@@ -28,6 +28,7 @@ flowchart TB
     ai_gen["[Container]<br/>AI Generator (FastAPI)"]
     unsplash["[System Ext]<br/>Unsplash API"]
     apple["[System Ext]<br/>Apple ID (SIWA)"]
+    gemini["[System Ext]<br/>Google Gemini API"]
 
     client --> public
     client --> apikey
@@ -37,13 +38,14 @@ flowchart TB
     access --> ai_gen
     access --> unsplash
     access --> apple
+    handlers --> gemini
 
     classDef ext   fill:#999,stroke:#666,color:#fff
     classDef layer fill:#1168BD,stroke:#0B4884,color:#fff
     classDef cont  fill:#2E7D32,stroke:#1B5E20,color:#fff
     class public,apikey,protected,handlers,access layer
     class client,ai_gen cont
-    class mongo,firebase_admin,unsplash,apple ext
+    class mongo,firebase_admin,unsplash,apple,gemini ext
 ```
 
 Le backend expose **trois niveaux d'accès** distincts, définis dans `main()` : des routes **publiques** (aucun middleware), un groupe **API-key-only** et un groupe **protégé** (clé API *puis* token Firebase). Cette discipline est imposée par la composition des `router.Group(...)` dans `main.go`.
@@ -130,6 +132,30 @@ Tous ces handlers reçoivent l'`uid` via `c.Get("uid")` après passage des deux 
 
 > Contrairement au PNG de thumbnail (public), `GET /models/:filename` est dans le groupe **protégé** : la consultation d'un modèle 3D exige clé API **et** token Firebase.
 
+#### Domaine Assistant IA (`/chat`, `/diagnose`)
+
+Ces deux routes sont des **proxies** vers l'API **Google Gemini** : le backend relaie l'appel côté serveur pour que la clé Gemini ne soit **jamais** exposée au client. Le prompt système est envoyé via le champ `systemInstruction` (séparé du contenu utilisateur).
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `POST /chat` | `handleGeminiChat` | Assistant jardinage conversationnel (historique + message + image optionnelle). Réponse en texte brut (markdown retiré). |
+| `POST /diagnose` | `handleGeminiDiagnose` | Diagnostic phytopathologique à partir d'une photo + données colorimétriques. Réponse **JSON normalisée** (cf. ci-dessous). |
+
+L'appel sortant (`callGeminiAPI`) porte la clé dans l'en-tête `x-goog-api-key` (jamais dans l'URL, qui fuiterait dans les `*url.Error`), avec retries à backoff et **propagation du `context`** de la requête : un client déconnecté annule l'appel Gemini en cours (`http.NewRequestWithContext`). L'erreur brute n'est jamais renvoyée au client (log serveur + `502` générique).
+
+### Durcissement des proxies Gemini (#303, #312)
+
+Regroupé dans des fichiers dédiés, appliqué uniquement à `/chat` et `/diagnose` :
+
+| Fichier | Rôle |
+|---|---|
+| `ratelimit.go` — `userRateLimiter` | **Rate limiting par `uid`** (token bucket `golang.org/x/time/rate`). `/chat` ~30 req/h (burst 10), `/diagnose` ~15 req/h (burst 5). Dépassement → `429` + `Retry-After`. Borne le coût Gemini et bloque un client qui boucle. |
+| `httphardening.go` — `limitRequestBody` | **Cap du corps** à 16 Mo (`http.MaxBytesReader`) sur les deux routes (corps JSON avec image base64). |
+| `httphardening.go` — `newServer` | **Timeouts serveur explicites** (`ReadHeaderTimeout` 15 s anti-Slowloris, `ReadTimeout` 60 s, `WriteTimeout` 300 s, `IdleTimeout` 120 s) — remplace `router.Run`. `MaxMultipartMemory` ramené de 1 Go à 32 Mo. |
+| `httphardening.go` — `backoffOrCancel` | Backoff des retries **interruptible** par le `context` (pas d'attente ni de rappel Gemini pour une requête abandonnée). |
+| `promptsafety.go` | **Anti-prompt-injection** : clause de sécurité prioritaire ajoutée aux system prompts (le contenu utilisateur est une donnée, jamais une instruction) ; entrées bornées (message, historique) ; `plantName` assaini (une ligne, sans caractères de contrôle) et encadré comme donnée non fiable au lieu d'être interpolé brut. |
+| `diagnose_normalize.go` — `normalizeDiagnose` | **Validation du schéma de sortie** du diagnostic : décodage typé, valeurs numériques clampées dans `[0,1]`, tableaux bornés et jamais `null`, maladies sans nom écartées, défauts prudents. Respecte le contrat du décodeur iOS (`diseases[].name` toujours émis, clés camelCase). |
+
 ## Modules de support et clients externes
 
 | Fichier / fonction | Rôle |
@@ -158,12 +184,14 @@ Tous ces handlers reçoivent l'`uid` via `c.Get("uid")` après passage des deux 
 | `APPLE_SIWA_CLIENT_ID` | `client_id` OAuth Apple. Flux natif iOS = bundle ID `com.arboreteam.arbore`. | configuration |
 | `APPLE_SIWA_KEY_PATH` / `APPLE_SIWA_PRIVATE_KEY` | Clé privée `.p8` (PKCS8 EC) SIWA, par chemin ou contenu PEM. | 🔒 secret |
 | `UNSPLASH_ACCESS_KEY` | Clé API Unsplash (photos du catalogue). | 🔒 secret |
+| `GEMINI_API_KEY` | Clé de l'API Google Gemini pour les proxies `/chat` et `/diagnose`. Portée dans l'en-tête `x-goog-api-key`. | 🔒 secret |
+| `GEMINI_MODEL` | Modèle Gemini utilisé. Défaut code : `gemini-2.5-flash`. | configuration |
 | `AI_GENERATOR_URL` | URL de l'AI Generator. Défaut code : `http://localhost:8001` ; en prod : URL interne Docker. Endpoint `/generate`. | configuration |
 | `THUMBNAILS_DIR` | Répertoire des thumbnails PNG. | configuration |
 | `THUMBNAIL_UPLOAD_ALLOWED_UIDS` | UID autorisés à uploader des thumbnails. | configuration |
 | `GIN_MODE` | `release` en prod, `debug` en local. | configuration |
 
-> **Note `OPENAI_API_KEY`** : présente dans `.env.example` mais **consommée par l'AI Generator**, jamais par le backend Go. **Note `PORT`** : présente dans `.env.example` mais inerte — le serveur écoute en dur sur `:8080` (`router.Run(":8080")`) ; `PORT` n'agit que sur le mapping de port côté hôte (docker-compose).
+> **Note `OPENAI_API_KEY`** : présente dans `.env.example` mais **consommée par l'AI Generator**, jamais par le backend Go. **Note `PORT`** : présente dans `.env.example` mais inerte — le serveur écoute en dur sur `:8080` (`http.Server` construit par `newServer` avec timeouts explicites, cf. durcissement Gemini) ; `PORT` n'agit que sur le mapping de port côté hôte (docker-compose).
 
 ## Points clés
 
@@ -171,6 +199,7 @@ Tous ces handlers reçoivent l'`uid` via `c.Get("uid")` après passage des deux 
 - **Aucun ORM** : driver MongoDB officiel utilisé directement avec `bson.M{...}`. Lisibilité maximale, pas de protection structurelle contre les fautes de frappe sur les champs.
 - **Self-only authz omniprésente** : les handlers `users`/`gardens` filtrent par `uid` extrait du token, jamais par l'`uid` du body ou de l'URL (cf. [ADR 0005](../decisions/0005-self-authz-pattern.md)).
 - **Défense en profondeur** : clé API (temps constant) **et** token Firebase (vérifié, email-verified, non banni) sur tout le trafic métier.
+- **Proxies IA durcis** : les routes Gemini (`/chat`, `/diagnose`) ne relaient jamais la clé au client, sont rate-limitées par `uid`, bornées en taille de corps et en temps, protégées contre le prompt injection, et leur sortie de diagnostic est validée/normalisée avant renvoi (#303, #312).
 - **Secrets chiffrés au repos** : le refresh token Apple est chiffré AES-256-GCM (`crypto.go`) avant écriture en base.
 - **Configuration uniquement par l'environnement** : `MONGODB_URI` est obligatoire (`log.Fatal` si absente) — aucun credential Mongo n'est codé en dur.
 - **HTTPS** : l'accès public se fait en HTTPS via Cloudflare (cf. [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md)) ; le durcissement TLS Cloudflare → origine est suivi côté opérations.

--- a/docs/fr/testing/backend.md
+++ b/docs/fr/testing/backend.md
@@ -1,6 +1,6 @@
 # Tests Backend (back)
 
-Les tests du backend Go vivent à la racine du package (`ArboreBackend/*_test.go`) et dans `middleware/`. Ils utilisent le mode test de Gin et `github.com/stretchr/testify/assert`. Aucun MongoDB réel n'est requis : les handlers sont **re-implémentés en routers Gin mockés** qui reflètent la logique d'autorisation réelle, ce qui garde les tests rapides et hermétiques.
+Les tests du backend Go vivent à la racine du package (`ArboreBackend/*_test.go`) et dans `middleware/`. Ils utilisent le mode test de Gin. Aucun MongoDB réel n'est requis : selon le cas, les handlers sont **re-implémentés en routers Gin mockés** (logique d'autorisation) ou **appelés directement** via une indirection injectable (proxies Gemini, où l'appel réseau est remplacé par une fausse réponse). Les tests restent rapides et hermétiques.
 
 ## Inventaire
 
@@ -11,6 +11,11 @@ Les tests du backend Go vivent à la racine du package (`ArboreBackend/*_test.go
 | `ArboreBackend/crypto_test.go` | AES-256-GCM (`encryptWith`/`decryptWith`) : round-trip, le chiffré ne contient pas le clair, mauvaise clé → échec, tag altéré → échec, blob trop court → échec. |
 | `ArboreBackend/apple_revocation_test.go` | Révocation Sign in with Apple : `generateClientSecret()` (JWT ES256 avec kid/iss/sub/aud), `exchangeAuthorizationCode` contre un `httptest` (champs de formulaire vérifiés, refresh_token retourné, chemin d'erreur Apple), `revokeRefreshToken` (token + `token_type_hint=refresh_token`). Les variables de package `appleTokenURL`/`appleRevokeURL` sont swappées vers le serveur de test. |
 | `ArboreBackend/middleware/firebase_auth_test.go` | `isReleaseMode()`, `InitFirebase()` (fatal en release si credential manquant/invalide, OK en debug), sémantique fail-closed (`firebaseAuth == nil` en release → 503, en debug → passe avec uid `unauthenticated`), en-tête manquant → 401, format invalide → 401. |
+| `ArboreBackend/ratelimit_test.go` | Rate limiter par `uid` (`userRateLimiter`) : rafale autorisée puis blocage, isolation par utilisateur, réutilisation du bucket. |
+| `ArboreBackend/httphardening_test.go` | Cap du corps (`limitRequestBody` : trop gros → 400, dans la limite → 200) et backoff **interruptible** (`backoffOrCancel` : attend, ou rend la main immédiatement si le contexte est annulé). |
+| `ArboreBackend/promptsafety_test.go` | Helpers anti-injection : `truncateRunes` (troncature sûre en runes) et `sanitizeLine` (retrait des caractères de contrôle, compactage des espaces, troncature). |
+| `ArboreBackend/gemini_handlers_test.go` | Handlers `/chat` et `/diagnose` appelés **réellement** via l'indirection `geminiCaller` (fausse réponse Gemini injectée) : message vide → 400, markdown nettoyé, historique borné + clause anti-injection présente, image obligatoire, extraction JSON (brut et noyé dans du texte), erreurs amont → 502, `plantName` assaini et encadré. |
+| `ArboreBackend/diagnose_normalize_test.go` | Normalisation du diagnostic (`normalizeDiagnose`) : clamp `[0,1]`, bornes (max maladies / recommandations), maladies sans nom écartées, défauts (`isUncertain=true`, `species` null si vide), tableaux jamais `null`, JSON invalide → erreur. |
 
 ## Ce qui est garanti par ces tests
 
@@ -18,6 +23,7 @@ Les tests du backend Go vivent à la racine du package (`ArboreBackend/*_test.go
 - **Autorisation par propriété (self-authz)** : un utilisateur ne peut ni lire, ni modifier, ni supprimer les jardins / photos d'un autre ; les réponses évitent de divulguer l'existence de ressources d'autrui.
 - **Chiffrement au repos** : le refresh token Apple est protégé par AES-256-GCM et résiste à l'altération.
 - **Conformité Apple** : la génération du `client_secret` ES256 et les échanges/révocations de token suivent le protocole Apple.
+- **Durcissement des proxies IA** : rate limiting par `uid`, cap et backoff interruptible, bornes des entrées et clause anti-injection, et normalisation du schéma de sortie du diagnostic (valeurs clampées, contrat iOS respecté).
 
 ## Exécution
 


### PR DESCRIPTION
Documente les proxies Gemini (`/chat`, `/diagnose`) et leur durcissement (#303, #312) dans la doc bilingue — ils n'y figuraient pas encore.

## Composants backend (`architecture/03-components-backend.md`, FR + EN)
- **Nouvelle section « Assistant IA / AI Assistant »** : les deux routes proxy, clé jamais exposée côté client, `systemInstruction`, en-tête `x-goog-api-key`, propagation du `context`.
- **Section durcissement** : rate limiting par `uid`, cap du corps + timeouts serveur, backoff interruptible, anti-prompt-injection, normalisation du schéma de sortie — avec le fichier Go responsable de chaque garde-fou.
- **Diagramme C4** : ajout de **Google Gemini** en système externe.
- **Variables d'env** : `GEMINI_API_KEY`, `GEMINI_MODEL` ; note serveur mise à jour (`http.Server` / `newServer` au lieu de `router.Run`).
- Intro : nouveaux fichiers `.go` listés, compteur de lignes de `main.go` actualisé.

## Tests backend (`testing/backend.md`, FR + EN)
- Inventaire des 5 nouveaux fichiers de test + garantie « durcissement des proxies IA ».
- Intro : mention de l'indirection injectable (`geminiCaller`) permettant de tester les **vrais** handlers.

## Parité
FR canonique + EN miroir à parité (211/211 et 49/49 lignes). Aucune mention de scraping. Docs-only, pas de déploiement.