### PR TITLE
test(ios): unit tests for July services (health scanner + notification planner)

### DIFF
--- a/ArboreUi/ArboreUiTests/ArboreNotificationPlannerTests.swift
+++ b/ArboreUi/ArboreUiTests/ArboreNotificationPlannerTests.swift
@@ -1,0 +1,163 @@
+//
+//  ArboreNotificationPlannerTests.swift
+//  ArboreUiTests
+//
+//  Couvre la logique pure du planificateur de notifications (chantier juillet) :
+//  identifiants, ajustement météo/soin de la date d'arrosage, contenu des notifs.
+//
+
+import XCTest
+@testable import ArboreUi
+
+final class ArboreNotificationPlannerTests: XCTestCase {
+
+    private let planner = ArboreNotificationPlanner()
+
+    // Base d'arrosage volontairement loin dans le futur pour que le clamp
+    // `max(now+60s, …)` de adjustedWateringDate n'interfère pas avec le delta.
+    private func farFutureBase() -> Date { Date().addingTimeInterval(30 * 86_400) }
+
+    private func makeRoutine(
+        nextWatering: Date,
+        amount: String = "",
+        notes: String = ""
+    ) -> WateringRoutine {
+        WateringRoutine(
+            id: "r1",
+            gardenId: "g1",
+            plantId: "p1",
+            plantName: "Basilic",
+            frequency: .weekly,
+            amount: amount,
+            notes: notes,
+            nextWateringDate: nextWatering
+        )
+    }
+
+    private func expectedShift(from base: Date, days: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: days, to: base)!
+    }
+
+    // MARK: - Identifiants
+
+    func testIdentifierFormats() {
+        XCTAssertEqual(ArboreNotificationPlanner.wateringIdentifier(routineId: "abc"), "watering.abc")
+        XCTAssertEqual(ArboreNotificationPlanner.careIdentifier(routineId: "abc"), "care.abc")
+        XCTAssertEqual(
+            ArboreNotificationPlanner.projectCompletionIdentifier(projectId: "proj"),
+            "project-completion.proj"
+        )
+    }
+
+    // MARK: - adjustedWateringDate
+
+    func testAdjustedDate_noSignals_isUnchanged() {
+        let base = farFutureBase()
+        let routine = makeRoutine(nextWatering: base)
+        let result = planner.adjustedWateringDate(for: routine, careProfile: nil, weather: nil)
+        XCTAssertEqual(result, base)
+    }
+
+    func testAdjustedDate_hotAndDry_pullsTwoDaysEarlier() {
+        let base = farFutureBase()
+        let routine = makeRoutine(nextWatering: base)
+        let weather = ArboreLocalWeatherSnapshot(
+            maximumTemperatureCelsius: 32,   // ≥ 30 → -1
+            humidityPercent: 30              // < 35 → -1
+        )
+        let result = planner.adjustedWateringDate(for: routine, careProfile: nil, weather: weather)
+        XCTAssertEqual(
+            result.timeIntervalSinceReferenceDate,
+            expectedShift(from: base, days: -2).timeIntervalSinceReferenceDate,
+            accuracy: 1.0
+        )
+    }
+
+    func testAdjustedDate_waterNeedHighVsLow() {
+        let base = farFutureBase()
+        let routine = makeRoutine(nextWatering: base)
+
+        let high = ArborePlantCareProfile(speciesName: "x", waterNeed: .high)  // -1
+        let low = ArborePlantCareProfile(speciesName: "x", waterNeed: .low)    // +1
+
+        let resultHigh = planner.adjustedWateringDate(for: routine, careProfile: high, weather: nil)
+        let resultLow = planner.adjustedWateringDate(for: routine, careProfile: low, weather: nil)
+
+        XCTAssertEqual(
+            resultHigh.timeIntervalSinceReferenceDate,
+            expectedShift(from: base, days: -1).timeIntervalSinceReferenceDate,
+            accuracy: 1.0
+        )
+        XCTAssertEqual(
+            resultLow.timeIntervalSinceReferenceDate,
+            expectedShift(from: base, days: 1).timeIntervalSinceReferenceDate,
+            accuracy: 1.0
+        )
+    }
+
+    func testAdjustedDate_outdoorRain_pushesOneDayLater() {
+        let base = farFutureBase()
+        let routine = makeRoutine(nextWatering: base)
+        let weather = ArboreLocalWeatherSnapshot(
+            precipitationProbability: 0.7,   // ≥ 0.65 en extérieur → +1
+            isOutdoorContext: true
+        )
+        let result = planner.adjustedWateringDate(for: routine, careProfile: nil, weather: weather)
+        XCTAssertEqual(
+            result.timeIntervalSinceReferenceDate,
+            expectedShift(from: base, days: 1).timeIntervalSinceReferenceDate,
+            accuracy: 1.0
+        )
+    }
+
+    // MARK: - Construction des notifications
+
+    func testWateringReminder_idCategoryBodyAndMetadata() {
+        let routine = makeRoutine(nextWatering: farFutureBase(), amount: "200ml")
+        let notif = planner.wateringReminder(for: routine)
+
+        XCTAssertEqual(notif.id, "watering.r1")
+        XCTAssertEqual(notif.category, .wateringReminder)
+        XCTAssertTrue(notif.body.contains("200ml"), "le body devrait reprendre la quantité")
+        XCTAssertEqual(notif.metadata[ArboreNotificationPayloadKey.routineId], "r1")
+        XCTAssertEqual(notif.metadata[ArboreNotificationPayloadKey.plantId], "p1")
+        XCTAssertEqual(notif.metadata[ArboreNotificationPayloadKey.gardenId], "g1")
+    }
+
+    func testWateringReminder_dropsEmptyMetadata() {
+        // Routine sans plantId/gardenId → ces clés ne doivent pas apparaître.
+        let routine = WateringRoutine(
+            id: "solo",
+            plantName: "Menthe",
+            frequency: .weekly,
+            nextWateringDate: farFutureBase()
+        )
+        let notif = planner.wateringReminder(for: routine)
+        XCTAssertNil(notif.metadata[ArboreNotificationPayloadKey.plantId])
+        XCTAssertNil(notif.metadata[ArboreNotificationPayloadKey.gardenId])
+        XCTAssertEqual(notif.metadata[ArboreNotificationPayloadKey.routineId], "solo")
+    }
+
+    func testCareReminder_idCategoryAndFallbackBody() {
+        let care = PlantCareRoutine(
+            id: "c1",
+            gardenId: "g1",
+            plantId: "p1",
+            plantName: "Ficus",
+            kind: .fertilize
+        )
+        let notif = planner.careReminder(for: care)
+
+        XCTAssertEqual(notif.id, "care.c1")
+        XCTAssertEqual(notif.category, .careReminder)
+        // detail et notes vides → body de repli.
+        XCTAssertTrue(notif.body.contains("Ouvrez Arbore"))
+    }
+
+    func testProjectCompletionReminder_idAndCategory() {
+        let notif = planner.projectCompletionReminder(projectId: "proj42", projectName: "Balcon")
+        XCTAssertEqual(notif.id, "project-completion.proj42")
+        XCTAssertEqual(notif.category, .projectCompletion)
+        XCTAssertTrue(notif.title.contains("Balcon"))
+    }
+}

--- a/ArboreUi/ArboreUiTests/PlantHealthScannerTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantHealthScannerTests.swift
@@ -1,0 +1,138 @@
+//
+//  PlantHealthScannerTests.swift
+//  ArboreUiTests
+//
+//  Couvre la logique pure du scan de santé (chantier juillet) : erreurs,
+//  validateur de qualité d'image, analyse colorimétrique (images synthétiques),
+//  et décodage de la réponse de diagnostic (contrat backend #312).
+//
+
+import XCTest
+import CoreImage
+@testable import ArboreUi
+
+final class PlantHealthScannerTests: XCTestCase {
+
+    private func solidImage(
+        red: CGFloat, green: CGFloat, blue: CGFloat, side: CGFloat = 240
+    ) -> CIImage {
+        CIImage(color: CIColor(red: red, green: green, blue: blue))
+            .cropped(to: CGRect(x: 0, y: 0, width: side, height: side))
+    }
+
+    // MARK: - PlantScanError
+
+    func testScanError_descriptionsAreNonEmpty() {
+        let errors: [PlantScanError] = [
+            .lowBrightness(luminance: 0.05),
+            .blurryImage(variance: 12),
+            .noPlantDetected(bestLabel: "wall", bestConfidence: 0.2),
+            .cameraUnavailable,
+            .analysisTimeout,
+            .geminiError("boom")
+        ]
+        for error in errors {
+            XCTAssertFalse(error.errorDescription?.isEmpty ?? true, "\(error) sans description")
+            XCTAssertFalse(error.systemImage.isEmpty, "\(error) sans icône")
+        }
+    }
+
+    func testScanError_geminiErrorEmbedsMessage() {
+        let error = PlantScanError.geminiError("quota dépassé")
+        XCTAssertTrue(error.errorDescription?.contains("quota dépassé") ?? false)
+    }
+
+    func testScanError_iconsAreDistinctPerCase() {
+        XCTAssertEqual(PlantScanError.cameraUnavailable.systemImage, "camera.fill")
+        XCTAssertEqual(PlantScanError.analysisTimeout.systemImage, "clock.fill")
+        XCTAssertEqual(PlantScanError.lowBrightness(luminance: 0).systemImage, "sun.min.fill")
+    }
+
+    // MARK: - ImageQualityValidator
+
+    func testValidator_rejectsDarkImageAsLowBrightness() {
+        let dark = solidImage(red: 0, green: 0, blue: 0)
+        switch ImageQualityValidator.validate(dark) {
+        case .failure(.lowBrightness):
+            break // attendu
+        default:
+            XCTFail("une image noire devrait échouer en lowBrightness")
+        }
+    }
+
+    func testValidator_brightImagePassesBrightnessCheck() {
+        // Une image lumineuse ne doit jamais être rejetée pour manque de luminosité.
+        // (Le seuil de netteté dépend du contenu de l'image — artefacts de bord
+        // CoreImage inclus — et n'est donc pas assertable de façon déterministe ici.)
+        let bright = solidImage(red: 0.6, green: 0.6, blue: 0.6)
+        if case .failure(.lowBrightness) = ImageQualityValidator.validate(bright) {
+            XCTFail("une image lumineuse ne devrait pas échouer en lowBrightness")
+        }
+    }
+
+    // MARK: - ColorimetricAnalyzer
+
+    func testColorimetry_greenImageIsHealthy() {
+        let green = solidImage(red: 0.1, green: 0.7, blue: 0.1)
+        let result = ColorimetricAnalyzer.analyze(green)
+        XCTAssertGreaterThan(result.greenRatio, 0.85, "un feuillage vert plein → ratio vert élevé")
+        XCTAssertGreaterThan(result.healthScore, 0.85)
+        XCTAssertLessThan(result.brownRatio, 0.1)
+    }
+
+    func testColorimetry_brownImageIsNotGreen() {
+        let brown = solidImage(red: 0.45, green: 0.28, blue: 0.12)
+        let result = ColorimetricAnalyzer.analyze(brown)
+        XCTAssertGreaterThan(result.brownRatio, 0.5, "une image brune → ratio brun dominant")
+        XCTAssertLessThan(result.greenRatio, 0.2)
+    }
+
+    // MARK: - Décodage du contrat de diagnostic (backend #312)
+
+    func testDiagnoseResponse_decodesNormalizedShape() throws {
+        let json = """
+        {
+          "species": "Rosa",
+          "overallHealth": 0.9,
+          "diseases": [{ "name": "Oïdium", "severity": 0.3, "confidence": 0.8 }],
+          "recommendations": ["Arroser le matin"],
+          "isUncertain": false
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(
+            GeminiDiagnosticService.GeminiDiagnosticResponse.self,
+            from: json
+        )
+        XCTAssertEqual(decoded.species, "Rosa")
+        XCTAssertEqual(decoded.overallHealth, 0.9)
+        XCTAssertEqual(decoded.diseases?.count, 1)
+        XCTAssertEqual(decoded.diseases?.first?.name, "Oïdium")
+        XCTAssertEqual(decoded.isUncertain, false)
+        XCTAssertEqual(decoded.recommendations, ["Arroser le matin"])
+    }
+
+    func testDiagnoseResponse_toleratesMissingOptionalFields() throws {
+        // Le backend garantit des tableaux non-null, mais le client doit tolérer
+        // l'absence des champs optionnels (species/overallHealth/etc.).
+        let json = "{}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(
+            GeminiDiagnosticService.GeminiDiagnosticResponse.self,
+            from: json
+        )
+        XCTAssertNil(decoded.species)
+        XCTAssertNil(decoded.overallHealth)
+        XCTAssertNil(decoded.diseases)
+    }
+
+    func testDiagnoseResponse_diseaseWithoutNameFailsDecoding() {
+        // `name` est non-optionnel côté client → le backend ne doit jamais émettre
+        // une maladie sans nom (garanti par la normalisation #312).
+        let json = """
+        { "diseases": [{ "severity": 0.5 }] }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(GeminiDiagnosticService.GeminiDiagnosticResponse.self, from: json)
+        )
+    }
+}


### PR DESCRIPTION
Suite **iOS** de #313 : couvre la logique pure des nouveaux services de juillet (`PlantHealthScanner`, `NotificationManager`), l'item « tests des nouveaux services » resté ouvert dans l'audit #301. **18/18 verts sur simulateur** (iPhone 17 Pro).

## `PlantHealthScannerTests`
- **`PlantScanError`** : descriptions non vides + icônes SF Symbol par cas, message Gemini embarqué dans la description.
- **`ImageQualityValidator`** : image noire → `lowBrightness` ; image lumineuse ne tombe jamais en `lowBrightness`. *(Le seuil de netteté dépend du contenu de l'image — artefacts de bord CoreImage inclus — donc non assertable de façon déterministe en unitaire.)*
- **`ColorimetricAnalyzer`** sur images synthétiques : vert plein → `greenRatio`/`healthScore` élevés, brun → `brownRatio` dominant et non-vert.
- **`GeminiDiagnosticResponse`** : décodage de la forme normalisée (#312), tolérance des champs optionnels absents, **maladie sans `name` → échec de décodage** (le pendant client du contrat backend).

## `ArboreNotificationPlannerTests`
- Formats d'identifiants (`watering.`/`care.`/`project-completion.`).
- **`adjustedWateringDate`** (logique météo/soin) : chaud+sec → −2j, besoin en eau haut/bas → ∓1j, pluie en extérieur → +1j, aucun signal → date inchangée.
- Construction des notifs : id / catégorie / body / metadata, métadonnées vides écartées, body de repli du soin.

## Exécution
`xcodebuild test -workspace ArboreUi.xcworkspace -scheme ArboreUi -destination 'iPhone 17 Pro simulator'` → **TEST SUCCEEDED**, 18/18.

Ferme l'item « tests des nouveaux services (PlantHealthScanner, NotificationManager) » de #301.