### PR TITLE
fix(ci): build iOS on macos-15 / Xcode 26 for iOS 26 SDK (Liquid Glass)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ concurrency:
 env:
   GO_VERSION: "1.22"
   PYTHON_VERSION: "3.11"
-  XCODE_VERSION: "16.2"
+  # latest-stable : chaque runner prend son Xcode le plus récent.
+  # ios_ui tourne sur macos-15 → Xcode 26 (SDK iOS 26 requis pour Liquid Glass,
+  # ex. .buttonStyle(.glass)). ios_ar reste sur macos-14 → Xcode 16.x.
+  XCODE_VERSION: "latest-stable"
 
 jobs:
   # Détection des changements pour optimiser les builds
@@ -218,7 +221,8 @@ jobs:
   ios_ui:
     needs: changes
     if: needs.changes.outputs.ios_ui == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-14
+    # macos-15 pour disposer d'Xcode 26 (SDK iOS 26, Liquid Glass).
+    runs-on: macos-15
     timeout-minutes: 45
     defaults:
       run:
@@ -329,7 +333,7 @@ jobs:
           xcodebuild clean build \
             -workspace ArboreUi.xcworkspace \
             -scheme ArboreUi \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -configuration Debug \
             -derivedDataPath build/ \
             CODE_SIGNING_ALLOWED=NO \
@@ -376,7 +380,7 @@ jobs:
           xcodebuild test \
             -workspace ArboreUi.xcworkspace \
             -scheme ArboreUi \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -derivedDataPath build/ \
             -resultBundlePath build/TestResults.xcresult \
             -parallel-testing-enabled YES \
@@ -537,7 +541,7 @@ jobs:
           xcodebuild clean build \
             -project ArboreARkit.xcodeproj \
             -scheme ArboreARkit \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -configuration Debug \
             -derivedDataPath build/ \
             CODE_SIGNING_ALLOWED=NO \
@@ -551,7 +555,7 @@ jobs:
           xcodebuild test \
             -project ArboreARkit.xcodeproj \
             -scheme ArboreARkit \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -derivedDataPath build/ \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty


### PR DESCRIPTION
## Problème
Le job `ios_ui` échoue à la compilation :
```
HomeView.swift:120: reference to member 'glass' cannot be resolved without a contextual type
** BUILD FAILED **
```
`.buttonStyle(.glass)` (Liquid Glass) fait partie du **SDK iOS 26** (introduit le 14/07). La CI est pinnée **Xcode 16.2**, dont le SDK ne connaît pas ce symbole — même sous `#available(iOS 26.0, *)`, qui est un check *runtime*, pas *compile-time*. L'app se compile en local sous **Xcode 26.2**.

Latent jusqu'ici : `ios_ui` est path-filtré (`ArboreUi/**`), il n'avait pas tourné sur du code iOS depuis l'ajout de `.glass`. Révélé quand un PR a touché `ArboreUi/`.

## Fix
- `XCODE_VERSION: 16.2` → **`latest-stable`** : chaque runner prend son Xcode le plus récent.
- `ios_ui` : `macos-14` → **`macos-15`** (pour Xcode 26). `ios_ar` reste sur `macos-14` (Xcode 16.x, pas de Liquid Glass).
- Destinations simulateur : retrait du pin `OS=18.2` → chaque runner utilise le runtime disponible pour l'iPhone 16 Pro (iOS 26 sur macos-15, iOS 18.x sur macos-14).

Aucun changement de code app — c'est un désalignement **CI vs SDK cible**, pas un bug du code.

## Validation
Ce PR touche `ci.yml`, qui est dans le filtre `ios_ui` → **le job se relance et valide le fix**. Suit #319 (audit).