### PR TITLE
chore: dedupe .env.example — root is the single canonical reference (#319)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Docker Compose production configuration.
 # Copy to .env, replace every placeholder, then keep the resulting file at 0600.
+#
+# 📌 Canonical env reference for the whole stack (backend + ai-generator + web).
+# Component-level files (e.g. ArboreBackend/.env.example) only add what a
+# standalone run needs on top of this; shared secrets are documented here only.
 
 BIND_ADDRESS=127.0.0.1
 PORT=8080

--- a/ArboreBackend/.env.example
+++ b/ArboreBackend/.env.example
@@ -1,61 +1,30 @@
-# Configuration Backend Arbore
-# Copier ce fichier en .env et remplir les valeurs
-
-# === SÉCURITÉ ===
-# Clé API pour authentifier l'application iOS
-# ⚠️ Cette clé DOIT être identique à celle injectée par Secrets.xcconfig
-# ⚠️ Ne JAMAIS commit la vraie clé dans Git
-ARBORE_API_KEY=arbore_ios_v1_VOTRE_CLE_ICI
-ARBORE_API_KEY_TEST=
-
-# UIDs Firebase autorisés à modifier le catalogue et lancer les générations IA.
-# Préférer ensuite le custom claim Firebase `admin: true`; cette liste sert au
-# bootstrap et à la récupération. Séparer plusieurs UIDs par des virgules.
-ARBORE_ADMIN_UIDS=
-
-# === FIREBASE ===
-# Chemin vers le fichier de service account Firebase Admin SDK
-# Téléchargez-le depuis Firebase Console > Project Settings > Service accounts
-# ⚠️ Ne JAMAIS commit ce fichier JSON dans Git
-FIREBASE_SERVICE_ACCOUNT_PATH=./arbore-firebase-adminsdk.json
-
-# === MONGODB ===
-# URI de connexion MongoDB
-MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/arbore?retryWrites=true&w=majority
-
-# === IA ===
-# Le chatbot et le diagnostic transitent par Gemini. La génération de fiches
-# passe par le service AiGenerator via le réseau interne.
-GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.5-flash
-AI_GENERATOR_URL=http://localhost:8000
-
-# === UNSPLASH ===
-# Clé d'accès Unsplash pour les images de plantes
-UNSPLASH_ACCESS_KEY=...
-
-# === SIGN IN WITH APPLE — RÉVOCATION (#210) ===
-# Requis pour révoquer le compte Apple à la suppression utilisateur
-# (Guideline 5.1.1(v)). En mode release, le serveur refuse désormais de
-# démarrer si cette configuration ou la clé de chiffrement est absente.
+# ─────────────────────────────────────────────────────────────
+# Backend Arbore — configuration STANDALONE (hors Docker)
+# ─────────────────────────────────────────────────────────────
+# 📌 Référence CANONIQUE de toutes les variables : le `.env.example` à la
+#    RACINE du dépôt (utilisé par Docker Compose, la voie de déploiement).
+#    Ne pas re-documenter ici les secrets : ils vivent une seule fois, à la racine.
 #
-# Clé AES-256 (32 octets) en HEX (64 caractères) pour chiffrer le refresh_token
-# Apple au repos. Générer : openssl rand -hex 32
-MASTER_ENCRYPTION_KEY=
-# Team ID Apple Developer
-APPLE_TEAM_ID=582QH9652J
-# Key ID de la clé .p8 dédiée SIWA
-APPLE_KEY_ID=A4X35PAX94
-# client_id OAuth Apple. Flux NATIF iOS = bundle ID (com.arboreteam.arbore),
-# PAS le Service ID web (com.arboreteam.arbore.siwa).
-APPLE_SIWA_CLIENT_ID=com.arboreteam.arbore
-# Chemin vers la clé privée .p8 (PKCS8 EC). ⚠️ Ne JAMAIS committer la .p8.
-# Avec Docker Compose, utiliser plutôt APPLE_SIWA_KEY_HOST_PATH dans le .env racine.
-APPLE_SIWA_KEY_PATH=./AuthKey_A4X35PAX94.p8
+# Pour un run backend standalone (`make run-backend`, sans Docker) :
+#   1. Copier ce fichier en `.env` ICI (ArboreBackend/.env).
+#   2. Y ajouter les secrets partagés repris du `.env.example` RACINE :
+#      ARBORE_API_KEY, ARBORE_API_KEY_TEST, ARBORE_ADMIN_UIDS, MONGODB_URI,
+#      GEMINI_API_KEY, GEMINI_MODEL, AI_PROVIDER, UNSPLASH_ACCESS_KEY,
+#      MASTER_ENCRYPTION_KEY, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_SIWA_CLIENT_ID.
+#
+# Ci-dessous : UNIQUEMENT les variables spécifiques au run standalone.
+# En Docker, ces valeurs sont posées par docker-compose.yml (pas par ce fichier).
 
-# === SERVEUR ===
-# Port d'écoute du serveur (défaut: 8080)
+# Mode Gin : debug en local, release en prod.
+GIN_MODE=debug
+
+# Port d'écoute du serveur.
 PORT=8080
 
-# Mode Gin (debug|release)
-GIN_MODE=debug
+# AI Generator via localhost en standalone (en Docker : http://ai-generator:8000).
+AI_GENERATOR_URL=http://localhost:8000
+
+# Chemins LOCAUX des secrets fichiers (en Docker : /run/secrets/… via compose).
+# ⚠️ Ne JAMAIS committer ces fichiers.
+FIREBASE_SERVICE_ACCOUNT_PATH=./arbore-firebase-adminsdk.json
+APPLE_SIWA_KEY_PATH=./AuthKey_A4X35PAX94.p8


### PR DESCRIPTION
Suite de l'audit #319 : le `.env.example` **racine** (Docker Compose, voie de déploiement) et `ArboreBackend/.env.example` (run standalone) dupliquaient **~12 secrets partagés** (`ARBORE_API_KEY`, `MONGODB_URI`, `GEMINI_API_KEY`, `MASTER_ENCRYPTION_KEY`, `APPLE_*`, `UNSPLASH_ACCESS_KEY`…) → risque de drift, **déjà matérialisé** (le backend n'avait pas `AI_PROVIDER`, que `initLLMProvider` lit).

## Changement
- **Racine `.env.example` = source canonique unique** (note ajoutée à l'en-tête). Documente toutes les variables du stack (backend + ai-generator + web).
- **`ArboreBackend/.env.example`** réduit à un **pointeur** vers la racine + **uniquement** ses variables spécifiques au run standalone : `GIN_MODE`, `AI_GENERATOR_URL`, chemins locaux (`FIREBASE_SERVICE_ACCOUNT_PATH`, `APPLE_SIWA_KEY_PATH`), `PORT`.
- **Plus aucun secret dupliqué** (seul `PORT`, non-secret, se chevauche).

Le run standalone (`make run-backend`) reste supporté : l'en-tête liste explicitement les secrets à reprendre depuis la racine.

## Note
`web/.env.example` partage encore 2 secrets avec la racine (même schéma) — hors périmètre ici, à traiter séparément si souhaité.

Ferme l'item `.env.example` en double de #319.