### PR TITLE
fix(web,ios): re-enable Next.js auth middleware; drop orphan push background mode (#319)

### DIFF
--- a/ArboreUi/ArboreUi/Info.plist
+++ b/ArboreUi/ArboreUi/Info.plist
@@ -82,10 +82,6 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -7,7 +7,7 @@ const SESSION_COOKIE = 'arbore_auth';
 const PROTECTED = ['/garden', '/profile', '/welcome'];
 const AUTH_PAGES = ['/login', '/signup'];
 
-export function proxy(req: NextRequest) {
+export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const authed = req.cookies.has(SESSION_COOKIE);
   const isProtected = PROTECTED.some(


### PR DESCRIPTION
Deux reliquats du push `publish-arbore-final` relevés par l'audit #319.

## 1. Web — middleware d'auth désactivé par un renommage
`web/middleware.ts` (vrai middleware **edge** Next.js) avait été renommé en `web/proxy.ts`, et la fonction exportée `middleware` → `proxy`. Or **Next.js n'exécute que `middleware.ts`** avec un `export function middleware` : la garde était donc **désactivée** et `proxy.ts` était **du code mort** (jamais importé).

Effet perdu (garde **UX**, pas de sécurité — le backend Go valide toujours le token Firebase) :
- `/garden`, `/profile` → redirection vers `/login?redirect=…` si non connecté ;
- `/login`, `/signup` → redirection vers `/garden` si déjà connecté.

**Fix** : `git mv web/proxy.ts web/middleware.ts` + `export function proxy` → `export function middleware`. Le corps (matcher inclus) est inchangé.

## 2. iOS — background mode push orphelin
Toute l'infra push a été retirée (service extension + `ArborePushTokenService`, aucun appel `registerForRemoteNotifications` restant), mais `Info.plist` déclarait encore `UIBackgroundModes = [remote-notification]`. Retrait de la clé orpheline (les notifications **locales** d'arrosage/soin n'en ont pas besoin).

## Validation
- `plutil -lint Info.plist` : OK.
- `web/middleware.ts` : code verbatim de l'ancien middleware, juste renommé.

Ferme les 2 dernières vérifs de #319.