### PR TITLE
ci(ios): raise ios_ui test-step timeout 20→35 min (Xcode 26 rebuild)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,8 @@ jobs:
     if: needs.changes.outputs.ios_ui == 'true' || github.event_name == 'workflow_dispatch'
     # macos-15 pour disposer d'Xcode 26 (SDK iOS 26, Liquid Glass).
     runs-on: macos-15
-    timeout-minutes: 45
+    # 55 min : marge pour build (~7 min) + Run Unit Tests (jusqu'à 35 min) sous Xcode 26.
+    timeout-minutes: 55
     defaults:
       run:
         working-directory: ./ArboreUi
@@ -364,7 +365,10 @@ jobs:
           echo "✅ Secrets.xcconfig (test) écrit"
 
       - name: 🧪 Run Unit Tests
-        timeout-minutes: 20
+        # 35 min : sous Xcode 26 le `xcodebuild test` recompile l'app + les
+        # cibles de test (dont les UI/integration tests) avant de lancer la
+        # suite ; 20 min étaient trop justes et faisaient timeout le step.
+        timeout-minutes: 35
         env:
           ARBORE_API_KEY_EFFECTIVE: ${{ secrets.ARBORE_API_KEY_TEST != '' && secrets.ARBORE_API_KEY_TEST || secrets.ARBORE_API_KEY }}
         run: |


### PR DESCRIPTION
## Problème
Depuis le passage `ios_ui` sur macos-15 / **Xcode 26** (#320), le step **`Run Unit Tests`** (`xcodebuild test`) **recompile** l'app + les cibles de test (unit + UI + integration) **avant** de lancer la suite. Sous Xcode 26.3 + le code ajouté par le push de Hugo, la compilation seule dépasse presque les **20 min** du timeout de step → le step **timeout**, faisant échouer **toute PR iOS** (le build passe, mais les tests ne finissent jamais). Constaté sur #325 (build ✓, Run Unit Tests ✗ timeout 20 min).

## Fix
- step `Run Unit Tests` : `timeout-minutes` **20 → 35**.
- job `ios_ui` : `timeout-minutes` **45 → 55** (marge : ~7 min de build + jusqu'à 35 min de tests).

Ce PR touche `.github/workflows/ci.yml`, qui est dans le filtre `ios_ui` → **il relance `ios_ui` avec le nouveau timeout et se valide lui-même**.

Débloque #325 et toutes les futures PR iOS. Suit #319.