### PR TITLE
docs: document the July features (health scan, notifications, catalog) — FR + EN

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -25,6 +25,9 @@ The documentation is split into complementary views. Depending on what you are l
 | Per-screen spec — `GardenARPlacementView` | [`screens/garden-ar-placement.md`](screens/garden-ar-placement.md) |
 | Per-screen spec — creation wizard | [`screens/questionnaire-wizard.md`](screens/questionnaire-wizard.md) |
 | Per-screen spec — `PersonalDetailsView` | [`screens/personal-details.md`](screens/personal-details.md) |
+| Per-screen spec — plant health scan | [`screens/plant-health-scan.md`](screens/plant-health-scan.md) |
+| Per-screen spec — plant catalog | [`screens/plant-catalog.md`](screens/plant-catalog.md) |
+| Local notifications (watering and care) | [`architecture/notifications.md`](architecture/notifications.md) |
 | Testing strategy (front + back) | [`testing/_index.md`](testing/_index.md) |
 | iOS tests | [`testing/ios.md`](testing/ios.md) |
 | Backend tests (Go) | [`testing/backend.md`](testing/backend.md) |

--- a/docs/en/architecture/03-components-ios.md
+++ b/docs/en/architecture/03-components-ios.md
@@ -119,8 +119,11 @@ flowchart TB
 | `Models/PotMeasurement.swift` | Pot diameter measurement via ARKit (secondary feature). |
 | `UserService.swift` | Fetches the current user via `GET /users/:uid`. |
 | `Models/GardenProjectService.swift` | Garden CRUD via the backend. |
-| `Services/GardenSuggestionEngine.swift` | Filters and suggests plants suited to the profile. |
+| `Services/GardenSuggestionEngine.swift` | Weighted multi-axis scoring (style, exposure, soil, maintenance, safety) that suggests plants suited to the wizard profile. |
 | `Services/CalendarService.swift` | Generates the watering calendar from the `WateringRoutine` entries. |
+| `Services/PlantHealthScanner.swift` | Health scan: image-quality → Vision detection → colorimetry → AI diagnosis (`POST /diagnose`) pipeline, with an offline colorimetry fallback. See [`../screens/plant-health-scan.md`](../screens/plant-health-scan.md). |
+| `Models/PlantCatalogContext.swift` | Catalog filter dimensions + `PlantSuitabilityEvaluator` (plant ↔ garden-profile compatibility, 9 criteria). See [`../screens/plant-catalog.md`](../screens/plant-catalog.md). |
+| `Notifications/NotificationManager.swift` + `ArboreNotificationPlanner.swift` | **Local** watering and care notifications (authorization, categories/quick actions, scheduling, weather adjustment). See [`notifications.md`](notifications.md). |
 | `LoginAuth/saveAuthDB.swift` | Bridge between Firebase Auth and `POST /users` — implements exponential retry and Firebase rollback (issue #137). |
 
 ### Infrastructure layer

--- a/docs/en/architecture/notifications.md
+++ b/docs/en/architecture/notifications.md
@@ -1,0 +1,62 @@
+# Component — Local notifications
+
+Arbore schedules **local notifications** (`UNUserNotificationCenter`) to remind the user to **water** their plants, perform a **care task** (repot, prune, fertilize…), and for a few nudges (unfinished garden, climate alert). **No remote notifications (push/APNs)**: the push infrastructure was removed, everything is scheduled on-device.
+
+Files: `NotificationManager.swift` (system access + scheduling), `ArboreNotificationPlanner.swift` (notification building + adjustments), `ArboreNotification.swift` (model + trigger + deep-link), `WateringRoutine.swift` (routines + `WateringRoutineStore`).
+
+## Overview
+
+```mermaid
+flowchart TB
+    store["WateringRoutineStore<br/>(persisted routines, UserDefaults)"]
+    planner["ArboreNotificationPlanner<br/>(builds ArboreNotification + adjusts the date)"]
+    mgr["NotificationManager<br/>(authorization, categories, schedule/cancel)"]
+    center["UNUserNotificationCenter (iOS)"]
+    action["User action on the notif<br/>Watered · Tomorrow · Done · Open"]
+
+    store -->|on each save/markWatered| mgr
+    planner --> mgr
+    mgr -->|UNNotificationRequest| center
+    center -->|response| mgr
+    mgr -->|handleNotificationAction| action --> store
+
+    classDef c fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef ext fill:#999,stroke:#666,color:#fff
+    class store,planner,mgr c
+    class center ext
+```
+
+## Components
+
+| File / type | Role |
+|---|---|
+| `NotificationManager` | Requests authorization (`requestAuthorization`, alert/badge/sound, provisional supported), exposes state (`currentAuthorizationState`), registers the **categories** (watering, care, climate emergency) with their actions, and schedules/cancels `UNNotificationRequest`. `handleNotificationAction` routes actions to `WateringRoutineStore`. |
+| `ArboreNotificationPlanner` | Builds an `ArboreNotification` from a `WateringRoutine`/`PlantCareRoutine` (title, contextual body, category, schedule, deep-link, metadata). Computes the **adjusted watering date**. Provides stable identifiers (`watering.<id>`, `care.<id>`, `project-completion.<id>`). |
+| `ArboreNotification` + `ArboreNotificationSchedule` | Neutral model → `UNNotificationTrigger`: `.date` / `.timeInterval` / `.calendar`. Carries a `NotificationRoute` (deep-link to the garden/task) and `metadata` (routineId, plantId, gardenId). |
+| `WateringRoutine` / `PlantCareRoutine` / `WateringRoutineStore` | Watering and care routines, persisted in `UserDefaults`. On each create/`markWatered`/`defer`, the store **re-syncs** the matching notification. |
+
+## Smart watering-date adjustment
+
+`adjustedWateringDate` shifts the next date based on context (within a bounded window):
+- **Care profile**: high water need → −1 day; low → +1 day; preferred-interval gap clamped to ±2 days.
+- **Weather** (if available): heat ≥ 30 °C → −1 day; dry air (humidity < 35%) → −1 day; outdoors with likely rain (≥ 65%) → +1 day; frost risk + sensitive species → +1 day.
+- Guard: never before `now + 60 s`.
+
+The notification body is contextualized too (water amount, heat/dry-air alert, routine notes).
+
+## Quick actions
+
+From a notification, without opening the app:
+- **Watered** (`markWatered`) → marks the routine watered, reschedules the next one.
+- **Done** (`markCareDone`) → completes the care task.
+- **Tomorrow** (`deferTomorrow`) → defers by one day.
+- **Open** → deep-link to the garden/task.
+
+`rescheduleAllRoutineNotifications` (on launch/refresh) reschedules all active routines, and `cancelObsoleteRoutineNotifications` purges those whose routine no longer exists.
+
+## Key points
+
+- **100% local**: no network or server dependency; works offline. The `remote-notification` background mode was removed from `Info.plist` (no more push).
+- **Idempotent**: each routine has a stable identifier → rescheduling replaces the existing notification (no duplicates).
+- **Persistence**: routines live in `UserDefaults` (not yet synced cross-device — see backlog).
+- **Tests**: the planner's pure logic (identifiers, `adjustedWateringDate`, notification building) is covered by `ArboreNotificationPlannerTests.swift` (see [`../testing/ios.md`](../testing/ios.md)).

--- a/docs/en/screens/_index.md
+++ b/docs/en/screens/_index.md
@@ -22,6 +22,8 @@ A screen becomes a hero screen, and therefore a target for a per-screen spec, wh
 | `GardenARPlacementView` | [`garden-ar-placement.md`](garden-ar-placement.md) | State machine (`RelocationPhase`), 3,300 LOC, 3 frameworks (ARKit + SceneKit + SwiftUI), ≥ 5 issues (#96, #111, #113, #114, #123, #124, #136, #138). |
 | Garden creation wizard | [`questionnaire-wizard.md`](questionnaire-wizard.md) | 10 steps with skip rules, `POST /gardens` + branching into two distinct AR flows, ≥ 3 issues (#139, #21, #97). |
 | `PersonalDetailsView` | [`personal-details.md`](personal-details.md) | `PATCH /users/me` + Firebase `displayName` update, save state machine (idle → saving → success/error), issue #138. |
+| Plant health scan | [`plant-health-scan.md`](plant-health-scan.md) | State machine (`ScanPhase`), 4-step pipeline, 2 Apple frameworks (Vision + CoreImage), `POST /diagnose`, GDPR contract (photo sent to Gemini). |
+| Plant catalog | [`plant-catalog.md`](plant-catalog.md) | Multi-dimension filtering + compatibility evaluation (`PlantSuitabilityEvaluator`, 9 criteria), ~1,600 LOC, tracked scoring duplication (#319). |
 
 ## Undocumented hero screens (to be promoted if needed)
 
@@ -30,7 +32,7 @@ The following screens are borderline but are not yet documented. They will be pr
 - `LiDARScanWizardView` — single screen but RoomPlan + transition to `GardenARPlacementView`. Tracked by issue #139.
 - `ARViewContainerMeasure` — single screen, mainly for non-LiDAR perimeter tracing.
 - `SignUpView` — critical flow (#137) but the details are already in [`../flows/auth-signup.md`](../flows/auth-signup.md).
-- `CatalogueView` and `PlantCatalogView` — listings with filters but without complex logic.
+- `CatalogueView` — listing with filters but without complex logic (`PlantCatalogView` is now documented above).
 
 ## Structure of a per-screen spec
 

--- a/docs/en/screens/personal-details.md
+++ b/docs/en/screens/personal-details.md
@@ -113,12 +113,29 @@ Three keys added in fr/en/de/es by issue #138:
 
 ### iOS permissions
 
-No iOS permission required by this screen.
+No iOS permission is required to edit the name. For the profile photo (parent screen, see below), `PHPickerViewController` runs **out-of-process** and therefore requires **no photo-library access authorization**.
 
 ### Apple frameworks used
 
 - **SwiftUI** for the entire view.
 - **FirebaseAuth** for reading the current profile and updating the `displayName`.
+- **PhotosUI** (`PHPickerViewController`) for picking the profile photo from the parent screen.
+
+## Profile photo (parent screen `ProfileView`)
+
+The profile photo is not edited from `PersonalDetailsView` but from its **parent screen** `ProfileView` (button on the header avatar). It is documented here because it is part of the identity data.
+
+| Step | Detail |
+|---|---|
+| Picking | `PhotoPicker` (`ProfileComponents.swift`) wraps `PHPickerViewController` (`filter = .images`, `selectionLimit = 1`). No permission required. |
+| Normalization | `normalizedProfileImage()` then **JPEG quality 0.86** encoding. |
+| Storage | ⚠️ **Local only**: `Documents/ProfileImages/<uid>.jpg` (atomic write). The photo is reloaded when the screen appears (`fetchProfileImage`). |
+| Network | **No upload.** The backend endpoint `POST /users/:uid/photo` still exists server-side but is **no longer called by the iOS app** — the photo never leaves the device. |
+| Error | Write failure → "Impossible de sauvegarder la photo." message (`uploadError`), no retry. |
+
+**Consequences** (tracked in #329): the photo is **not synced across devices** and is lost on uninstall. From a GDPR standpoint this is the most protective behavior (local data, never transmitted) — but the data export (art. 20) cannot include it while it stays on-device.
+
+> **Saving a capture to the photo library** — in a separate flow (`ARViewContainerMeasure`), the app offers to save a capture via `UIImageWriteToSavedPhotosAlbum`, which **requires** `NSPhotoLibraryAddUsageDescription` in `Info.plist` (missing, the app crashed — fixed, see #304).
 
 ## Related issues
 
@@ -130,6 +147,6 @@ No iOS permission required by this screen.
 
 ## Out of scope for this spec
 
-- Managing the **profile photo** goes through the `POST /users/:uid/photo` endpoint (multipart) and is not exposed by this screen. A separate photo editor will be added if needed.
+- The **profile photo** is edited from the parent screen `ProfileView` — described above, in its dedicated section.
 - **Changing the email** and **changing the password** are separate flows not yet implemented.
 - The backend spec for `PATCH /users/me` is in [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).

--- a/docs/en/screens/plant-catalog.md
+++ b/docs/en/screens/plant-catalog.md
@@ -1,0 +1,58 @@
+# Screen — Plant catalog
+
+The catalog lets the user **browse and filter** the plant reference set, and shows for each plant a **compatibility badge** with their garden (based on the collected profile). It is also the entry point to AR placement.
+
+Files: `PlantCatalogView.swift` (screen + filters), `PlantCatalogContext.swift` (filter dimensions + `PlantSuitabilityEvaluator`), `PlantCatalogPreferenceViews.swift` (preferences/filters UI).
+
+## Two distinct mechanisms
+
+1. **Filtering** — the user narrows the list along catalog dimensions.
+2. **Compatibility evaluation** — each plant is scored against the **garden profile** (`GardenWizardDTO`) and gets a level.
+
+> ⚠️ This catalog scoring (`PlantSuitabilityEvaluator`, based on `GardenWizardDTO`) is **distinct** from the wizard's suggestion scoring (`GardenSuggestionEngine`). Both coexist today — consolidation still to be decided (see audit #319).
+
+## Filter dimensions
+
+Defined in `PlantCatalogContext.swift`, each a filterable `enum`:
+
+| Dimension | Examples |
+|---|---|
+| `PlantCatalogGoal` | goal (decorative, vegetable garden, air-purifying…) |
+| `PlantCatalogKind` | type (tree, flower, succulent…) |
+| `PlantCatalogColor` | dominant color |
+| `PlantCatalogAppearance` / `PlantCatalogHabit` | habit / silhouette |
+| `PlantCatalogScale` / `PlantCatalogSize` | size class |
+| `PlantCatalogCareLevel` | care requirement |
+
+The garden style (former wizard step) is meant to live **here, as a filter**, rather than as a step in the creation flow.
+
+## Compatibility evaluation (`PlantSuitabilityEvaluator`)
+
+The evaluator aggregates several **criteria**, each producing a score, then derives an overall level:
+
+| Criterion | Based on (profile / plant flags) |
+|---|---|
+| Space (`appendSpaceCriterion`) | `wizard.spaceType` (interior/balcony/terrace/garden) |
+| Sunlight (`appendSunlightCriterion`) | `wizard.siteProfile.sunlight` vs the plant's tolerances |
+| Safety (`appendSafetyCriteria`) | `wizard.safety` vs `flags.toxicToPets` / `toxicToChildren` |
+| Planting (`appendPlantingCriterion`) | `conditionalAnswers.plantingMode == .containers` |
+| Drainage (`appendDrainageCriterion`) | `conditionalAnswers.drainage` vs `flags.humidityLoving` |
+| Wind (`appendWindCriterion`) | `conditionalAnswers.windExposure` / `siteProfile.wind` |
+| Humidity (`appendHumidityCriterion`) | `conditionalAnswers.indoorHumidity` |
+| Heat (`appendHeatCriterion`) | `conditionalAnswers.nearbyHeat` |
+| Height (`appendHeightCriterion`) | `siteProfile.availableHeight` |
+
+Level (`PlantSuitabilityLevel`): `unsuitable` → `neutral` → `suitable` → `verySuitable`. A **critical** criterion (e.g. toxic while the user has pets) pulls the level down. Each criterion carries a localized reason shown to the user.
+
+> Criteria only apply when the matching profile data is present: an incomplete profile scores on fewer criteria (possibly none → no badge), and never crashes.
+
+## Key points
+
+- **Decoupled from the wizard UI**: the evaluator reads the **DTO** (`GardenWizardDTO`), not the wizard's screen state — so it is independent of the active creation flow.
+- **Plant data**: compatibility relies on the plant record's `flags` (toxicity, humidity-loving…) and the catalog's LOD/botanical schema.
+- **Known duplication**: two scoring systems (`PlantSuitabilityEvaluator` catalog vs `GardenSuggestionEngine` wizard) — kept in place until the flow is frozen (see #319).
+
+## Out of scope for this view
+
+- AR plant placement is documented in [`garden-ar-placement.md`](garden-ar-placement.md).
+- Plant record generation (AI Generator) and 3D LOD are in [`../3d-lod-architecture.md`](../3d-lod-architecture.md).

--- a/docs/en/screens/plant-health-scan.md
+++ b/docs/en/screens/plant-health-scan.md
@@ -1,0 +1,69 @@
+# Screen — Plant Health Scan
+
+The health scan lets the user photograph a plant to get a **phytopathological diagnosis**: probable species, overall health, detected diseases, and recommendations. The pipeline combines **on-device pre-checks** (quality, detection, colorimetry) with an **AI analysis via Gemini** (backend proxy), plus an **offline fallback** based on colorimetry alone.
+
+Code: `PlantHealthScanner.swift` (orchestrator + steps); view: `PlantHealthScannerView.swift`. The AI diagnosis goes through the backend `POST /diagnose` (see [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md)).
+
+## Pipeline
+
+```mermaid
+flowchart TB
+    capture["📸 Captured photo (UIImage)"]
+    q["1. Image quality<br/>ImageQualityValidator"]
+    d["2. Plant detection<br/>PlantDetector (Vision)"]
+    c["3. Colorimetry<br/>ColorimetricAnalyzer (HSL)"]
+    g["4. AI diagnosis<br/>GeminiDiagnosticService → POST /diagnose"]
+    merge["Merge Gemini 70% + colorimetry 30%"]
+    res["PlantHealthScanResult"]
+    fallback["Colorimetry-only fallback<br/>(source = colorimetryOnly)"]
+
+    capture --> q
+    q -->|brightness/sharpness failure| err["PlantScanError → error screen"]
+    q -->|ok| d
+    d -->|low confidence / not detected| warn["non-blocking warning"]
+    d --> c
+    c --> g
+    g -->|success| merge --> res
+    g -->|offline / failure| fallback --> res
+
+    classDef step fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef alt fill:#999,stroke:#666,color:#fff
+    class q,d,c,g,merge step
+    class err,warn,fallback alt
+```
+
+## Pipeline steps
+
+| Step | Type | Role |
+|---|---|---|
+| `ImageQualityValidator.validate` | on-device (CoreImage) | Rejects an image that is **too dark** (mean luminance < 0.15) or **blurry** (Laplacian variance < threshold). Failure → blocking `PlantScanError`. |
+| `PlantDetector.detect` | on-device (Vision `VNClassifyImageRequest`) | Checks a plant is present (labels `plant`/`flower`/`leaf`… ≥ 0.50). Low confidence or absence → **non-blocking warning** (AI reinforces the analysis). Skipped on the simulator. |
+| `ColorimetricAnalyzer.analyze` | on-device | Classifies each pixel in HSL (healthy green / yellow chlorosis / brown necrosis / cottony white) → ratios + colorimetric `healthScore`. Also serves as the **offline fallback**. |
+| `GeminiDiagnosticService.diagnose` | network (backend) | Resizes the image (800px, JPEG q0.6) + colorimetry + species name → `POST /diagnose`. Normalized JSON response (see backend contract). |
+| `PlantHealthScanner.analyze` | orchestrator (`@MainActor`) | Chains the 4 steps, publishes `phase` (preview/capturing/analyzing/result/error) + real-time indicators (`brightnessOK`, `plantDetected`), merges the results. |
+
+## Merge & result
+
+On Gemini success, both sources are combined:
+- **Overall health** = Gemini `overallHealth` **70%** + colorimetry `healthScore` **30%**.
+- **Diseases** = those returned by Gemini (`name`, `severity`, `confidence`).
+- **Uncertainty** (`isUncertain`) = Gemini flag, or average confidence < 0.60.
+
+Result: `PlantHealthScanResult` — `overallHealth`, `confidence`, `species` (optional), `diseases: [DetectedDisease]`, `recommendations`, `isUncertain`, and **`source`**:
+- `gemini` — full AI diagnosis.
+- `colorimetryOnly` — **fallback** when Gemini is unavailable (offline / failure): score and messages derived from colorimetry alone.
+
+## Errors (`PlantScanError`)
+
+`lowBrightness` · `blurryImage` · `noPlantDetected` · `cameraUnavailable` · `analysisTimeout` · `geminiError`. Each exposes a localized description and an SF Symbol icon for the error screen.
+
+## Key points
+
+- **Graceful degradation**: an invalid image is rejected early (no network call); an undetected plant is only a warning; Gemini unavailable → colorimetry fallback. The app stays usable offline with a degraded diagnosis.
+- **Bounded cost & latency**: image resized to 800px / JPEG 0.6 before sending; the backend bounds size, rate-limits, and normalizes the output.
+- **GDPR**: the diagnosis photo is sent to **Google Gemini** (outside the EU) via the backend proxy — disclosed in the in-app privacy policy.
+- **Tests**: the pure logic (errors, quality validator, colorimetry, contract decoding) is covered by `PlantHealthScannerTests.swift` (see [`../testing/ios.md`](../testing/ios.md)).
+
+## Out of scope for this view
+
+- The `/diagnose` proxy (auth, rate-limit, schema normalization) is documented in [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -25,6 +25,9 @@ La documentation est découpée en vues complémentaires. Selon l'information re
 | Per-screen spec — `GardenARPlacementView` | [`screens/garden-ar-placement.md`](screens/garden-ar-placement.md) |
 | Per-screen spec — wizard de création | [`screens/questionnaire-wizard.md`](screens/questionnaire-wizard.md) |
 | Per-screen spec — `PersonalDetailsView` | [`screens/personal-details.md`](screens/personal-details.md) |
+| Per-screen spec — scan de santé des plantes | [`screens/plant-health-scan.md`](screens/plant-health-scan.md) |
+| Per-screen spec — catalogue de plantes | [`screens/plant-catalog.md`](screens/plant-catalog.md) |
+| Notifications locales (arrosage et soins) | [`architecture/notifications.md`](architecture/notifications.md) |
 | Stratégie de test (front + back) | [`testing/_index.md`](testing/_index.md) |
 | Tests iOS | [`testing/ios.md`](testing/ios.md) |
 | Tests Backend (Go) | [`testing/backend.md`](testing/backend.md) |

--- a/docs/fr/architecture/03-components-ios.md
+++ b/docs/fr/architecture/03-components-ios.md
@@ -119,8 +119,11 @@ flowchart TB
 | `Models/PotMeasurement.swift` | Mesure du diamètre d'un pot via ARKit (feature secondaire). |
 | `UserService.swift` | Récupère l'utilisateur courant via `GET /users/:uid`. |
 | `Models/GardenProjectService.swift` | CRUD des jardins via le backend. |
-| `Services/GardenSuggestionEngine.swift` | Filtre et propose les plantes adaptées au profil. |
+| `Services/GardenSuggestionEngine.swift` | Scoring multi-axes pondéré (style, exposition, sol, entretien, sécurité) qui propose les plantes adaptées au profil du wizard. |
 | `Services/CalendarService.swift` | Génère le calendrier d'arrosage à partir des `WateringRoutine`. |
+| `Services/PlantHealthScanner.swift` | Scan de santé : pipeline qualité d'image → détection Vision → colorimétrie → diagnostic IA (`POST /diagnose`), avec repli colorimétrie hors-ligne. Cf. [`../screens/plant-health-scan.md`](../screens/plant-health-scan.md). |
+| `Models/PlantCatalogContext.swift` | Dimensions de filtre du catalogue + `PlantSuitabilityEvaluator` (compatibilité plante ↔ profil de jardin, 9 critères). Cf. [`../screens/plant-catalog.md`](../screens/plant-catalog.md). |
+| `Notifications/NotificationManager.swift` + `ArboreNotificationPlanner.swift` | Notifications **locales** d'arrosage et de soin (autorisation, catégories/actions rapides, planification, ajustement météo). Cf. [`notifications.md`](notifications.md). |
 | `LoginAuth/saveAuthDB.swift` | Pont entre Firebase Auth et `POST /users` — implémente retry exponentiel et rollback Firebase (issue #137). |
 
 ### Couche infrastructure

--- a/docs/fr/architecture/notifications.md
+++ b/docs/fr/architecture/notifications.md
@@ -1,0 +1,62 @@
+# Composant — Notifications locales
+
+Arbore programme des **notifications locales** (`UNUserNotificationCenter`) pour rappeler à l'utilisateur d'**arroser** ses plantes, d'effectuer un **soin** (rempotage, taille, engrais…), et pour quelques nudges (jardin non finalisé, alerte climatique). **Aucune notification distante (push/APNs)** : l'infrastructure push a été retirée, tout est planifié on-device.
+
+Fichiers : `NotificationManager.swift` (accès système + planification), `ArboreNotificationPlanner.swift` (construction des notifs + ajustements), `ArboreNotification.swift` (modèle + trigger + deep-link), `WateringRoutine.swift` (routines + `WateringRoutineStore`).
+
+## Vue d'ensemble
+
+```mermaid
+flowchart TB
+    store["WateringRoutineStore<br/>(routines persistées, UserDefaults)"]
+    planner["ArboreNotificationPlanner<br/>(construit ArboreNotification + ajuste la date)"]
+    mgr["NotificationManager<br/>(autorisation, catégories, schedule/cancel)"]
+    center["UNUserNotificationCenter (iOS)"]
+    action["Action utilisateur sur la notif<br/>Arrosée · Demain · Fait · Ouvrir"]
+
+    store -->|à chaque save/markWatered| mgr
+    planner --> mgr
+    mgr -->|UNNotificationRequest| center
+    center -->|réponse| mgr
+    mgr -->|handleNotificationAction| action --> store
+
+    classDef c fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef ext fill:#999,stroke:#666,color:#fff
+    class store,planner,mgr c
+    class center ext
+```
+
+## Composants
+
+| Fichier / type | Rôle |
+|---|---|
+| `NotificationManager` | Demande l'autorisation (`requestAuthorization`, alert/badge/sound, provisoire possible), expose l'état (`currentAuthorizationState`), enregistre les **catégories** (arrosage, soin, urgence climat) avec leurs actions, et planifie/annule les `UNNotificationRequest`. `handleNotificationAction` route les actions vers `WateringRoutineStore`. |
+| `ArboreNotificationPlanner` | Construit un `ArboreNotification` à partir d'une `WateringRoutine`/`PlantCareRoutine` (titre, corps contextualisé, catégorie, planning, deep-link, metadata). Calcule la **date d'arrosage ajustée**. Fournit les identifiants stables (`watering.<id>`, `care.<id>`, `project-completion.<id>`). |
+| `ArboreNotification` + `ArboreNotificationSchedule` | Modèle neutre → `UNNotificationTrigger` : `.date` / `.timeInterval` / `.calendar`. Porte un `NotificationRoute` (deep-link vers le jardin/la tâche) et des `metadata` (routineId, plantId, gardenId). |
+| `WateringRoutine` / `PlantCareRoutine` / `WateringRoutineStore` | Routines d'arrosage et de soin, persistées en `UserDefaults`. À chaque création/`markWatered`/`defer`, le store **re-synchronise** la notification correspondante. |
+
+## Ajustement intelligent de la date d'arrosage
+
+`adjustedWateringDate` module la prochaine date selon le contexte (dans une fenêtre bornée) :
+- **Profil d'entretien** : besoin en eau élevé → −1 j ; faible → +1 j ; écart d'intervalle préféré borné à ±2 j.
+- **Météo** (si dispo) : chaleur ≥ 30 °C → −1 j ; air sec (humidité < 35 %) → −1 j ; en extérieur, pluie probable (≥ 65 %) → +1 j ; risque de gel + espèce sensible → +1 j.
+- Garde-fou : jamais avant `maintenant + 60 s`.
+
+Le corps de la notification est lui aussi contextualisé (quantité d'eau, alerte chaleur/air sec, notes de la routine).
+
+## Actions rapides
+
+Depuis une notification, sans ouvrir l'app :
+- **Arrosée** (`markWatered`) → marque la routine arrosée, replanifie la suivante.
+- **Fait** (`markCareDone`) → valide le soin.
+- **Demain** (`deferTomorrow`) → reporte d'un jour.
+- **Ouvrir** → deep-link vers le jardin/la tâche.
+
+`rescheduleAllRoutineNotifications` (au démarrage/refresh) replanifie toutes les routines actives et `cancelObsoleteRoutineNotifications` purge celles dont la routine n'existe plus.
+
+## Points clés
+
+- **100 % local** : aucune dépendance réseau ni serveur ; fonctionne hors-ligne. Le background mode `remote-notification` a été retiré de l'`Info.plist` (plus de push).
+- **Idempotent** : chaque routine a un identifiant stable → replanifier remplace la notif existante (pas de doublon).
+- **Persistance** : les routines vivent dans `UserDefaults` (pas encore synchronisées cross-device — cf. backlog).
+- **Tests** : la logique pure du planner (identifiants, `adjustedWateringDate`, construction des notifs) est couverte par `ArboreNotificationPlannerTests.swift` (cf. [`../testing/ios.md`](../testing/ios.md)).

--- a/docs/fr/screens/_index.md
+++ b/docs/fr/screens/_index.md
@@ -22,6 +22,8 @@ Un écran devient hero screen, et donc cible d'une per-screen spec, lorsqu'**au 
 | `GardenARPlacementView` | [`garden-ar-placement.md`](garden-ar-placement.md) | Machine d'états (`RelocationPhase`), 3 300 LOC, 3 frameworks (ARKit + SceneKit + SwiftUI), ≥ 5 issues (#96, #111, #113, #114, #123, #124, #136, #138). |
 | Wizard de création de jardin | [`questionnaire-wizard.md`](questionnaire-wizard.md) | 10 étapes avec skip rules, `POST /gardens` + branching vers deux flows AR distincts, ≥ 3 issues (#139, #21, #97). |
 | `PersonalDetailsView` | [`personal-details.md`](personal-details.md) | `PATCH /users/me` + mise à jour Firebase `displayName`, machine d'états save (idle → saving → success/error), issue #138. |
+| Scan de santé des plantes | [`plant-health-scan.md`](plant-health-scan.md) | Machine d'états (`ScanPhase`), pipeline 4 étapes, 2 frameworks Apple (Vision + CoreImage), `POST /diagnose`, contrat RGPD (photo envoyée à Gemini). |
+| Catalogue de plantes | [`plant-catalog.md`](plant-catalog.md) | Filtrage multi-dimensions + évaluation de compatibilité (`PlantSuitabilityEvaluator`, 9 critères), ~1 600 LOC, doublon de scoring suivi (#319). |
 
 ## Hero screens non-documentés (à promouvoir si nécessaire)
 
@@ -30,7 +32,7 @@ Les écrans suivants sont en limite mais ne sont pas encore documentés. Ils ser
 - `LiDARScanWizardView` — single screen mais RoomPlan + transition vers `GardenARPlacementView`. Suivi par l'issue #139.
 - `ARViewContainerMeasure` — single screen, principalement pour le tracé périmètre non-LiDAR.
 - `SignUpView` — flow critique (#137) mais le détail est déjà dans [`../flows/auth-signup.md`](../flows/auth-signup.md).
-- `CatalogueView` et `PlantCatalogView` — listings avec filtres mais sans logique complexe.
+- `CatalogueView` — listing avec filtres mais sans logique complexe (`PlantCatalogView` est désormais documenté ci-dessus).
 
 ## Structure d'une per-screen spec
 

--- a/docs/fr/screens/personal-details.md
+++ b/docs/fr/screens/personal-details.md
@@ -113,12 +113,29 @@ Trois clés ajoutées en fr/en/de/es par l'issue #138 :
 
 ### Permissions iOS
 
-Aucune permission iOS requise par cet écran.
+Aucune permission iOS requise par l'édition du nom. Pour la photo de profil (écran parent, cf. ci-dessous), `PHPickerViewController` s'exécute **hors-process** et ne demande donc **aucune autorisation d'accès** à la photothèque.
 
 ### Frameworks Apple utilisés
 
 - **SwiftUI** pour toute la vue.
 - **FirebaseAuth** pour la lecture du profil courant et la mise à jour du `displayName`.
+- **PhotosUI** (`PHPickerViewController`) pour la sélection de la photo de profil depuis l'écran parent.
+
+## Photo de profil (écran parent `ProfileView`)
+
+La photo de profil n'est pas éditée depuis `PersonalDetailsView` mais depuis son **écran parent** `ProfileView` (bouton sur l'avatar de l'en-tête). Elle est documentée ici car elle fait partie des données d'identité.
+
+| Étape | Détail |
+|---|---|
+| Sélection | `PhotoPicker` (`ProfileComponents.swift`) enveloppe `PHPickerViewController` (`filter = .images`, `selectionLimit = 1`). Aucune permission requise. |
+| Normalisation | `normalizedProfileImage()` puis encodage **JPEG qualité 0.86**. |
+| Stockage | ⚠️ **Local uniquement** : `Documents/ProfileImages/<uid>.jpg` (écriture atomique). La photo est rechargée au montage de l'écran (`fetchProfileImage`). |
+| Réseau | **Aucun envoi.** L'endpoint backend `POST /users/:uid/photo` existe toujours côté serveur mais **n'est plus appelé par l'app iOS** — la photo ne quitte pas l'appareil. |
+| Erreur | Échec d'écriture → message « Impossible de sauvegarder la photo. » (`uploadError`), pas de retry. |
+
+**Conséquences** (suivies dans #329) : la photo n'est **pas synchronisée entre appareils** et disparaît à la désinstallation. Côté RGPD c'est le comportement le plus protecteur (donnée locale, jamais transmise) — mais l'export de données (art. 20) ne peut pas l'inclure tant qu'elle reste on-device.
+
+> **Sauvegarde d'une capture en photothèque** — dans un flow distinct (`ARViewContainerMeasure`), l'app propose d'enregistrer une capture via `UIImageWriteToSavedPhotosAlbum`, ce qui **exige** `NSPhotoLibraryAddUsageDescription` dans l'`Info.plist` (absente, l'app crashait — corrigé, cf. #304).
 
 ## Issues associées
 
@@ -130,6 +147,6 @@ Aucune permission iOS requise par cet écran.
 
 ## Hors-scope de cette spec
 
-- La gestion de la **photo de profil** passe par l'endpoint `POST /users/:uid/photo` (multipart) et n'est pas exposée par cet écran. Un éditeur de photo distinct sera ajouté si nécessaire.
+- La **photo de profil** est éditée depuis l'écran parent `ProfileView` — décrite ci-dessus, dans la section dédiée.
 - Le **changement d'email** et le **changement de mot de passe** sont des flows séparés non encore implémentés.
 - La spec backend de `PATCH /users/me` est dans [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).

--- a/docs/fr/screens/plant-catalog.md
+++ b/docs/fr/screens/plant-catalog.md
@@ -1,0 +1,58 @@
+# Écran — Catalogue de plantes
+
+Le catalogue permet à l'utilisateur de **parcourir et filtrer** le référentiel de plantes, et affiche pour chaque plante un **badge de compatibilité** avec son jardin (selon le profil recueilli). Il sert aussi de point d'entrée au placement AR.
+
+Fichiers : `PlantCatalogView.swift` (écran + filtres), `PlantCatalogContext.swift` (dimensions de filtre + `PlantSuitabilityEvaluator`), `PlantCatalogPreferenceViews.swift` (UI des préférences/filtres).
+
+## Deux mécanismes distincts
+
+1. **Filtrage** — l'utilisateur affine la liste selon des dimensions catalogue.
+2. **Évaluation de compatibilité** — chaque plante est notée par rapport au **profil de jardin** (`GardenWizardDTO`) et reçoit un niveau.
+
+> ⚠️ Ce scoring catalogue (`PlantSuitabilityEvaluator`, basé sur `GardenWizardDTO`) est **distinct** du scoring de suggestion du wizard (`GardenSuggestionEngine`). Les deux coexistent aujourd'hui — consolidation à trancher (cf. audit #319).
+
+## Dimensions de filtre
+
+Définies dans `PlantCatalogContext.swift`, chacune un `enum` filtrable :
+
+| Dimension | Exemples |
+|---|---|
+| `PlantCatalogGoal` | objectif (déco, potager, dépolluant…) |
+| `PlantCatalogKind` | type (arbre, fleur, succulente…) |
+| `PlantCatalogColor` | couleur dominante |
+| `PlantCatalogAppearance` / `PlantCatalogHabit` | port / silhouette |
+| `PlantCatalogScale` / `PlantCatalogSize` | gabarit |
+| `PlantCatalogCareLevel` | exigence d'entretien |
+
+Le style de jardin (ancien step wizard) a vocation à vivre **ici, comme filtre**, plutôt que comme étape du parcours.
+
+## Évaluation de compatibilité (`PlantSuitabilityEvaluator`)
+
+L'évaluateur agrège plusieurs **critères**, chacun produisant un score, puis en déduit un niveau global :
+
+| Critère | Basé sur (profil / flags plante) |
+|---|---|
+| Espace (`appendSpaceCriterion`) | `wizard.spaceType` (intérieur/balcon/terrasse/jardin) |
+| Lumière (`appendSunlightCriterion`) | `wizard.siteProfile.sunlight` vs tolérances de la plante |
+| Sécurité (`appendSafetyCriteria`) | `wizard.safety` vs `flags.toxicToPets` / `toxicToChildren` |
+| Plantation (`appendPlantingCriterion`) | `conditionalAnswers.plantingMode == .containers` |
+| Drainage (`appendDrainageCriterion`) | `conditionalAnswers.drainage` vs `flags.humidityLoving` |
+| Vent (`appendWindCriterion`) | `conditionalAnswers.windExposure` / `siteProfile.wind` |
+| Humidité (`appendHumidityCriterion`) | `conditionalAnswers.indoorHumidity` |
+| Chaleur (`appendHeatCriterion`) | `conditionalAnswers.nearbyHeat` |
+| Hauteur (`appendHeightCriterion`) | `siteProfile.availableHeight` |
+
+Niveau (`PlantSuitabilityLevel`) : `unsuitable` → `neutral` → `suitable` → `verySuitable`. Un critère **critique** (ex. toxique alors que l'utilisateur a des animaux) tire le niveau vers le bas. Chaque critère porte une raison localisée affichée à l'utilisateur.
+
+> Les critères ne s'appliquent que si la donnée de profil correspondante est présente : un profil incomplet donne un score sur moins de critères (voire aucun → pas de badge), sans jamais planter.
+
+## Points clés
+
+- **Découplé du wizard UI** : l'évaluateur lit le **DTO** (`GardenWizardDTO`), pas l'état d'écran du wizard — donc indépendant du parcours de création actif.
+- **Données plante** : la compatibilité s'appuie sur les `flags` de la fiche plante (toxicité, amour de l'humidité…) et le schéma LOD/botanique du catalogue.
+- **Doublon connu** : deux systèmes de scoring (`PlantSuitabilityEvaluator` catalogue vs `GardenSuggestionEngine` wizard) — laissés en place le temps de figer le parcours (cf. #319).
+
+## Hors-scope de cette vue
+
+- Le placement AR des plantes est documenté dans [`garden-ar-placement.md`](garden-ar-placement.md).
+- La génération des fiches (AI Generator) et le LOD 3D sont dans [`../3d-lod-architecture.md`](../3d-lod-architecture.md).

--- a/docs/fr/screens/plant-health-scan.md
+++ b/docs/fr/screens/plant-health-scan.md
@@ -1,0 +1,69 @@
+# Écran — Scan de santé des plantes
+
+Le scan de santé permet à l'utilisateur de photographier une plante pour obtenir un **diagnostic phytopathologique** : espèce probable, état de santé global, maladies détectées et recommandations. Le pipeline combine des **pré-vérifications on-device** (qualité, détection, colorimétrie) et une **analyse IA via Gemini** (proxy backend), avec un **repli hors-ligne** basé sur la seule colorimétrie.
+
+Code : `PlantHealthScanner.swift` (orchestrateur + étapes) ; vue : `PlantHealthScannerView.swift`. Le diagnostic IA passe par le backend `POST /diagnose` (cf. [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md)).
+
+## Pipeline
+
+```mermaid
+flowchart TB
+    capture["📸 Photo capturée (UIImage)"]
+    q["1. Qualité image<br/>ImageQualityValidator"]
+    d["2. Détection plante<br/>PlantDetector (Vision)"]
+    c["3. Colorimétrie<br/>ColorimetricAnalyzer (HSL)"]
+    g["4. Diagnostic IA<br/>GeminiDiagnosticService → POST /diagnose"]
+    merge["Fusion Gemini 70% + colorimétrie 30%"]
+    res["PlantHealthScanResult"]
+    fallback["Repli colorimétrie seule<br/>(source = colorimetryOnly)"]
+
+    capture --> q
+    q -->|échec luminosité/netteté| err["PlantScanError → écran d'erreur"]
+    q -->|ok| d
+    d -->|confiance faible / non détectée| warn["warning non bloquant"]
+    d --> c
+    c --> g
+    g -->|succès| merge --> res
+    g -->|hors-ligne / échec| fallback --> res
+
+    classDef step fill:#2E7D32,stroke:#1B5E20,color:#fff
+    classDef alt fill:#999,stroke:#666,color:#fff
+    class q,d,c,g,merge step
+    class err,warn,fallback alt
+```
+
+## Étapes du pipeline
+
+| Étape | Type | Rôle |
+|---|---|---|
+| `ImageQualityValidator.validate` | on-device (CoreImage) | Rejette une image **trop sombre** (luminance moyenne < 0.15) ou **floue** (variance du Laplacien < seuil). Échec → `PlantScanError` bloquant. |
+| `PlantDetector.detect` | on-device (Vision `VNClassifyImageRequest`) | Vérifie qu'une plante est présente (labels `plant`/`flower`/`leaf`… ≥ 0.50). Confiance faible ou absence → **warning non bloquant** (l'IA renforce l'analyse). Sautée sur simulateur. |
+| `ColorimetricAnalyzer.analyze` | on-device | Classe chaque pixel en HSL (vert sain / jaune chlorose / brun nécrose / blanc cotonneux) → ratios + `healthScore` colorimétrique. Sert aussi de **repli hors-ligne**. |
+| `GeminiDiagnosticService.diagnose` | réseau (backend) | Redimensionne l'image (800px, JPEG q0.6) + colorimétrie + nom d'espèce → `POST /diagnose`. Réponse JSON normalisée (cf. contrat backend). |
+| `PlantHealthScanner.analyze` | orchestrateur (`@MainActor`) | Enchaîne les 4 étapes, publie `phase` (preview/capturing/analyzing/result/error) + indicateurs temps réel (`brightnessOK`, `plantDetected`), fusionne les résultats. |
+
+## Fusion & résultat
+
+En cas de succès Gemini, les deux sources sont combinées :
+- **Santé globale** = `overallHealth` Gemini **70 %** + `healthScore` colorimétrie **30 %**.
+- **Maladies** = celles renvoyées par Gemini (`name`, `severity`, `confidence`).
+- **Incertitude** (`isUncertain`) = flag Gemini, ou confiance moyenne < 0.60.
+
+Résultat : `PlantHealthScanResult` — `overallHealth`, `confidence`, `species` (optionnel), `diseases: [DetectedDisease]`, `recommendations`, `isUncertain`, et **`source`** :
+- `gemini` — diagnostic IA complet.
+- `colorimetryOnly` — **repli** quand Gemini est indisponible (hors-ligne / échec) : score et messages dérivés de la seule colorimétrie.
+
+## Erreurs (`PlantScanError`)
+
+`lowBrightness` · `blurryImage` · `noPlantDetected` · `cameraUnavailable` · `analysisTimeout` · `geminiError`. Chacune expose une description localisée et une icône SF Symbol pour l'écran d'erreur.
+
+## Points clés
+
+- **Dégradation gracieuse** : une image invalide est refusée tôt (pas d'appel réseau) ; une plante non détectée n'est qu'un avertissement ; Gemini indisponible → repli colorimétrie. L'app reste utilisable hors-ligne avec un diagnostic dégradé.
+- **Coût & latence maîtrisés** : image redimensionnée à 800px / JPEG 0.6 avant envoi ; le backend borne la taille, le rate-limit et normalise la sortie.
+- **RGPD** : la photo de diagnostic est envoyée à **Google Gemini** (hors UE) via le proxy backend — divulgué dans la politique de confidentialité in-app.
+- **Tests** : la logique pure (erreurs, validateur de qualité, colorimétrie, décodage du contrat) est couverte par `PlantHealthScannerTests.swift` (cf. [`../testing/ios.md`](../testing/ios.md)).
+
+## Hors-scope de cette vue
+
+- Le proxy `/diagnose` (auth, rate-limit, normalisation du schéma) est documenté dans [`../architecture/03-components-backend.md`](../architecture/03-components-backend.md).


### PR DESCRIPTION
Rattrapage de la doc pour refléter l'état réel de l'app. **Premier PR du nouveau workflow : base = `dev`** (pas `main`).

## Méthode
Analyse de fraîcheur : la base de la doc datait du **28/06 (#289)** ; les docs backend étaient à jour (nos PR), mais **3 features de juillet n'étaient documentées nulle part** (0 doc pour scan santé / notifications / catalogue).

## Contenu (FR canonique + EN miroir, parité vérifiée)
- **`screens/plant-health-scan.md`** (nouveau) — pipeline en 4 étapes (qualité `ImageQualityValidator` → détection Vision → colorimétrie HSL → diagnostic Gemini via `POST /diagnose`), fusion **70 % Gemini / 30 % colorimétrie**, **repli hors-ligne** `colorimetryOnly`, erreurs `PlantScanError`, note RGPD (photo → Gemini hors UE).
- **`architecture/notifications.md`** (nouveau) — notifications **100 % locales** (plus de push : infra retirée), `NotificationManager` / `ArboreNotificationPlanner` / `WateringRoutineStore`, **ajustement météo** de la date d'arrosage (chaleur/air sec −1 j, pluie extérieure +1 j, gel +1 j, clamp ±2 j), actions rapides (Arrosée / Fait / Demain / Ouvrir), idempotence par identifiant stable.
- **`screens/plant-catalog.md`** (nouveau) — dimensions de filtre + `PlantSuitabilityEvaluator` (9 critères : espace, lumière, sécurité, plantation, drainage, vent, humidité, chaleur, hauteur), niveaux `unsuitable → verySuitable`, et **note explicite du doublon de scoring** avec `GardenSuggestionEngine` (#319).
- **`architecture/03-components-ios.md`** — ajout des 3 modules qui n'y figuraient pas + précision du rôle de `GardenSuggestionEngine`.
- **`screens/_index.md`** — scan santé + catalogue promus hero screens (critères remplis), retrait de la mention obsolète « `PlantCatalogView` non documenté ».
- **`README.md`** (fr+en) — entrées d'index ajoutées.

## Validation
`docs-drift-check.sh` local : **No doc drift detected**. Parité FR/EN vérifiée sur les 6 fichiers (69/69, 58/58, 62/62, 49/49, 116/116, 164/164). Zéro mention de scraping.

## Reste à faire (hors périmètre)
Caméra/galerie (photo de profil) — petit, à documenter dans `personal-details.md` plutôt qu'en doc dédiée. Les docs wizard ont déjà été réalignées sur l'ancien flow dans #327.