### PR TITLE
ci: run the pipelines on dev and on PRs targeting dev (dev → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: 🌱 Arbore CI/CD
 
-# Déclenche le workflow sur push ou PR vers main/develop
+# Déclenche le workflow sur push ou PR vers main/dev.
+# `dev` est la branche d'intégration : les PR de feature la ciblent, donc la CI
+# doit y tourner (sinon une feature entre dans dev sans build/test/lint).
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   workflow_dispatch:
     inputs:
       clean_pods_cache:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,9 +8,9 @@ name: "🔒 CodeQL Security Analysis"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
   schedule:
     - cron: '30 2 * * 1'  # Tous les lundis à 2h30 UTC
   workflow_dispatch:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: [ "main" ]
     tags: [ 'v*.*.*' ]
+  # Les PR vers dev sont buildées pour validation, mais aucune image n'est
+  # publiée (l'étape push est conditionnée à `github.event_name != 'pull_request'`).
+  # `dev` n'est volontairement pas dans `push:` : pas de publication depuis dev.
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: 📚 Docs validation
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "docs/**"
       - "ArboreUi/**/*.swift"
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/docs.yml"
       - ".github/scripts/docs-*.sh"
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"


### PR DESCRIPTION
Release `dev` → `main`. **Contenu : uniquement des triggers de workflow** — aucun changement de code applicatif.

## Pourquoi
Le nouveau workflow (`main` = prod, `dev` = intégration, `feature/*` → `dev`) n'était pas couvert par la CI : aucun workflow ne se déclenchait sur `dev` ni sur les PR vers `dev` (tous ciblaient `main`, et `ci.yml` listait **`develop`**, une branche inexistante). Une PR de feature entrait donc dans `dev` **sans build, sans tests, sans lint**.

## Contenu
| Workflow | push | pull_request |
|---|---|---|
| `ci.yml` | main, **dev** | main, **dev** |
| `docs.yml` | main, **dev** | main, **dev** |
| `codeql.yml` | main, **dev** | main, **dev** |
| `docker-publish.yml` | main *(inchangé)* | main, **dev** |
| `deploy.yml` | main *(inchangé)* | — |

- `docker-publish` : `dev` en `pull_request` seulement → PR buildées **sans publier d'image**.
- `deploy.yml` : **non touché** → aucun déploiement depuis `dev`.

## Validation
Vérifié empiriquement sur #331 : la CI s'est bien déclenchée sur une PR ciblant `dev` (13 checks verts — backend, ai_generator, docs, CodeQL, security…). Un échec initial de `build-backend` était un **flake réseau** (timeout Docker Hub sur `alpine:3.23`), re-run → pass.