### PR TITLE
docs: correct plant-catalog filter examples (dev → main)

### DIFF
--- a/docs/en/screens/plant-catalog.md
+++ b/docs/en/screens/plant-catalog.md
@@ -17,12 +17,12 @@ Defined in `PlantCatalogContext.swift`, each a filterable `enum`:
 
 | Dimension | Examples |
 |---|---|
-| `PlantCatalogGoal` | goal (decorative, vegetable garden, air-purifying…) |
-| `PlantCatalogKind` | type (tree, flower, succulent…) |
-| `PlantCatalogColor` | dominant color |
-| `PlantCatalogAppearance` / `PlantCatalogHabit` | habit / silhouette |
-| `PlantCatalogScale` / `PlantCatalogSize` | size class |
-| `PlantCatalogCareLevel` | care requirement |
+| `PlantCatalogGoal` | design goal: add color, create privacy, cover a wall, attract pollinators, edible/aromatic, focal point… |
+| `PlantCatalogKind` | type: green plant, flowering, cactus/succulent, palm, fern, orchid, tree, shrub, perennial, annual, grass, groundcover, climbing, edible/aromatic |
+| `PlantCatalogColor` | dominant color (white, yellow, orange, red, pink, purple, blue, green, dark) |
+| `PlantCatalogAppearance` / `PlantCatalogHabit` | habit: upright, spreading, climbing, trailing |
+| `PlantCatalogScale` / `PlantCatalogSize` | size class: compact, balanced, statement |
+| `PlantCatalogCareLevel` | care requirement: minimal, regular |
 
 The garden style (former wizard step) is meant to live **here, as a filter**, rather than as a step in the creation flow.
 

--- a/docs/fr/screens/plant-catalog.md
+++ b/docs/fr/screens/plant-catalog.md
@@ -17,12 +17,12 @@ Définies dans `PlantCatalogContext.swift`, chacune un `enum` filtrable :
 
 | Dimension | Exemples |
 |---|---|
-| `PlantCatalogGoal` | objectif (déco, potager, dépolluant…) |
-| `PlantCatalogKind` | type (arbre, fleur, succulente…) |
-| `PlantCatalogColor` | couleur dominante |
-| `PlantCatalogAppearance` / `PlantCatalogHabit` | port / silhouette |
-| `PlantCatalogScale` / `PlantCatalogSize` | gabarit |
-| `PlantCatalogCareLevel` | exigence d'entretien |
+| `PlantCatalogGoal` | objectif d'aménagement : ajouter de la couleur, créer de l'intimité, couvrir un mur, attirer les pollinisateurs, aromatique/comestible, point focal… |
+| `PlantCatalogKind` | type : plante verte, fleurie, cactus/succulente, palmier, fougère, orchidée, arbre, arbuste, vivace, annuelle, graminée, couvre-sol, grimpante, aromatique/comestible |
+| `PlantCatalogColor` | couleur dominante (blanc, jaune, orange, rouge, rose, violet, bleu, vert, sombre) |
+| `PlantCatalogAppearance` / `PlantCatalogHabit` | port : dressé, étalé, grimpant, retombant |
+| `PlantCatalogScale` / `PlantCatalogSize` | gabarit : compact, équilibré, imposant |
+| `PlantCatalogCareLevel` | exigence d'entretien : minimal, régulier |
 
 Le style de jardin (ancien step wizard) a vocation à vivre **ici, comme filtre**, plutôt que comme étape du parcours.
 


### PR DESCRIPTION
Release `dev` → `main`. **Documentation uniquement**, aucun changement de code — sans impact sur le build 24 déjà sur TestFlight.

Corrige une inexactitude introduite dans #328 : les exemples de dimensions de filtre du catalogue étaient inventés. Remplacés par les valeurs réellement définies dans `PlantCatalogContext.swift` (`PlantCatalogGoal` : `addColor`, `createPrivacy`, `coverWall`, `attractPollinators`, `edibleAromatic`, `focalPoint`…).

Parité FR/EN vérifiée, `docs-drift-check` vert, 12/12 checks passés sur #335.