### PR TITLE
release: hygiène de déploiement et exposition du commit déployé (#341)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,16 @@
-name: 🚀 Deploy
+name: 📦 Build & Publish images
+
+# ⚠️ Ce workflow NE DÉPLOIE PAS. Il builde et pousse des images sur ghcr, que
+# rien ne consomme aujourd'hui : le VPS builde ses propres images localement via
+# `deploy.sh` + `docker compose build`.
+#
+# Il s'appelait « 🚀 Deploy », ce qui a laissé croire pendant des semaines que la
+# production suivait `main`. Elle avait en réalité 15 commits de retard, dont un
+# correctif de sécurité, sans que rien ne le signale (#341). Le déploiement réel
+# se lance à la main : `ssh` puis `./deploy.sh` à la racine du dépôt sur le VPS.
+#
+# Pour vérifier ce qui tourne réellement en production :
+#   curl -s https://api.arbore.app/health | jq -r .commit
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -122,11 +122,21 @@ yarn-error.log*
 .env
 .env.local
 .env.*.local
+# Sauvegardes de .env prises à la main sur le serveur avant une opération
+# sensible. Elles contiennent les mêmes secrets que le .env : jamais dans git.
+.env.bak*
+.env.backup*
 # Exception : config web PUBLIQUE committée (DSN Sentry, etc. — aucun secret).
 !web/.env
 *.key
 *.pem
 secrets/
+
+# Artefacts opérationnels du VPS — présents dans le checkout de production, ils
+# le rendaient « sale » et faisaient refuser le déploiement par deploy.sh (#341).
+ArboreBackend/backend
+ArboreBackend/testapp
+ArboreBackend/uploads/
 
 # Docker
 .dockerignore

--- a/ArboreBackend/Dockerfile
+++ b/ArboreBackend/Dockerfile
@@ -12,8 +12,14 @@ RUN go mod download
 # Copy source code
 COPY . .
 
+# Commit déployé, injecté dans le binaire pour que GET /health puisse le
+# rapporter (détection de dérive prod ↔ main, cf. #341). Vaut "unknown" si le
+# build arg n'est pas fourni — un binaire anonyme ne prétend rien.
+ARG GIT_COMMIT=unknown
+
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s" -o main .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags="-w -s -X main.buildCommit=${GIT_COMMIT}" -o main .
 
 # Final stage
 FROM alpine:3.23

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -98,6 +98,21 @@ func maybeLabelTestDoc(dbSelector string, doc interface{}) interface{} {
 
 var thumbnailPlantIDRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// buildCommit est le commit git à partir duquel ce binaire a été construit. Il
+// est injecté à la compilation :
+//
+//	go build -ldflags "-X main.buildCommit=$(git rev-parse HEAD)"
+//
+// `GET /health` le renvoie, ce qui permet de vérifier d'un `curl` si la
+// production est à jour avec `main`. Sans cette information, le backend de prod
+// avait dérivé de 15 commits — dont un correctif de sécurité — sans que rien ne
+// le signale (cf. #341). Remplace le `"version": "1.0.0"` codé en dur, qui
+// n'avait jamais été mis à jour et ne renseignait donc rien (#338 constat 11).
+//
+// La valeur reste "unknown" si elle n'est pas injectée : un binaire construit à
+// la main ne doit pas prétendre connaître sa provenance.
+var buildCommit = "unknown"
+
 type User struct {
 	UID              string `json:"uid" bson:"uid"`
 	Email            string `json:"email" bson:"email"`
@@ -1963,13 +1978,7 @@ func main() {
 	router.MaxMultipartMemory = 8 << 20
 
 	// === ROUTE PUBLIQUE (Health Check) ===
-	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"status":  "ok",
-			"service": "arbore-backend",
-			"version": "1.0.0",
-		})
-	})
+	router.GET("/health", healthHandler)
 
 	router.GET("/models/thumbnails/:filename", publicLimiter.Middleware(), func(c *gin.Context) {
 		filename := c.Param("filename")
@@ -2132,6 +2141,17 @@ func main() {
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatal("❌ Erreur lors du démarrage du serveur :", err) // nolint:misspell
 	}
+}
+
+// healthHandler répond à GET /health. Route publique, non authentifiée : elle ne
+// renvoie que de quoi vérifier que le service tourne et savoir QUELLE version
+// tourne — jamais d'information exploitable sur la configuration.
+func healthHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "ok",
+		"service": "arbore-backend",
+		"commit":  buildCommit,
+	})
 }
 
 // hardenClientIPResolution empêche gin de déduire l'IP client de

--- a/ArboreBackend/main_test.go
+++ b/ArboreBackend/main_test.go
@@ -1108,6 +1108,43 @@ func TestValidateReleaseSecurityConfigFailsClosed(t *testing.T) {
 	}
 }
 
+// MARK: - Health endpoint (détection de dérive, #341)
+
+func TestHealthHandlerReportsBuildCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	original := buildCommit
+	t.Cleanup(func() { buildCommit = original })
+	buildCommit = "d94496dcafe0000000000000000000000000cafe"
+
+	router := gin.New()
+	router.GET("/health", healthHandler)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var payload map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("réponse /health illisible: %v", err)
+	}
+	assert.Equal(t, "ok", payload["status"])
+	assert.Equal(t, "arbore-backend", payload["service"])
+	// C'est tout l'intérêt de l'endpoint : pouvoir comparer la prod à main.
+	assert.Equal(t, "d94496dcafe0000000000000000000000000cafe", payload["commit"])
+	// L'ancien `"version": "1.0.0"` codé en dur ne renseignait rien (#338 constat 11).
+	assert.NotContains(t, payload, "version")
+}
+
+// Un binaire construit sans -ldflags ne doit pas prétendre connaître sa provenance.
+func TestBuildCommitDefaultsToUnknown(t *testing.T) {
+	if buildCommit != "unknown" {
+		t.Skipf("buildCommit injecté à la compilation (%q) — valeur par défaut non observable", buildCommit)
+	}
+	assert.Equal(t, "unknown", buildCommit)
+}
+
 // MARK: - Client IP hardening (audit #338, constat 2)
 
 func TestHardenClientIPResolution(t *testing.T) {

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,7 +35,12 @@ cd "$SCRIPT_DIR"
 
 SNAPSHOT_DIR="$SCRIPT_DIR/backups/daily"
 SNAPSHOT_RETENTION_DAYS=14
-DOCKER_COMPOSE=( sudo docker compose )
+# Préfixe de privilège isolé du reste de la commande : il faut pouvoir insérer
+# une assignation de variable APRÈS `sudo`, car sudo réinitialise
+# l'environnement — un préfixe `VAR=val sudo …` est silencieusement perdu
+# (vérifié sur le VPS). Vider ce tableau suffit si docker tourne sans sudo.
+DOCKER_PRIVILEGE=( sudo )
+DOCKER_COMPOSE=( "${DOCKER_PRIVILEGE[@]}" docker compose )
 
 step() { printf '%b[%s/6]%b %s\n' "$YELLOW" "$1" "$NC" "$2"; }
 ok()   { printf '%b✅ %s%b\n' "$GREEN" "$1" "$NC"; }
@@ -68,15 +73,81 @@ require_prereqs() {
 }
 
 # ───── [1/6] Git pull ─────────────────────────────────────────────
+#
+# Données hors bande : fichiers que git suit encore (ils ont été committés avant
+# que la règle `.gitignore` n'existe) mais qui sont en réalité gérés directement
+# sur le serveur — les modèles 3D sont regénérés et nettoyés en place.
+#
+# Historiquement le garde-fou refusait tout checkout non vierge. Comme ces
+# fichiers sont modifiés en permanence, `deploy.sh` était inutilisable en
+# pratique : les déploiements le contournaient à la main, et sautaient donc le
+# `mongodump` pre-deploy — le seul filet de sécurité, Atlas M0 n'ayant aucun
+# backup automatique. Le garde-fou distingue maintenant les modifications de
+# code (bloquantes) des données hors bande (attendues). Cf. #341.
+OUT_OF_BAND_PATHS=( "ArboreBackend/models/" )
+
+# is_out_of_band <chemin> — vrai si le chemin est sous un préfixe hors bande.
+is_out_of_band() {
+    local path="$1" prefix
+    for prefix in "${OUT_OF_BAND_PATHS[@]}"; do
+        case "$path" in "$prefix"*) return 0 ;; esac
+    done
+    return 1
+}
+
 do_git_pull() {
     step 1 "Git pull..."
-    if [ -n "$(git status --porcelain)" ]; then
-        fail "Le checkout contient des changements locaux — déploiement refusé"
-        fail "Utiliser un checkout de release propre et les chemins *_HOST_PATH pour les données persistantes"
+
+    # Trois catégories, traitées différemment :
+    #   - fichier SUIVI modifié hors données hors bande  → bloquant (du code)
+    #   - fichier SUIVI modifié sous un chemin hors bande → toléré, signalé
+    #   - fichier NON SUIVI                              → toléré, signalé
+    #     (un fichier non suivi ne peut pas faire échouer un fast-forward)
+    local blocking=() out_of_band=0 untracked=0
+    local line entry_status entry_path
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        entry_status="${line:0:2}"
+        entry_path="${line:3}"
+        # Un renommage s'écrit « ancien -> nouveau » : seule la destination compte.
+        # À faire AVANT de retirer les guillemets, sinon celui qui ouvre la
+        # destination survit et le préfixe hors bande n'est plus reconnu.
+        case "$entry_status" in R*) entry_path="${entry_path##* -> }" ;; esac
+        # git entoure de guillemets les chemins contenant des espaces.
+        entry_path="${entry_path%\"}"
+        entry_path="${entry_path#\"}"
+
+        if [ "$entry_status" = "??" ]; then
+            untracked=$((untracked + 1))
+        elif is_out_of_band "$entry_path"; then
+            out_of_band=$((out_of_band + 1))
+        else
+            blocking+=("$entry_status $entry_path")
+        fi
+    done < <(git status --porcelain)
+
+    if [ "${#blocking[@]}" -gt 0 ]; then
+        fail "Le checkout contient des modifications de fichiers suivis — déploiement refusé"
+        printf '     %s\n' "${blocking[@]}" >&2
+        fail "Committer ou annuler ces changements avant de déployer"
         exit 1
     fi
+
+    # `if` explicite plutôt que `[ ... ] && warn ...` : sous `set -e`, un test
+    # faux en fin de fonction ferait sortir le script.
+    if [ "$out_of_band" -gt 0 ]; then
+        warn "$out_of_band fichier(s) de données hors bande modifiés (${OUT_OF_BAND_PATHS[*]}) — ignorés, gérés hors git"
+    fi
+    if [ "$untracked" -gt 0 ]; then
+        warn "$untracked fichier(s) non suivis présents — ignorés (sans effet sur un fast-forward)"
+    fi
+
     if ! git pull --ff-only; then
         fail "Erreur lors du git pull"
+        if [ "$out_of_band" -gt 0 ]; then
+            fail "Si un commit entrant touche ${OUT_OF_BAND_PATHS[*]}, git refuse d'écraser les"
+            fail "modifications locales : sauvegarder ces fichiers puis les restaurer après le pull"
+        fi
         exit 1
     fi
     ok "Git pull réussi"
@@ -144,7 +215,10 @@ do_docker_build() {
     local git_sha
     git_sha="$(git rev-parse HEAD)"
     step 3 "Docker compose build (commit ${git_sha:0:7})..."
-    if ! "${DOCKER_COMPOSE[@]}" build backend ai-generator web; then
+    # GIT_COMMIT est injecté dans le binaire backend puis renvoyé par GET /health :
+    # c'est ce qui rend une dérive prod ↔ main détectable d'un simple curl (#341).
+    # L'assignation vient après DOCKER_PRIVILEGE, cf. le commentaire à sa définition.
+    if ! "${DOCKER_PRIVILEGE[@]}" GIT_COMMIT="$git_sha" docker compose build backend ai-generator web; then
         fail "docker compose build a échoué"
         exit 1
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,10 @@ services:
     build:
       context: ./ArboreBackend
       dockerfile: Dockerfile
+      args:
+        # Commit déployé, remonté par GET /health (cf. #341). deploy.sh
+        # l'exporte ; un build manuel sans cette variable donne "unknown".
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
     container_name: arbore-backend
     restart: unless-stopped
     init: true

--- a/docs/en/architecture/03-components-backend.md
+++ b/docs/en/architecture/03-components-backend.md
@@ -69,7 +69,7 @@ The `middleware/` subfolder exposes two chained middlewares, in this order for t
 
 | Endpoint | Handler | Notes |
 |---|---|---|
-| `GET /health` | inline | Docker healthcheck. Returns `{status, service, version}`. |
+| `GET /health` | `healthHandler` | Docker healthcheck. Returns `{status, service, commit}`. `commit` is the git SHA injected at build time (`-ldflags -X main.buildCommit`), and is `unknown` for a hand-built binary. This is how you check what actually runs in production: `curl -s https://api.arbore.app/health \| jq -r .commit`. Replaces a hardcoded `version` that was never updated (see #341). |
 | `GET /models/thumbnails/:filename` | inline (**public**) | Serves catalog PNGs from `THUMBNAILS_DIR`. Rejects `..` / `/`, requires `.png`. |
 
 ### API-key-only group (`APIKeyMiddleware` only)

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -265,16 +265,42 @@ End-to-end health check:
 
 ```bash
 curl -fsS http://localhost:8080/health
-# → {"status":"ok","service":"arbore-backend","version":"..."}
+# → {"status":"ok","service":"arbore-backend","commit":"<sha>"}
 curl -fsS http://localhost:3000/   # web (Next.js)
 curl -fsS http://<VPS_IP>/health   # via nginx
 ```
 
+The `commit` field is the git SHA actually deployed. It is the only way to know
+whether production follows `main`:
+
+```bash
+curl -s https://api.arbore.app/health | jq -r .commit   # what is running
+git rev-parse origin/main                               # what should be running
+```
+
 From now on, subsequent deployments go through
-`./deploy.sh` (which takes a Mongo snapshot before each rebuild). The checkout
-must be clean. USDZ files, thumbnails, legacy uploads, and secrets remain under
+`./deploy.sh` (which takes a Mongo snapshot before each rebuild).
+
+**Checkout guard.** `deploy.sh` refuses to deploy when a git-**tracked** file is
+modified — that is uncommitted code, hence a silent divergence. It does
+however **tolerate** two things: untracked files (they cannot break a
+fast-forward) and changes under `ArboreBackend/models/`, declared as
+out-of-band data in `OUT_OF_BAND_PATHS`. Those 3D models are regenerated and
+cleaned directly on the server; requiring them to be clean made `deploy.sh`
+unusable, and deployments bypassed it — skipping the pre-deploy Mongo
+snapshot, the only safety net since Atlas M0 has no automatic backups
+(see #341).
+
+USDZ files, thumbnails, legacy uploads, and secrets are meant to live under
 `/home/fedora/arbore-data` through absolute `.env` paths, so a fresh release
 checkout cannot overwrite or delete them.
+
+> ⚠️ **Actual state as of 2026-07-26**: `/home/fedora/arbore-data/models` exists
+> and does contain the 124 models, but **no `MODELS_HOST_PATH` is set in the VPS
+> `.env`**. `docker-compose.yml` therefore falls back to its
+> `./ArboreBackend/models` default, and production serves the models **from the
+> git checkout**. This switch is still pending (#341); until then, any git
+> operation on those files changes what the app downloads.
 
 ---
 

--- a/docs/fr/architecture/03-components-backend.md
+++ b/docs/fr/architecture/03-components-backend.md
@@ -69,7 +69,7 @@ Le sous-dossier `middleware/` expose deux middlewares chaînés, dans cet ordre 
 
 | Endpoint | Handler | Notes |
 |---|---|---|
-| `GET /health` | inline | Healthcheck Docker. Renvoie `{status, service, version}`. |
+| `GET /health` | `healthHandler` | Healthcheck Docker. Renvoie `{status, service, commit}`. `commit` est le SHA git injecté à la compilation (`-ldflags -X main.buildCommit`), et vaut `unknown` pour un binaire construit à la main. C'est le moyen de vérifier ce qui tourne réellement en production : `curl -s https://api.arbore.app/health \| jq -r .commit`. Remplace un `version` codé en dur qui n'était jamais mis à jour (cf. #341). |
 | `GET /models/thumbnails/:filename` | inline (**public**) | Sert les PNG du catalogue depuis `THUMBNAILS_DIR`. Rejette `..` / `/`, exige `.png`. |
 
 ### Groupe API-key-only (`APIKeyMiddleware` seul)

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -265,16 +265,42 @@ Health check end-to-end :
 
 ```bash
 curl -fsS http://localhost:8080/health
-# → {"status":"ok","service":"arbore-backend","version":"..."}
+# → {"status":"ok","service":"arbore-backend","commit":"<sha>"}
 curl -fsS http://localhost:3000/   # web (Next.js)
 curl -fsS http://<VPS_IP>/health   # via nginx
 ```
 
+Le champ `commit` est le SHA git réellement déployé. C'est le seul moyen de
+savoir si la production suit `main` :
+
+```bash
+curl -s https://api.arbore.app/health | jq -r .commit   # ce qui tourne
+git rev-parse origin/main                               # ce qui devrait tourner
+```
+
 À partir de maintenant, les déploiements suivants passent par
-`./deploy.sh` (qui prend un snapshot Mongo avant chaque rebuild). Le checkout
-doit être propre. Les USDZ, miniatures, anciens uploads et secrets restent dans
-`/home/fedora/arbore-data` grâce aux chemins absolus du `.env` : un nouveau
-checkout de release ne peut donc ni les écraser ni les supprimer.
+`./deploy.sh` (qui prend un snapshot Mongo avant chaque rebuild).
+
+**Garde-fou du checkout.** `deploy.sh` refuse de déployer si un fichier **suivi**
+par git est modifié — c'est du code non committé, donc une divergence
+silencieuse. En revanche il **tolère** deux choses : les fichiers non suivis (ils
+ne peuvent pas faire échouer un fast-forward) et les modifications sous
+`ArboreBackend/models/`, déclarées comme données hors bande dans
+`OUT_OF_BAND_PATHS`. Ces modèles 3D sont regénérés et nettoyés directement sur le
+serveur ; les exiger propres rendait `deploy.sh` inutilisable, et les
+déploiements le contournaient — en sautant le snapshot Mongo pre-deploy, seul
+filet de sécurité puisque Atlas M0 n'a aucun backup automatique (cf. #341).
+
+Les USDZ, miniatures, anciens uploads et secrets sont censés vivre dans
+`/home/fedora/arbore-data` grâce aux chemins absolus du `.env`, pour qu'un
+nouveau checkout de release ne puisse ni les écraser ni les supprimer.
+
+> ⚠️ **État réel au 26/07/2026** : `/home/fedora/arbore-data/models` existe et
+> contient bien les 124 modèles, mais **aucun `MODELS_HOST_PATH` n'est défini
+> dans le `.env` du VPS**. `docker-compose.yml` retombe donc sur son défaut
+> `./ArboreBackend/models`, et la production sert les modèles **depuis le
+> checkout git**. Cette bascule reste à faire (#341) ; d'ici là, toute opération
+> git sur ces fichiers change ce que l'app télécharge.
 
 ---
 


### PR DESCRIPTION
Release `dev` → `main` pour déployer l'hygiène de déploiement de #341.

Contenu : la PR #342, déjà validée et mergée sur `dev` (13 checks pass, 0 fail).

## Ce qui part en production

| Cause #341 | Correctif |
|---|---|
| **1** — `deploy.yml` ne déploie rien mais s'appelait « Deploy » | Renommé `📦 Build & Publish images`, avec un en-tête qui dit où est le vrai déploiement |
| **2** — `deploy.sh` inutilisable car le checkout est perpétuellement sale | Garde-fou reciblé : bloque sur les fichiers **suivis** hors `OUT_OF_BAND_PATHS`, tolère `ArboreBackend/models/` et les non-suivis |
| **Détection** — rien ne comparait la prod à `main` | `GET /health` renvoie le SHA git injecté à la compilation |

**Aucun impact sur les modèles 3D de production** — c'était la contrainte explicite. La bascule `MODELS_HOST_PATH` reste ouverte dans #341.

## Amorçage requis après le merge

Le VPS a besoin d'**un** `git pull --ff-only` manuel pour récupérer le nouveau `deploy.sh` : la version actuellement sur le serveur refuserait encore de tourner à cause du checkout sale. Ensuite `./deploy.sh` redevient le chemin normal, `mongodump` pre-deploy inclus.

## Vérification post-déploiement

```bash
curl -s https://api.arbore.app/health | jq -r .commit   # doit renvoyer le SHA de main
git rev-parse origin/main
```

Avant ce déploiement, `/health` renvoie encore `{"version":"1.0.0"}` — l'absence du champ `commit` est en soi le signe que la prod n'a pas encore la nouvelle version.

Refs #341, #342
