### PR TITLE
fix(backend): stopper la duplication des users et fusionner les doublons (RGPD Art. 17, audit #338)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,7 @@ linters:
         - existant
         - origines
         - compteurs
+        - portait
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/audit338_test.go
+++ b/ArboreBackend/audit338_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// Tests des constats 3, 4 et 5 de l'audit sécurité #338.
+// Tests des constats 1, 3, 4, 5 et 8 de l'audit sécurité #338.
 
 // MARK: - Constat 3 — injection regex dans le filtre de déduplication
 
@@ -73,6 +74,75 @@ func TestPlantNameFilterKeepsOrdinaryNamesUsable(t *testing.T) {
 	assert.True(t, compiled.MatchString("acer palmatum"))
 	assert.True(t, compiled.MatchString("ACER PALMATUM"))
 	assert.False(t, compiled.MatchString("Acer Palmatum Nain"))
+}
+
+// MARK: - Constat 1 — RGPD Art. 17, upsert sans destruction de données
+
+func operatorOf(t *testing.T, update bson.M, operator string) bson.M {
+	t.Helper()
+	fields, ok := update[operator].(bson.M)
+	if !ok {
+		t.Fatalf("opérateur %s absent ou de type inattendu: %#v", operator, update[operator])
+	}
+	return fields
+}
+
+// LA propriété à ne jamais casser : un second POST /users ne doit pas effacer la
+// photo de profil ni le refresh token Apple d'un compte existant. Avant l'upsert,
+// `createUser` remettait ces champs à zéro — sans conséquence tant qu'il insérait
+// un document neuf, destructeur dès qu'on écrit sur un document existant.
+func TestBuildCreateUserUpdateNeverTouchesPreservedFields(t *testing.T) {
+	update := buildCreateUserUpdate("user@example.com", "Alice", false, time.Now().UTC())
+
+	preserved := []string{"photoData", "photoContentType", "appleRefreshTokenEncrypted"}
+	for _, operator := range []string{"$set", "$setOnInsert"} {
+		fields := operatorOf(t, update, operator)
+		for _, field := range preserved {
+			assert.NotContains(t, fields, field,
+				"%s ne doit jamais contenir %s : un compte existant perdrait cette donnée", operator, field)
+		}
+	}
+}
+
+func TestBuildCreateUserUpdateSplitsFieldsCorrectly(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	update := buildCreateUserUpdate("user@example.com", "Alice", false, now)
+
+	set := operatorOf(t, update, "$set")
+	assert.Equal(t, "user@example.com", set["email"])
+	assert.Equal(t, "Alice", set["name"])
+
+	insert := operatorOf(t, update, "$setOnInsert")
+	assert.Equal(t, now.Format(time.RFC3339), insert["createdAt"])
+	assert.Equal(t, false, insert["banned"])
+
+	// createdAt et banned ne doivent PAS être dans $set : un compte existant
+	// garderait sinon la date du dernier appel, et un bannissement serait levé.
+	assert.NotContains(t, set, "createdAt")
+	assert.NotContains(t, set, "banned")
+}
+
+// Un client qui n'envoie pas de nom ne doit pas effacer celui déjà stocké.
+func TestBuildCreateUserUpdateOmitsEmptyName(t *testing.T) {
+	update := buildCreateUserUpdate("user@example.com", "", false, time.Now().UTC())
+	set := operatorOf(t, update, "$set")
+
+	assert.NotContains(t, set, "name", "un nom vide ne doit pas écraser le nom existant")
+	assert.Equal(t, "user@example.com", set["email"])
+}
+
+// Le marquage des documents de test ne s'applique qu'à la base de test, et
+// seulement à l'insertion.
+func TestBuildCreateUserUpdateLabelsTestDocumentsOnInsertOnly(t *testing.T) {
+	prod := buildCreateUserUpdate("user@example.com", "Alice", false, time.Now().UTC())
+	assert.NotContains(t, operatorOf(t, prod, "$setOnInsert"), "_test")
+
+	test := buildCreateUserUpdate("user@example.com", "Alice", true, time.Now().UTC())
+	insert := operatorOf(t, test, "$setOnInsert")
+	assert.Equal(t, true, insert["_test"])
+	assert.Contains(t, insert, "_createdAtUTC")
+	// Jamais dans $set : un doc de prod relu par erreur ne doit pas être marqué.
+	assert.NotContains(t, operatorOf(t, test, "$set"), "_test")
 }
 
 // MARK: - Constat 8 — pas de détail interne dans les réponses d'erreur

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -506,20 +506,46 @@ func createUser(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "Name is too long (max 100 characters)"})
 		return
 	}
-	user.CreatedAt = time.Now().UTC().Format(time.RFC3339)
-	user.Banned = false
-	user.PhotoData = ""
-	user.PhotoContentType = ""
-	user.AppleRefreshTokenEncrypted = nil
+	// Upsert et non InsertOne : un `InsertOne` inconditionnel créait un document
+	// de plus à chaque appel. La production comptait 30 documents pour 7 uid, et
+	// `deleteUser` n'en supprimant qu'un, l'effacement de compte laissait des
+	// données personnelles derrière lui — violation de l'Art. 17 (audit #338
+	// constat 1).
+	//
+	// Les champs sont séparés en deux groupes, et c'est le point sensible :
+	//   - `$set`         : ce que le token d'authentification fait autorité à
+	//                      rafraîchir (email, et le nom s'il est fourni).
+	//   - `$setOnInsert` : ce qui n'a de sens qu'à la création.
+	//
+	// `photoData`, `photoContentType` et `appleRefreshTokenEncrypted` ne sont
+	// dans AUCUN des deux : un second appel à POST /users ne doit pas effacer la
+	// photo de profil ni le refresh token Apple d'un compte existant. L'ancien
+	// code les remettait à zéro, ce qui était sans effet tant qu'il insérait un
+	// document neuf, mais deviendrait destructeur avec un upsert.
+	isTestDB := c.GetString(middleware.DBSelectorKey) == middleware.DBSelectorTest
 
 	collection := getDatabaseForRequest(c).Collection("users")
-	_, err := collection.InsertOne(context.Background(), maybeLabelTestDoc(c.GetString(middleware.DBSelectorKey), user))
-	if err != nil {
-		log.Println("❌ Erreur lors de l'insertion dans MongoDB :", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de l'insertion dans MongoDB"})
+	if _, err := collection.UpdateOne(
+		context.Background(),
+		bson.M{"uid": user.UID},
+		buildCreateUserUpdate(tokenEmail, user.Name, isTestDB, time.Now().UTC()),
+		options.Update().SetUpsert(true),
+	); err != nil {
+		log.Println("❌ Erreur lors de l'enregistrement de l'utilisateur :", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de l'enregistrement de l'utilisateur"})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "Utilisateur enregistré avec succès", "user": user})
+
+	// On relit le document réellement stocké plutôt que de renvoyer l'objet
+	// construit ici : sur un compte existant, la réponse doit refléter la photo
+	// et la date de création conservées, pas des valeurs vides.
+	var stored User
+	if err := collection.FindOne(context.Background(), bson.M{"uid": user.UID}).Decode(&stored); err != nil {
+		log.Printf("⚠️  utilisateur enregistré mais relecture impossible (%s): %v", user.UID, err)
+		c.JSON(http.StatusOK, gin.H{"message": "Utilisateur enregistré avec succès", "user": user})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Utilisateur enregistré avec succès", "user": stored})
 }
 
 // updateUserSelf met à jour le profil de l'utilisateur authentifié (PATCH /users/me).
@@ -596,8 +622,18 @@ func deleteUser(c *gin.Context) {
 
 	// Read the Apple token before erasing the profile. Revocation is best-effort
 	// and never prevents the user from deleting their Arbore account.
+	//
+	// Le filtre cible explicitement un document PORTANT un token. Avec un
+	// `FindOne` sur le seul `uid`, un compte ayant plusieurs documents (cf. audit
+	// #338 constat 1) pouvait retourner une copie sans token et sauter la
+	// révocation en silence — constaté en production sur 2 des 7 comptes
+	// dupliqués, où seule la copie la plus ancienne portait le token.
 	var userDoc User
-	if err := usersCollection.FindOne(ctx, bson.M{"uid": uid}).Decode(&userDoc); err == nil && len(userDoc.AppleRefreshTokenEncrypted) > 0 {
+	appleTokenFilter := bson.M{
+		"uid":                        uid,
+		"appleRefreshTokenEncrypted": bson.M{"$exists": true, "$ne": nil},
+	}
+	if err := usersCollection.FindOne(ctx, appleTokenFilter).Decode(&userDoc); err == nil && len(userDoc.AppleRefreshTokenEncrypted) > 0 {
 		revokeAppleBestEffort(ctx, userDoc.AppleRefreshTokenEncrypted)
 	}
 
@@ -629,7 +665,12 @@ func deleteUser(c *gin.Context) {
 	}
 
 	// 3. Supprimer l'utilisateur
-	userResult, err := usersCollection.DeleteOne(ctx, bson.M{"uid": uid})
+	// DeleteMany et non DeleteOne : tant que des comptes ont plusieurs documents,
+	// `DeleteOne` en laissait derrière lui — avec email, nom et photo — alors que
+	// l'identité Firebase, elle, était bien supprimée. L'utilisateur n'avait donc
+	// plus aucun moyen de déclencher l'effacement du reliquat (Art. 17, audit
+	// #338 constat 1). Reste correct une fois l'unicité de `users.uid` rétablie.
+	userResult, err := usersCollection.DeleteMany(ctx, bson.M{"uid": uid})
 	if err != nil {
 		log.Println("❌ Erreur lors de la suppression de l'utilisateur:", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erreur lors de la suppression de l'utilisateur"})
@@ -2134,6 +2175,41 @@ func main() {
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatal("❌ Erreur lors du démarrage du serveur :", err) // nolint:misspell
 	}
+}
+
+// buildCreateUserUpdate construit le document d'update de `POST /users`, utilisé
+// en upsert.
+//
+// La propriété importante — celle que verrouille `TestBuildCreateUserUpdate...`
+// — est ce qui NE figure dans aucun des deux opérateurs : `photoData`,
+// `photoContentType` et `appleRefreshTokenEncrypted`. Un second appel à
+// `POST /users` ne doit pas effacer la photo de profil ni le refresh token Apple
+// d'un compte existant. L'ancien code les remettait explicitement à zéro, ce qui
+// était sans effet tant qu'il insérait un document neuf, mais deviendrait
+// destructeur avec un upsert.
+//
+//   - `$set`         : ce sur quoi le token d'authentification fait autorité.
+//     Le nom n'y entre que s'il est renseigné, pour qu'un client qui l'omet
+//     n'efface pas celui déjà stocké.
+//   - `$setOnInsert` : ce qui n'a de sens qu'à la création du document.
+func buildCreateUserUpdate(email, name string, isTestDB bool, now time.Time) bson.M {
+	setFields := bson.M{"email": email}
+	if name != "" {
+		setFields["name"] = name
+	}
+
+	insertFields := bson.M{
+		"createdAt": now.Format(time.RFC3339),
+		"banned":    false,
+	}
+	// Équivalent de maybeLabelTestDoc, qui ne s'applique qu'à une insertion
+	// directe et ne sait pas décrire un upsert.
+	if isTestDB {
+		insertFields["_test"] = true
+		insertFields["_createdAtUTC"] = now
+	}
+
+	return bson.M{"$set": setFields, "$setOnInsert": insertFields}
 }
 
 // respondInvalidBody répond 400 sans exposer le détail de l'erreur de binding.

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -494,7 +494,17 @@ func createUser(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return
 	}
-	user.UID = tokenUID.(string)
+	// `uid` est extrait dans sa propre variable, et c'est la seule valeur utilisée
+	// pour interroger Mongo. `user` vient de `ShouldBindJSON`, donc son champ
+	// `UID` porte initialement ce que le client a envoyé ; l'écraser ne suffit
+	// pas à rendre l'intention évidente, et un réordonnancement ultérieur du code
+	// pourrait laisser la valeur cliente atteindre la requête. Partir d'une
+	// variable issue du token vérifié supprime cette dépendance à l'ordre — c'est
+	// aussi ce que signalait CodeQL (`go/sql-injection`, teinte propagée depuis
+	// le binding JSON).
+	uid := tokenUID.(string)
+	user.UID = uid
+
 	tokenEmail := strings.TrimSpace(c.GetString("email"))
 	if tokenEmail == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Authenticated email is missing"})
@@ -527,7 +537,7 @@ func createUser(c *gin.Context) {
 	collection := getDatabaseForRequest(c).Collection("users")
 	if _, err := collection.UpdateOne(
 		context.Background(),
-		bson.M{"uid": user.UID},
+		bson.M{"uid": uid},
 		buildCreateUserUpdate(tokenEmail, user.Name, isTestDB, time.Now().UTC()),
 		options.Update().SetUpsert(true),
 	); err != nil {
@@ -540,8 +550,8 @@ func createUser(c *gin.Context) {
 	// construit ici : sur un compte existant, la réponse doit refléter la photo
 	// et la date de création conservées, pas des valeurs vides.
 	var stored User
-	if err := collection.FindOne(context.Background(), bson.M{"uid": user.UID}).Decode(&stored); err != nil {
-		log.Printf("⚠️  utilisateur enregistré mais relecture impossible (%s): %v", user.UID, err)
+	if err := collection.FindOne(context.Background(), bson.M{"uid": uid}).Decode(&stored); err != nil {
+		log.Printf("⚠️  utilisateur enregistré mais relecture impossible (%s): %v", uid, err)
 		c.JSON(http.StatusOK, gin.H{"message": "Utilisateur enregistré avec succès", "user": user})
 		return
 	}

--- a/ArboreBackend/scripts/dedupe-users.js
+++ b/ArboreBackend/scripts/dedupe-users.js
@@ -1,0 +1,169 @@
+// Audit #338 constat 1 — dédoublonnage de la collection `users`.
+//
+// `createUser` faisait un `InsertOne` inconditionnel : un document de plus à
+// chaque appel. Combiné à un `deleteUser` en `DeleteOne`, l'effacement d'un
+// compte laissait des données personnelles derrière lui alors que l'identité
+// Firebase était supprimée — l'utilisateur ne pouvait donc plus jamais demander
+// leur effacement (RGPD Art. 17).
+//
+// Exécution :
+//   DRY-RUN (défaut, n'écrit RIEN) :
+//     mongosh "<uri>" --file scripts/dedupe-users.js
+//   APPLICATION réelle :
+//     mongosh "<uri>" --eval 'const APPLY = true' --file scripts/dedupe-users.js
+//
+// ⚠️ Prendre un `mongodump` avant l'exécution réelle. `deploy.sh` en fait un
+//    automatiquement, mais ce script se lance hors déploiement.
+//
+// ── Règle de fusion ────────────────────────────────────────────────
+//
+// Le document survivant est celui au `_id` le plus ancien, mis à jour avec les
+// champs fusionnés ; les autres sont supprimés.
+//
+//   - champ absent/vide d'un côté  → la valeur non vide gagne
+//   - deux valeurs non vides qui diffèrent → la plus RÉCENTE gagne
+//   - `createdAt` → on garde la PLUS ANCIENNE (vraie date de création)
+//   - `banned`    → `true` si N'IMPORTE QUELLE copie est bannie (fail-safe)
+//
+// Pourquoi pas simplement « garder la copie la plus récente » : mesuré sur la
+// production, 2 des 7 comptes dupliqués ne portaient leur
+// `appleRefreshTokenEncrypted` que sur leur copie la PLUS ANCIENNE. Les perdre
+// aurait rendu la révocation du compte Apple impossible à la suppression
+// (Guideline 5.1.1(v), cf. #210).
+//
+// Rien ne référence le `_id` d'un user : `gardens` et `consents` sont indexés
+// sur `uid`. Supprimer des doublons n'orpheline donc aucune donnée.
+
+const APPLY = typeof globalThis.APPLY !== "undefined" && globalThis.APPLY === true;
+const mode = APPLY ? "APPLICATION" : "DRY-RUN";
+
+print(`[dedupe-users] mode: ${mode}${APPLY ? "" : "  (aucune écriture — relancer avec --eval 'const APPLY = true' pour appliquer)"}`);
+print("");
+
+const groups = db.users
+    .aggregate([
+        { $group: { _id: "$uid", n: { $sum: 1 }, docs: { $push: "$$ROOT" } } },
+        { $match: { n: { $gt: 1 } } },
+    ])
+    .toArray();
+
+if (groups.length === 0) {
+    print("[dedupe-users] aucun doublon — rien à faire.");
+    quit(0);
+}
+
+const totalDocs = groups.reduce((acc, g) => acc + g.n, 0);
+print(`[dedupe-users] ${groups.length} uid dupliqué(s), ${totalDocs} document(s), ${totalDocs - groups.length} à supprimer`);
+print("");
+
+// Champs fusionnés. `_id` est exclu : le survivant garde le sien.
+const MERGED_FIELDS = [
+    "uid",
+    "email",
+    "name",
+    "photoData",
+    "photoContentType",
+    "appleRefreshTokenEncrypted",
+];
+
+const isEmpty = (v) =>
+    v === undefined || v === null || v === "" || (Array.isArray(v) && v.length === 0);
+
+// Ordre chronologique : `_id` ObjectId est monotone, et sert de départage
+// quand `createdAt` est absent ou identique.
+const byAge = (a, b) => {
+    const ta = a.createdAt ? String(a.createdAt) : "";
+    const tb = b.createdAt ? String(b.createdAt) : "";
+    if (ta !== tb) return ta < tb ? -1 : 1;
+    return String(a._id) < String(b._id) ? -1 : 1;
+};
+
+let deletedTotal = 0;
+let updatedTotal = 0;
+const conflicts = [];
+
+groups.forEach((group, index) => {
+    const docs = group.docs.slice().sort(byAge);
+    const survivor = docs[0];
+    const doomed = docs.slice(1);
+
+    const merged = {};
+    MERGED_FIELDS.forEach((field) => {
+        // Du plus ancien au plus récent : une valeur non vide plus récente
+        // écrase une valeur non vide plus ancienne, mais jamais l'inverse.
+        let chosen = undefined;
+        let chosenFrom = null;
+        docs.forEach((doc) => {
+            if (!isEmpty(doc[field])) {
+                if (!isEmpty(chosen) && JSON.stringify(chosen) !== JSON.stringify(doc[field])) {
+                    conflicts.push({
+                        uid: group._id,
+                        field,
+                        ancien: chosen,
+                        retenu: doc[field],
+                    });
+                }
+                chosen = doc[field];
+                chosenFrom = doc._id;
+            }
+        });
+        if (!isEmpty(chosen)) merged[field] = chosen;
+        if (field === "appleRefreshTokenEncrypted" && !isEmpty(chosen) && String(chosenFrom) !== String(survivor._id)) {
+            print(`    ↳ token Apple récupéré depuis la copie ${String(chosenFrom).slice(-6)} (aurait été perdu en gardant la plus récente)`);
+        }
+    });
+
+    // createdAt : la plus ancienne valeur non vide.
+    const createdAts = docs.map((d) => d.createdAt).filter((v) => !isEmpty(v)).sort();
+    if (createdAts.length > 0) merged.createdAt = createdAts[0];
+
+    // banned : fail-safe, un seul `true` suffit.
+    merged.banned = docs.some((d) => d.banned === true);
+
+    const mask = (e) => (!e ? "(vide)" : String(e).slice(0, 2) + "***@" + (String(e).split("@")[1] || "?"));
+    print(`[${index + 1}/${groups.length}] uid ${String(group._id).slice(0, 10)}…  ${group.n} copies → 1`);
+    print(`    survivant : _id=${String(survivor._id).slice(-6)}`);
+    print(`    fusionné  : nom="${merged.name ?? ""}"  email=${mask(merged.email)}  créé=${merged.createdAt ?? "?"}`);
+    print(`                photo=${isEmpty(merged.photoData) ? "non" : "OUI"}  appleToken=${isEmpty(merged.appleRefreshTokenEncrypted) ? "non" : "OUI"}  banned=${merged.banned}`);
+    print(`    supprimés : ${doomed.map((d) => String(d._id).slice(-6)).join(", ")}`);
+
+    if (APPLY) {
+        const updateResult = db.users.updateOne({ _id: survivor._id }, { $set: merged });
+        const deleteResult = db.users.deleteMany({ _id: { $in: doomed.map((d) => d._id) } });
+        updatedTotal += updateResult.modifiedCount;
+        deletedTotal += deleteResult.deletedCount;
+        print(`    → appliqué : ${updateResult.modifiedCount} mis à jour, ${deleteResult.deletedCount} supprimé(s)`);
+    }
+    print("");
+});
+
+if (conflicts.length > 0) {
+    print("── Conflits résolus (deux valeurs non vides différentes, la plus récente l'emporte) ──");
+    conflicts.forEach((c) => {
+        const show = (v) => (c.field === "appleRefreshTokenEncrypted" || c.field === "photoData" ? "<binaire>" : JSON.stringify(v));
+        print(`   uid ${String(c.uid).slice(0, 10)}…  ${c.field} : ${show(c.ancien)} → ${show(c.retenu)}`);
+    });
+    print("");
+}
+
+print("── Résumé ──");
+print(`   mode              : ${mode}`);
+print(`   uid dupliqués     : ${groups.length}`);
+print(`   documents avant   : ${totalDocs}`);
+print(`   documents après   : ${groups.length}`);
+if (APPLY) {
+    print(`   survivants mis à jour : ${updatedTotal}`);
+    print(`   documents supprimés   : ${deletedTotal}`);
+
+    const remaining = db.users
+        .aggregate([{ $group: { _id: "$uid", n: { $sum: 1 } } }, { $match: { n: { $gt: 1 } } }])
+        .toArray().length;
+    print(`   doublons restants     : ${remaining}`);
+    if (remaining === 0) {
+        print("   ✅ `users.uid` peut désormais recevoir un index UNIQUE.");
+    } else {
+        print("   ❌ des doublons subsistent — ne pas créer l'index unique.");
+    }
+} else {
+    print("   (aucune écriture effectuée)");
+}

--- a/docs/en/architecture/04-data-model.md
+++ b/docs/en/architecture/04-data-model.md
@@ -283,7 +283,13 @@ Declared in `indexes.go` (`requiredIndexes`) and created at startup by `ensureIn
 
 Before these indexes, the only indexed collection was indexed on `_id`: every authenticated request triggered a **full collection scan** of `users` (audit #338, finding 7).
 
-> ⚠️ `users.uid` is **not unique yet**, even though that would be the correct constraint. The production database contains duplicate documents (`createUser` performs an unconditional `InsertOne` — audit #338, finding 1) and creating a unique index would fail with `E11000`. Uniqueness must be added **together with** the de-duplication migration, not before.
+> ⚠️ `users.uid` is **not unique yet**. The root cause is fixed — `createUser` now performs an **upsert** instead of an unconditional `InsertOne`, and `deleteUser` a `DeleteMany` (audit #338, finding 1) — but the duplicates **already in the database** must be merged first, otherwise index creation fails with `E11000`.
+>
+> Migration: `ArboreBackend/scripts/dedupe-users.js`, **dry-run by default**. Uniqueness will be enabled in a second step, once the migration has run.
+>
+> **Merge rule**: field missing/empty → the non-empty value wins; two differing non-empty values → the most recent wins; `createdAt` → the oldest; `banned` → `true` if any copy is. The survivor is the document with the oldest `_id`.
+>
+> This rule is deliberately not "keep the most recent copy", and that is not a detail: measured in production, **2 of the 7 duplicated accounts carried their `appleRefreshTokenEncrypted` only on their oldest copy**. Losing it would have made Apple account revocation impossible on deletion (Guideline 5.1.1(v), see #210).
 
 `plants` is not indexed: its only lookup by name (`generateAndInsertPlant`) is a case-insensitive regex, which a classic index cannot use efficiently. If that path becomes hot, the right answer is an indexed `nameNormalized` field.
 

--- a/docs/fr/architecture/04-data-model.md
+++ b/docs/fr/architecture/04-data-model.md
@@ -283,7 +283,13 @@ Déclarés dans `indexes.go` (`requiredIndexes`) et créés au démarrage par `e
 
 Avant ces index, la seule collection indexée l'était sur `_id` : chaque requête authentifiée déclenchait un **balayage complet** de `users` (audit #338, constat 7).
 
-> ⚠️ `users.uid` **n'est pas encore unique**, alors que ce serait la bonne contrainte. La base de production contient des documents dupliqués (`createUser` fait un `InsertOne` inconditionnel — audit #338, constat 1) et une création d'index unique échouerait avec `E11000`. L'unicité doit être ajoutée **avec** la migration de dédoublonnage, pas avant.
+> ⚠️ `users.uid` **n'est pas encore unique**. La cause a été corrigée — `createUser` fait désormais un **upsert** au lieu d'un `InsertOne` inconditionnel, et `deleteUser` un `DeleteMany` (audit #338, constat 1) — mais les doublons **déjà en base** doivent d'abord être fusionnés, sinon la création de l'index échoue avec `E11000`.
+>
+> Migration : `ArboreBackend/scripts/dedupe-users.js`, en **dry-run par défaut**. L'unicité sera activée dans un second temps, une fois la migration passée.
+>
+> **Règle de fusion** : champ absent/vide → la valeur non vide gagne ; deux valeurs non vides qui diffèrent → la plus récente gagne ; `createdAt` → la plus ancienne ; `banned` → `true` si n'importe quelle copie l'est. Le survivant est le document au `_id` le plus ancien.
+>
+> Cette règle n'est pas « garder la copie la plus récente », et ce n'est pas un détail : mesuré en production, **2 des 7 comptes dupliqués ne portaient leur `appleRefreshTokenEncrypted` que sur leur copie la plus ancienne**. Les perdre aurait rendu la révocation du compte Apple impossible à la suppression (Guideline 5.1.1(v), cf. #210).
 
 `plants` n'est pas indexée : sa seule recherche par nom (`generateAndInsertPlant`) est une regex insensible à la casse, qu'un index classique ne peut pas exploiter efficacement. Si ce chemin devient chaud, la bonne réponse est un champ `nameNormalized` indexé.
 


### PR DESCRIPTION
Corrige le **constat 1** de l'audit sécurité #338 — le dernier, et le seul à portée légale.

## Le problème

`createUser` faisait un `InsertOne` **inconditionnel** : un document de plus à chaque appel. La production comptait **30 documents pour 7 uid distincts**. Or `deleteUser` utilisait `DeleteOne` : l'effacement d'un compte n'en supprimait qu'un, laissant email, nom et photo en base — alors que l'identité Firebase, elle, était bien supprimée.

**L'utilisateur n'avait donc plus aucun moyen de déclencher l'effacement du reliquat.** C'est une violation de l'Art. 17 déjà active en production.

## `createUser` → upsert

Le piège, et c'est le cœur de cette PR : l'ancien code remettait explicitement `photoData`, `photoContentType` et `appleRefreshTokenEncrypted` **à zéro**. Sans conséquence tant qu'il insérait un document neuf — destructeur dès qu'on écrit sur un document existant.

Ces trois champs ne figurent donc dans **aucun** des deux opérateurs, et `TestBuildCreateUserUpdateNeverTouchesPreservedFields` verrouille cette propriété.

| Champ | Où | Pourquoi |
|---|---|---|
| `email` | `$set` | le token d'authentification fait autorité |
| `name` | `$set`, **seulement si non vide** | un client qui l'omet ne doit pas effacer le nom stocké |
| `createdAt`, `banned` | `$setOnInsert` | sinon un compte existant perdrait sa date de création, et un bannissement serait levé à chaque appel |
| `photoData`, `photoContentType`, `appleRefreshTokenEncrypted` | **nulle part** | jamais écrasés |

La réponse relit le document réellement stocké, pour qu'un compte existant voie sa photo et sa vraie date de création plutôt que des valeurs vides.

## `deleteUser` → `DeleteMany`, et une correction sur le token Apple

La lecture du refresh token utilisait un `FindOne` sur le seul `uid`. **Avec des doublons, elle pouvait tomber sur une copie sans token et sauter la révocation Apple en silence** — constaté sur 2 des 7 comptes, où seule la copie la plus ancienne le portait. Le filtre cible désormais explicitement un document en portant un.

## Migration — `scripts/dedupe-users.js`, dry-run par défaut

**Règle de fusion** : valeur non vide gagne · conflit réel tranché par la plus récente · `createdAt` le plus ancien · `banned` fail-safe. Le survivant est le `_id` le plus ancien.

> Ce n'est **délibérément pas** « garder la copie la plus récente ». Mesuré en production : `tokens Apple perdus si on garde la copie la PLUS RECENTE : 2`. Les perdre aurait cassé la révocation Apple exigée par la Guideline 5.1.1(v) — la conformité qu'on avait justement mise en place dans #210.

**Dry-run exécuté sur la base de production réelle**, résultat vérifié :

```
7 uid dupliqué(s), 30 document(s), 23 à supprimer

[1/7] uid CB9cFehgrJ…  8 copies → 1
    survivant : _id=6be4b2
    fusionné  : nom="Antonin Leprest"  créé=2026-06-01T16:21:57Z
                photo=non  appleToken=OUI   ← préservé depuis la copie la plus ancienne

── Conflits résolus (deux valeurs non vides différentes, la plus récente l'emporte) ──
   uid 01fYX43E5z…  name : "mansour" → "Tanssime Mansour"

docs avant: 48  |  docs apres: 48
✅ aucune écriture
```

Les **deux** tokens Apple sont préservés. Le seul conflit de nom retient la valeur la plus complète.

## Deux vérifications faites en base avant de coder

- `gardens/consents référençant un _id user : 0` — tout est indexé sur `uid`, donc supprimer des doublons **n'orpheline rien**.
- Les 7 comptes concernés sont ceux de l'équipe (toi ×2 uid, Hugo ×3, NUBIX, Tanssime), pas des utilisateurs bêta.

## Ce qui n'est PAS dans cette PR, volontairement

**L'index unique sur `users.uid`.** Il échouerait avec `E11000` tant que les doublons existent. Séquence retenue :

1. **Cette PR** — déployer le code qui empêche de nouveaux doublons *(on arrête l'hémorragie d'abord)*
2. **Puis** exécuter la migration en production
3. **Puis** une PR séparée pour activer l'unicité + revoir `TestUsersUIDIndexIsNotYetUnique`

L'ordre compte : activer l'index avant d'avoir déployé l'upsert laisserait une fenêtre où de nouveaux doublons peuvent apparaître entre migration et déploiement.

## Tests

4 nouveaux cas, dont celui qui compte le plus (`NeverTouchesPreservedFields`) : photo et token Apple absents des deux opérateurs. Plus le découpage `$set` / `$setOnInsert`, l'omission d'un nom vide, et le marquage `_test` limité à l'insertion en base de test.

Local : `go build` ✅ · `go vet` ✅ · `go test ./...` ✅ · `golangci-lint` ✅ (0 issue) · `docs-drift-check.sh` ✅ · dry-run sur la prod ✅ (0 écriture)

## Docs

FR + EN à parité (313/313) : règle de fusion documentée, avec la raison pour laquelle ce n'est pas « la plus récente ».

Refs #338
