### PR TITLE
fix(backend): rendre users.uid unique et corriger la base ciblée par dedupe-users (audit #338)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
         - origines
         - compteurs
         - portait
+        - conflit
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/indexes.go
+++ b/ArboreBackend/indexes.go
@@ -10,7 +10,10 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -24,22 +27,18 @@ type indexSpec struct {
 	collection string
 	keys       bson.D
 	name       string
+	unique     bool
 	reason     string
 }
 
 // requiredIndexes liste les index attendus sur une base Arbore.
-//
-// ⚠️ `users.uid` n'est volontairement PAS unique ici. La contrainte d'unicité est
-// ce qu'il faudrait, mais la base de production contient déjà des documents
-// dupliqués (cf. #338 constat 1 : 48 documents pour 25 uid distincts) et une
-// création d'index unique échouerait avec E11000. L'unicité doit être ajoutée
-// par le correctif du constat 1, APRÈS la migration de dédoublonnage.
 var requiredIndexes = []indexSpec{
 	{
 		collection: "users",
 		keys:       bson.D{{Key: "uid", Value: 1}},
 		name:       "uid_1",
-		reason:     "vérification de ban à chaque requête authentifiée + lecture/écriture de profil",
+		unique:     true,
+		reason:     "vérification de ban à chaque requête authentifiée + lecture/écriture de profil ; l'unicité est la garantie structurelle contre le retour des doublons (#338 constat 1)",
 	},
 	{
 		collection: "gardens",
@@ -74,15 +73,61 @@ func ensureIndexes(ctx context.Context, databases map[string]*mongo.Database) {
 		for _, spec := range requiredIndexes {
 			model := mongo.IndexModel{
 				Keys:    spec.keys,
-				Options: options.Index().SetName(spec.name),
+				Options: options.Index().SetName(spec.name).SetUnique(spec.unique),
 			}
 			if _, err := db.Collection(spec.collection).Indexes().CreateOne(ctx, model); err != nil {
-				log.Printf("⚠️  Index %s.%s (%s) non créé sur la base %s: %v",
-					spec.collection, spec.name, spec.reason, label, err)
+				logIndexFailure(label, spec, err)
 				continue
 			}
 		}
 		log.Printf("✅ Index vérifiés sur la base %s", label)
+	}
+}
+
+// Codes d'erreur MongoDB rencontrés à la création d'index. Ils méritent des
+// messages distincts : l'un se corrige par une commande d'exploitation, l'autre
+// signale que des données violent la contrainte.
+const (
+	mongoErrIndexOptionsConflict = 85 // même nom/clé, options différentes
+	mongoErrDuplicateKey         = 11000
+)
+
+// formatIndexKeys rend une clé d'index sous la forme attendue par mongosh, pour
+// que le message d'erreur contienne une commande directement copiable.
+// L'ordre des champs est significatif dans un index composé, d'où le parcours du
+// bson.D plutôt qu'une conversion en map.
+func formatIndexKeys(keys bson.D) string {
+	parts := make([]string, 0, len(keys))
+	for _, element := range keys {
+		parts = append(parts, fmt.Sprintf("%s: %v", element.Key, element.Value))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// logIndexFailure explique quoi faire, plutôt que de recracher l'erreur brute.
+//
+// Le cas important est le passage de `users.uid` en unique : l'index non unique
+// existe déjà en production, et MongoDB refuse d'en changer les options en
+// place. Le remplacement est une opération d'exploitation délibérée, PAS quelque
+// chose que le démarrage doit tenter : un `drop` suivi d'un `create` qui échoue
+// laisserait la collection sans aucun index, donc en balayage complet à chaque
+// requête authentifiée — exactement le problème que le constat 7 a corrigé.
+func logIndexFailure(label string, spec indexSpec, err error) {
+	var cmdErr mongo.CommandError
+	switch {
+	case errors.As(err, &cmdErr) && cmdErr.Code == mongoErrIndexOptionsConflict:
+		log.Printf("⚠️  Index %s.%s sur la base %s : options divergentes (unique attendu = %t).",
+			spec.collection, spec.name, label, spec.unique)
+		log.Printf("    Remplacement manuel requis, collection vide de doublons au préalable :")
+		log.Printf(`    db.%s.dropIndex("%s"); db.%s.createIndex(%s, {name:"%s", unique:%t})`,
+			spec.collection, spec.name, spec.collection, formatIndexKeys(spec.keys), spec.name, spec.unique)
+	case errors.As(err, &cmdErr) && cmdErr.Code == mongoErrDuplicateKey:
+		log.Printf("❌ Index %s.%s sur la base %s : des doublons violent l'unicité.",
+			spec.collection, spec.name, label)
+		log.Printf("    Lancer d'abord la migration : ArboreBackend/scripts/dedupe-users.js")
+	default:
+		log.Printf("⚠️  Index %s.%s (%s) non créé sur la base %s: %v",
+			spec.collection, spec.name, spec.reason, label, err)
 	}
 }
 

--- a/ArboreBackend/indexes_test.go
+++ b/ArboreBackend/indexes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -43,20 +44,68 @@ func TestRequiredIndexesCoverUIDLookups(t *testing.T) {
 	}
 }
 
-// Garde-fou délibéré : rendre `users.uid` unique est le bon objectif final, mais
-// la base de prod contient des doublons (audit #338 constat 1) et la création
-// échouerait avec E11000, ce qui masquerait l'index pour toutes les collections.
-// L'unicité doit arriver AVEC la migration de dédoublonnage, pas avant.
-func TestUsersUIDIndexIsNotYetUnique(t *testing.T) {
+// `users.uid` DOIT être unique : c'est la garantie structurelle qui empêche le
+// retour des doublons (audit #338 constat 1). Le code applicatif — `createUser`
+// en upsert — évite d'en créer, mais seul l'index rend la duplication
+// impossible, y compris pour un script, une écriture manuelle ou un futur
+// chemin de code qui oublierait la règle.
+//
+// Ce test remplace `TestUsersUIDIndexIsNotYetUnique`, qui verrouillait
+// l'ABSENCE d'unicité tant que la production contenait des doublons. La
+// migration `scripts/dedupe-users.js` ayant été appliquée (48 → 25 documents,
+// 0 doublon), la contrainte peut désormais être posée.
+func TestUsersUIDIndexIsUnique(t *testing.T) {
 	for _, spec := range requiredIndexes {
 		if spec.collection == "users" && spec.name == "uid_1" {
-			// L'unicité n'est pas exprimable dans indexSpec : c'est volontaire.
-			// Si un champ `unique` y est ajouté un jour, ce test doit être revu
-			// en même temps que la migration.
+			if !spec.unique {
+				t.Fatal("users.uid_1 doit être unique : sans cette contrainte, rien n'empêche structurellement le retour des doublons")
+			}
 			return
 		}
 	}
 	t.Fatal("index users.uid_1 introuvable dans requiredIndexes")
+}
+
+// Les autres index ne doivent PAS être uniques : un utilisateur a plusieurs
+// jardins et plusieurs consentements. Une unicité posée là casserait l'écriture.
+func TestOnlyUsersIndexIsUnique(t *testing.T) {
+	for _, spec := range requiredIndexes {
+		if spec.collection == "users" {
+			continue
+		}
+		if spec.unique {
+			t.Errorf("%s.%s ne doit pas être unique : un uid a légitimement plusieurs documents",
+				spec.collection, spec.name)
+		}
+	}
+}
+
+// Le message d'erreur d'un conflit d'options doit contenir une commande
+// mongosh copiable telle quelle : c'est tout son intérêt pour l'exploitant.
+// L'ordre des champs compte dans un index composé.
+func TestFormatIndexKeysPreservesOrder(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		keys bson.D
+		want string
+	}{
+		{
+			name: "cle simple",
+			keys: bson.D{{Key: "uid", Value: 1}},
+			want: "{uid: 1}",
+		},
+		{
+			name: "cle composee, ordre significatif",
+			keys: bson.D{{Key: "uid", Value: 1}, {Key: "updatedAt", Value: -1}},
+			want: "{uid: 1, updatedAt: -1}",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatIndexKeys(test.keys); got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
 }
 
 // ensureIndexes doit ignorer une base nil sans paniquer : `testClient` est nil

--- a/ArboreBackend/scripts/dedupe-users.js
+++ b/ArboreBackend/scripts/dedupe-users.js
@@ -37,10 +37,23 @@
 const APPLY = typeof globalThis.APPLY !== "undefined" && globalThis.APPLY === true;
 const mode = APPLY ? "APPLICATION" : "DRY-RUN";
 
+// Base ciblée explicitement, au lieu de dépendre de celle de la connexion.
+//
+// S'en remettre à la connexion obligeait à écrire `mongosh "$URI/arbore"`, or
+// l'URI Atlas contient déjà une query string (`?retryWrites=true&w=majority`) :
+// la concaténation produisait `w=majority/arbore`, et Mongo rejetait toute
+// écriture avec `No write concern mode named 'majority/arbore' found`. Rejet à
+// la validation, donc sans dégât — mais le script était inutilisable en APPLY.
+//
+// Surchargeable : `--eval 'const DB_NAME = "arbore_test"'`.
+const DB_NAME = typeof globalThis.DB_NAME !== "undefined" ? globalThis.DB_NAME : "arbore";
+const target = db.getSiblingDB(DB_NAME);
+print(`[dedupe-users] base ciblée : ${DB_NAME}`);
+
 print(`[dedupe-users] mode: ${mode}${APPLY ? "" : "  (aucune écriture — relancer avec --eval 'const APPLY = true' pour appliquer)"}`);
 print("");
 
-const groups = db.users
+const groups = target.users
     .aggregate([
         { $group: { _id: "$uid", n: { $sum: 1 }, docs: { $push: "$$ROOT" } } },
         { $match: { n: { $gt: 1 } } },
@@ -128,8 +141,8 @@ groups.forEach((group, index) => {
     print(`    supprimés : ${doomed.map((d) => String(d._id).slice(-6)).join(", ")}`);
 
     if (APPLY) {
-        const updateResult = db.users.updateOne({ _id: survivor._id }, { $set: merged });
-        const deleteResult = db.users.deleteMany({ _id: { $in: doomed.map((d) => d._id) } });
+        const updateResult = target.users.updateOne({ _id: survivor._id }, { $set: merged });
+        const deleteResult = target.users.deleteMany({ _id: { $in: doomed.map((d) => d._id) } });
         updatedTotal += updateResult.modifiedCount;
         deletedTotal += deleteResult.deletedCount;
         print(`    → appliqué : ${updateResult.modifiedCount} mis à jour, ${deleteResult.deletedCount} supprimé(s)`);
@@ -155,7 +168,7 @@ if (APPLY) {
     print(`   survivants mis à jour : ${updatedTotal}`);
     print(`   documents supprimés   : ${deletedTotal}`);
 
-    const remaining = db.users
+    const remaining = target.users
         .aggregate([{ $group: { _id: "$uid", n: { $sum: 1 } } }, { $match: { n: { $gt: 1 } } }])
         .toArray().length;
     print(`   doublons restants     : ${remaining}`);

--- a/docs/en/architecture/04-data-model.md
+++ b/docs/en/architecture/04-data-model.md
@@ -277,19 +277,21 @@ Declared in `indexes.go` (`requiredIndexes`) and created at startup by `ensureIn
 
 | Collection | Index | Used for |
 |---|---|---|
-| `users` | `{uid: 1}` | Ban check on **every authenticated request** (`checkUserBannedFromDB`) + profile reads/writes |
+| `users` | `{uid: 1}` **unique** | Ban check on **every authenticated request** (`checkUserBannedFromDB`) + profile reads/writes, and the **structural guarantee of account uniqueness** |
 | `gardens` | `{uid: 1, updatedAt: -1}` | `listGardens` (filter `uid` + sort `updatedAt`); also acts as a prefix for queries on `uid` alone |
 | `consents` | `{uid: 1, timestamp: -1}` | `getUserConsents` / `getLatestUserConsents` (filter `uid` + sort `timestamp`) |
 
 Before these indexes, the only indexed collection was indexed on `_id`: every authenticated request triggered a **full collection scan** of `users` (audit #338, finding 7).
 
-> ⚠️ `users.uid` is **not unique yet**. The root cause is fixed — `createUser` now performs an **upsert** instead of an unconditional `InsertOne`, and `deleteUser` a `DeleteMany` (audit #338, finding 1) — but the duplicates **already in the database** must be merged first, otherwise index creation fails with `E11000`.
+> ✅ **`users.uid` is unique.** Two complementary protections, and both are needed: `createUser` as an **upsert** avoids creating duplicates, but only the **unique index** makes duplication impossible — including for a script, a manual write, or a future code path that forgets the rule (audit #338, finding 1).
 >
-> Migration: `ArboreBackend/scripts/dedupe-users.js`, **dry-run by default**. Uniqueness will be enabled in a second step, once the migration has run.
+> **History.** `createUser` performed an unconditional `InsertOne` and `deleteUser` a `DeleteOne`: production held 30 documents for 7 uids, and deleting an account left personal data behind while the Firebase identity was removed. Migration applied on 2026-07-26 via `ArboreBackend/scripts/dedupe-users.js`: **48 → 25 documents, 0 duplicates, no user lost**.
 >
 > **Merge rule**: field missing/empty → the non-empty value wins; two differing non-empty values → the most recent wins; `createdAt` → the oldest; `banned` → `true` if any copy is. The survivor is the document with the oldest `_id`.
 >
 > This rule is deliberately not "keep the most recent copy", and that is not a detail: measured in production, **2 of the 7 duplicated accounts carried their `appleRefreshTokenEncrypted` only on their oldest copy**. Losing it would have made Apple account revocation impossible on deletion (Guideline 5.1.1(v), see #210).
+>
+> ⚠️ **Changing the options of an existing index is not possible in place.** MongoDB returns `IndexOptionsConflict` (code 85). `ensureIndexes` therefore does **not** attempt to replace the index automatically: a `drop` followed by a failing `create` would leave the collection with no index at all, hence a full scan on every authenticated request. The log prints the `dropIndex`/`createIndex` command to run instead, once duplicates are gone.
 
 `plants` is not indexed: its only lookup by name (`generateAndInsertPlant`) is a case-insensitive regex, which a classic index cannot use efficiently. If that path becomes hot, the right answer is an indexed `nameNormalized` field.
 

--- a/docs/fr/architecture/04-data-model.md
+++ b/docs/fr/architecture/04-data-model.md
@@ -277,19 +277,21 @@ Déclarés dans `indexes.go` (`requiredIndexes`) et créés au démarrage par `e
 
 | Collection | Index | Sert à |
 |---|---|---|
-| `users` | `{uid: 1}` | Vérification de ban à **chaque requête authentifiée** (`checkUserBannedFromDB`) + lectures/écritures de profil |
+| `users` | `{uid: 1}` **unique** | Vérification de ban à **chaque requête authentifiée** (`checkUserBannedFromDB`) + lectures/écritures de profil, et **garantie structurelle d'unicité du compte** |
 | `gardens` | `{uid: 1, updatedAt: -1}` | `listGardens` (filtre `uid` + tri `updatedAt`) ; sert aussi de préfixe aux requêtes sur `uid` seul |
 | `consents` | `{uid: 1, timestamp: -1}` | `getUserConsents` / `getLatestUserConsents` (filtre `uid` + tri `timestamp`) |
 
 Avant ces index, la seule collection indexée l'était sur `_id` : chaque requête authentifiée déclenchait un **balayage complet** de `users` (audit #338, constat 7).
 
-> ⚠️ `users.uid` **n'est pas encore unique**. La cause a été corrigée — `createUser` fait désormais un **upsert** au lieu d'un `InsertOne` inconditionnel, et `deleteUser` un `DeleteMany` (audit #338, constat 1) — mais les doublons **déjà en base** doivent d'abord être fusionnés, sinon la création de l'index échoue avec `E11000`.
+> ✅ **`users.uid` est unique.** Deux protections complémentaires, et il faut les deux : `createUser` en **upsert** évite de créer des doublons, mais seul l'**index unique** rend la duplication impossible — y compris pour un script, une écriture manuelle ou un futur chemin de code qui oublierait la règle (audit #338, constat 1).
 >
-> Migration : `ArboreBackend/scripts/dedupe-users.js`, en **dry-run par défaut**. L'unicité sera activée dans un second temps, une fois la migration passée.
+> **Historique.** `createUser` faisait un `InsertOne` inconditionnel et `deleteUser` un `DeleteOne` : la production comptait 30 documents pour 7 uid, et l'effacement d'un compte laissait des données personnelles derrière lui alors que l'identité Firebase était supprimée. Migration appliquée le 26/07/2026 via `ArboreBackend/scripts/dedupe-users.js` : **48 → 25 documents, 0 doublon, aucun utilisateur perdu**.
 >
 > **Règle de fusion** : champ absent/vide → la valeur non vide gagne ; deux valeurs non vides qui diffèrent → la plus récente gagne ; `createdAt` → la plus ancienne ; `banned` → `true` si n'importe quelle copie l'est. Le survivant est le document au `_id` le plus ancien.
 >
 > Cette règle n'est pas « garder la copie la plus récente », et ce n'est pas un détail : mesuré en production, **2 des 7 comptes dupliqués ne portaient leur `appleRefreshTokenEncrypted` que sur leur copie la plus ancienne**. Les perdre aurait rendu la révocation du compte Apple impossible à la suppression (Guideline 5.1.1(v), cf. #210).
+>
+> ⚠️ **Changer les options d'un index existant est impossible en place.** MongoDB renvoie `IndexOptionsConflict` (code 85). `ensureIndexes` ne tente donc **pas** de remplacer l'index automatiquement : un `drop` suivi d'un `create` qui échoue laisserait la collection sans aucun index, donc en balayage complet à chaque requête authentifiée. Le log affiche à la place la commande `dropIndex`/`createIndex` à exécuter, une fois les doublons éliminés.
 
 `plants` n'est pas indexée : sa seule recherche par nom (`generateAndInsertPlant`) est une regex insensible à la casse, qu'un index classique ne peut pas exploiter efficacement. Si ce chemin devient chaud, la bonne réponse est un champ `nameNormalized` indexé.
 


### PR DESCRIPTION
Termine le **constat 1** de l'audit sécurité #338 — et corrige un bug du script de migration livré dans #362.

## 1. `users.uid` devient unique

`createUser` en upsert **évite** de créer des doublons ; seul l'index les rend **impossibles** — y compris pour un script, une écriture manuelle, ou un futur chemin de code qui oublierait la règle. Le code applicatif est une garantie de discipline, l'index une garantie structurelle. Il faut les deux.

**Possible seulement maintenant**, la migration ayant été appliquée en production :

```
users : 48 → 25 documents   |   25 uids   |   0 doublon
tokens Apple : 5 → 5, aucun perdu
utilisateurs perdus : 0
conflit de nom : "mansour" → "Tanssime Mansour"
```

L'index a été remplacé sur la prod (`drop` + `create unique`), et **la contrainte a été vérifiée par une insertion réelle** plutôt que supposée :

```
tentative de duplication d'un uid existant
→ ✅ REFUSE par MongoDB : code 11000 (E11000 duplicate key error)
→ aucun document de test résiduel
```

## 2. `ensureIndexes` ne remplace **pas** un index automatiquement

Changer les options d'un index existant est impossible en place : MongoDB renvoie `IndexOptionsConflict` (code 85). La tentation serait de faire un `drop` puis un `create` au démarrage.

**Ce serait un piège** : si le `create` échoue (doublons présents), la collection se retrouve **sans aucun index**, donc en balayage complet à chaque requête authentifiée — exactement le problème que le constat 7 avait corrigé. Un correctif qui, en cas d'échec, réintroduit un problème déjà résolu.

`logIndexFailure` distingue donc les cas et affiche une commande copiable :

| Code | Message |
|---|---|
| `85` | la commande `dropIndex`/`createIndex` exacte à exécuter |
| `11000` | « lancer d'abord la migration `dedupe-users.js` » |
| autre | l'erreur brute |

## 3. Bug du script de migration, rencontré en production

`dedupe-users.js` utilisait `db.users`, donc dépendait de la base de **connexion**. Cela obligeait à écrire `mongosh "$URI/arbore"` — or l'URI Atlas contient déjà une query string, et la concaténation produisait `w=majority/arbore` :

```
MongoWriteConcernError: No write concern mode named 'majority/arbore' found
```

**Aucune écriture n'a eu lieu** : le rejet est intervenu à la validation du write concern. État vérifié immédiatement après l'erreur, avant toute autre action — 48 documents, les 8 copies du cas en cours intactes.

Le script cible désormais `getSiblingDB(DB_NAME)` explicitement (`arbore` par défaut, surchargeable). J'ai corrigé la dépendance à la connexion plutôt que de bricoler l'URI : le script devient utilisable quelle que soit la façon de se connecter.

## Tests

- `TestUsersUIDIndexIsUnique` **remplace** `TestUsersUIDIndexIsNotYetUnique`, qui verrouillait l'*absence* d'unicité tant que les doublons existaient. Le garde-fou a rempli son rôle : il a survécu jusqu'à ce que la condition soit levée.
- `TestOnlyUsersIndexIsUnique` — `gardens` et `consents` ne doivent **pas** être uniques : un uid y a légitimement plusieurs documents, une unicité posée là casserait l'écriture.
- `TestFormatIndexKeysPreservesOrder` — l'ordre des champs est significatif dans un index composé, et la commande suggérée doit être copiable telle quelle.

Local : `go build` ✅ · `go vet` ✅ · `go test ./...` ✅ · `golangci-lint` ✅ (0 issue) · `docs-drift-check.sh` ✅

## Docs

FR + EN à parité (315/315) : l'index est documenté comme unique, avec l'historique de la migration, la règle de fusion, et l'explication de pourquoi le remplacement d'index n'est pas automatisé.

## État après cette PR

L'index unique est **déjà actif en production** (posé manuellement, comme prévu par la séquence). Ce merge aligne le code sur cet état : un environnement neuf le créera directement en unique, et la prod ne verra aucun changement au prochain démarrage.

**L'audit #338 sera alors terminé — 11 constats sur 11.**

Refs #338
