### PR TITLE
release: bannissement opposable aux invités et gardes d'autorisation fail-closed

### DIFF
--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -402,14 +403,38 @@ type Garden struct {
 func loadAccessProfileFromDB(c *gin.Context, uid string) (middleware.AccessProfile, error) {
 	collection := getDatabaseForRequest(c).Collection("users")
 
-	var user User
-	err := collection.FindOne(context.Background(), bson.M{"uid": uid}).Decode(&user)
+	find := func(uid string) (User, error) {
+		var user User
+		err := collection.FindOne(context.Background(), bson.M{"uid": uid}).Decode(&user)
+		return user, err
+	}
 
+	return resolveAccessProfile(find, uid, time.Now())
+}
+
+// userFinder abstrait la lecture d'un utilisateur pour rendre
+// `resolveAccessProfile` testable sans MongoDB (#381). Le contrat est celui du
+// driver Mongo : `mongo.ErrNoDocuments` quand l'utilisateur n'existe pas.
+type userFinder func(uid string) (User, error)
+
+// resolveAccessProfile applique les règles d'autorisation au document lu.
+//
+// Extrait de `loadAccessProfileFromDB` parce que cette fonction est sur le
+// chemin de CHAQUE requête authentifiée : une erreur de mapping y donnerait un
+// rôle faux à tous les utilisateurs, et elle n'était couverte par aucun test
+// tant qu'elle était soudée à l'appel Mongo.
+//
+// Trois comportements y sont verrouillés :
+//   - utilisateur absent → profil par défaut member/free, SANS erreur. C'est le
+//     cas nominal de `POST /users`, qui s'exécute avant sa propre création.
+//   - toute autre erreur de lecture → remontée telle quelle, le middleware
+//     répond 500 (fail-closed : jamais de profil par défaut sur panne DB).
+//   - document présent → normalisation de `role` et `tier`, `banned` transmis
+//     tel quel.
+func resolveAccessProfile(find userFinder, uid string, now time.Time) (middleware.AccessProfile, error) {
+	user, err := find(uid)
 	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			// Le document n'existe pas encore : c'est le cas nominal de
-			// `POST /users`, qui s'exécute forcément avant sa propre création.
-			// Profil par défaut, non banni.
+		if errors.Is(err, mongo.ErrNoDocuments) {
 			return middleware.AccessProfile{
 				Role: middleware.RoleMember,
 				Tier: middleware.TierFree,
@@ -420,7 +445,7 @@ func loadAccessProfileFromDB(c *gin.Context, uid string) (middleware.AccessProfi
 
 	return middleware.AccessProfile{
 		Role:   middleware.NormalizeRole(user.Role),
-		Tier:   middleware.NormalizeTier(user.Tier, user.TierExpiresAt, time.Now()),
+		Tier:   middleware.NormalizeTier(user.Tier, user.TierExpiresAt, now),
 		Banned: user.Banned,
 	}, nil
 }
@@ -2029,37 +2054,21 @@ func disconnectMongoDatabases(ctx context.Context) {
 	fmt.Println("🔌 Déconnecté de MongoDB.")
 }
 
-func main() {
-	loadDotEnv(".env")
-
-	if err := connectMongoDatabases(context.Background()); err != nil {
-		log.Fatalf("❌ MongoDB initialization failed: %v", err)
-	}
-	defer disconnectMongoDatabases(context.Background())
-
-	// Index sur les champs `uid` : sans eux, chaque requête authentifiée déclenche
-	// un balayage complet de `users` (cf. indexes.go).
-	ensureIndexesAtStartup()
-
-	// Initialiser Firebase Admin SDK.
-	// En release mode, toute erreur est fatale : le backend refuse de démarrer
-	// sans authentification pour éviter d'exposer les endpoints sans token.
-	if err := middleware.InitFirebase(); err != nil {
-		log.Fatalf("❌ Firebase init failed: %v", err)
-	}
-	if err := validateReleaseSecurityConfig(); err != nil {
-		log.Fatalf("❌ Production security configuration invalid: %v", err)
-	}
-
-	// Sélection du fournisseur d'IA/LLM (Gemini par défaut, cf. AI_PROVIDER).
-	if err := initLLMProvider(); err != nil {
-		log.Fatalf("❌ LLM provider init failed: %v", err)
-	}
-	log.Printf("🤖 Fournisseur d'IA actif : %s", providerName())
-
-	// Configurer la fonction de vérification ban pour le middleware
-	middleware.LoadAccessProfileFunc = loadAccessProfileFromDB
-
+// buildRouter construit le routeur complet : durcissement de l'IP client,
+// limiteurs de débit, CORS, et enregistrement de toutes les routes avec leurs
+// gardes.
+//
+// Extrait de `main()` pour être atteignable depuis les tests (#381). Le câblage
+// du groupe `account` est la seule chose qui affirme « un invité ne peut pas
+// lire les jardins », et il n'était vérifiable par aucun test tant que le
+// routeur ne se construisait qu'au démarrage du serveur. Rien ne garantissait
+// non plus qu'une route ajoutée plus tard atterrisse sur `account` plutôt que
+// sur `protected`.
+//
+// Les dépendances externes (Mongo, Firebase, fournisseur LLM) sont initialisées
+// par `main()` avant l'appel : un test qui n'exerce que le routage et les gardes
+// n'a pas besoin qu'elles soient prêtes, les handlers n'étant jamais atteints.
+func buildRouter() *gin.Engine {
 	router := gin.Default()
 	hardenClientIPResolution(router)
 
@@ -2256,6 +2265,42 @@ func main() {
 		admin.POST("/plants/generate-multiple", generationMinuteLimiter.Middleware(), generationDailyQuota.Middleware(), generateMultiplePlantsHandler)
 		admin.POST("/models/thumbnails/:plantId", middleware.MaxBodyBytes(maxThumbnailBytes+(1<<20)), uploadMinuteLimiter.Middleware(), uploadPlantThumbnail)
 	}
+
+	return router
+}
+
+func main() {
+	loadDotEnv(".env")
+
+	if err := connectMongoDatabases(context.Background()); err != nil {
+		log.Fatalf("❌ MongoDB initialization failed: %v", err)
+	}
+	defer disconnectMongoDatabases(context.Background())
+
+	// Index sur les champs `uid` : sans eux, chaque requête authentifiée déclenche
+	// un balayage complet de `users` (cf. indexes.go).
+	ensureIndexesAtStartup()
+
+	// Initialiser Firebase Admin SDK.
+	// En release mode, toute erreur est fatale : le backend refuse de démarrer
+	// sans authentification pour éviter d'exposer les endpoints sans token.
+	if err := middleware.InitFirebase(); err != nil {
+		log.Fatalf("❌ Firebase init failed: %v", err)
+	}
+	if err := validateReleaseSecurityConfig(); err != nil {
+		log.Fatalf("❌ Production security configuration invalid: %v", err)
+	}
+
+	// Sélection du fournisseur d'IA/LLM (Gemini par défaut, cf. AI_PROVIDER).
+	if err := initLLMProvider(); err != nil {
+		log.Fatalf("❌ LLM provider init failed: %v", err)
+	}
+	log.Printf("🤖 Fournisseur d'IA actif : %s", providerName())
+
+	// Configurer la fonction de vérification ban pour le middleware
+	middleware.LoadAccessProfileFunc = loadAccessProfileFromDB
+
+	router := buildRouter()
 
 	port := strings.TrimSpace(os.Getenv("PORT"))
 	if port == "" {

--- a/ArboreBackend/middleware/firebase_auth.go
+++ b/ArboreBackend/middleware/firebase_auth.go
@@ -146,28 +146,45 @@ func FirebaseAuthMiddleware() gin.HandlerFunc {
 
 		uid := token.UID
 
-		// Le rôle `guest` se déduit du fournisseur de connexion, jamais d'un
-		// champ en base (cf. #377). Une session anonyme n'a pas de document
-		// utilisateur : il n'y a rien à lire et rien à bannir, on évite donc
-		// aussi un FindOne par requête.
 		isGuest := token.Firebase.SignInProvider == signInProviderAnonymous
 
-		profile := AccessProfile{Role: RoleGuest, Tier: TierFree}
-		if !isGuest {
-			profile = AccessProfile{Role: RoleMember, Tier: TierFree}
-			if LoadAccessProfileFunc != nil {
-				loaded, err := LoadAccessProfileFunc(c, uid)
-				if err != nil {
-					log.Printf("❌ Error loading access profile: %v", err)
-					c.JSON(500, gin.H{
-						"error": "Internal server error",
-						"code":  "DATABASE_ERROR",
-					})
-					c.Abort()
-					return
-				}
-				profile = loaded
+		// La lecture du profil est faite pour TOUTE identité, invités compris
+		// (#381). La version initiale la sautait pour les sessions anonymes, au
+		// motif qu'un invité n'a pas de document utilisateur — vrai dans le cas
+		// nominal, mais cela rendait `banned` structurellement inopposable à un
+		// invité : le seul levier de modération du backend devenait inapplicable
+		// à toute une population, et le deviendrait aussi aux comptes anonymes
+		// liés ensuite à une identité permanente, qui conservent leur uid.
+		//
+		// Bannir un invité consiste donc à créer un document `users` portant son
+		// uid et `banned: true`, exactement comme pour un membre. Le coût est
+		// d'une requête indexée sur `uid` — l'index existe (cf. indexes.go), et
+		// c'est le prix d'un contrôle de modération qui s'applique à tous.
+		profile := AccessProfile{Role: RoleMember, Tier: TierFree}
+		if LoadAccessProfileFunc != nil {
+			loaded, err := LoadAccessProfileFunc(c, uid)
+			if err != nil {
+				log.Printf("❌ Error loading access profile: %v", err)
+				c.JSON(500, gin.H{
+					"error": "Internal server error",
+					"code":  "DATABASE_ERROR",
+				})
+				c.Abort()
+				return
 			}
+			profile = loaded
+		}
+
+		// Le rôle `guest` est imposé APRÈS la lecture, et écrase ce que porte le
+		// document. Deux raisons :
+		//
+		//   - `sign_in_provider` est signé par Firebase ; un document Mongo est
+		//     modifiable par le porteur du compte via les autres endpoints. Le
+		//     token fait donc autorité sur le rôle.
+		//   - L'écrasement ne concerne que `Role` et `Tier` : `Banned`, lu juste
+		//     au-dessus, survit et reste opposable.
+		if isGuest {
+			profile = applyGuestOverride(profile)
 		}
 
 		if profile.Banned {

--- a/ArboreBackend/middleware/roles.go
+++ b/ArboreBackend/middleware/roles.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -133,6 +134,12 @@ func AccessProfileFromContext(c *gin.Context) (AccessProfile, bool) {
 }
 
 // RoleFromContext retourne le rôle de la requête, ou `RoleMember` par défaut.
+//
+// Ce défaut est un confort de LECTURE, réservé aux appelants pour qui une
+// absence de profil n'a pas de conséquence de sécurité (choix d'un budget de
+// quota, journalisation). Les gardes d'autorisation ne doivent PAS l'utiliser :
+// ils lisent `AccessProfileFromContext` et refusent quand le profil manque
+// (#381).
 func RoleFromContext(c *gin.Context) string {
 	if profile, ok := AccessProfileFromContext(c); ok {
 		return profile.Role
@@ -141,11 +148,32 @@ func RoleFromContext(c *gin.Context) string {
 }
 
 // TierFromContext retourne le niveau d'abonnement de la requête, ou `TierFree`.
+//
+// Même réserve que RoleFromContext : défaut de confort en lecture, jamais une
+// base de décision d'autorisation.
 func TierFromContext(c *gin.Context) string {
 	if profile, ok := AccessProfileFromContext(c); ok {
 		return profile.Tier
 	}
 	return TierFree
+}
+
+// denyMissingProfile refuse une requête dont le contexte ne porte pas de profil
+// d'accès, et signale la cause réelle : le garde a été monté sur un groupe où
+// `FirebaseAuthMiddleware` n'a pas tourné.
+//
+// C'est une erreur de câblage serveur, pas une faute du client — d'où un 500 et
+// non un 403. Le point important est le fail-CLOSED : la version initiale
+// passait par `RoleFromContext`, dont le repli `member` faisait silencieusement
+// AUTORISER la requête dans ce cas.
+func denyMissingProfile(c *gin.Context) {
+	log.Printf("❌ Garde d'autorisation monté sans FirebaseAuthMiddleware sur %s %s",
+		c.Request.Method, c.FullPath())
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"error": "Authorization context unavailable",
+		"code":  "AUTHZ_CONTEXT_MISSING",
+	})
+	c.Abort()
 }
 
 // RequireAccount ferme la route aux invités.
@@ -160,7 +188,12 @@ func TierFromContext(c *gin.Context) string {
 // appareil, ces routes n'auraient pas de sens pour lui.
 func RequireAccount() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if RoleFromContext(c) == RoleGuest {
+		profile, ok := AccessProfileFromContext(c)
+		if !ok {
+			denyMissingProfile(c)
+			return
+		}
+		if profile.Role == RoleGuest {
 			c.JSON(http.StatusForbidden, gin.H{
 				"error": "This action requires a registered account",
 				"code":  "ACCOUNT_REQUIRED",
@@ -182,8 +215,12 @@ func RequireRole(allowed ...string) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		role := RoleFromContext(c)
-		if _, ok := permitted[role]; !ok {
+		profile, ok := AccessProfileFromContext(c)
+		if !ok {
+			denyMissingProfile(c)
+			return
+		}
+		if _, allowed := permitted[profile.Role]; !allowed {
 			c.JSON(http.StatusForbidden, gin.H{
 				"error": "This action requires a registered account",
 				"code":  "ACCOUNT_REQUIRED",
@@ -193,4 +230,20 @@ func RequireRole(allowed ...string) gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+// applyGuestOverride impose le rôle invité au profil lu en base.
+//
+// N'écrase QUE `Role` et `Tier`. `Banned` est délibérément préservé : c'est ce
+// qui rend la modération opposable à une session anonyme (#381). La version
+// initiale sautait purement et simplement la lecture en base pour les invités,
+// ce qui figeait `Banned` à false pour toute cette population.
+//
+// Le rôle vient du token (`sign_in_provider`, signé par Firebase) et non du
+// document Mongo, modifiable par le porteur du compte : un invité ne peut donc
+// pas se hisser en `member` en écrivant dans sa propre fiche.
+func applyGuestOverride(profile AccessProfile) AccessProfile {
+	profile.Role = RoleGuest
+	profile.Tier = TierFree
+	return profile
 }

--- a/ArboreBackend/middleware/roles_test.go
+++ b/ArboreBackend/middleware/roles_test.go
@@ -207,3 +207,78 @@ func TestMiddleware_NilFirebaseAuth_DevMode_SetsMemberProfile(t *testing.T) {
 	assert.Equal(t, RoleMember, seenRole)
 	assert.Equal(t, TierFree, seenTier)
 }
+
+// ─── #381 — bannissement opposable aux invités ──────────────────────────────
+
+// L'invariant central du correctif : imposer le rôle invité ne doit PAS effacer
+// le bannissement lu en base. Sans cela, `banned` — seul levier de modération du
+// backend — devient inapplicable à toute session anonyme.
+func TestApplyGuestOverridePreservesBanned(t *testing.T) {
+	banned := applyGuestOverride(AccessProfile{
+		Role:   RoleMember,
+		Tier:   TierPremium,
+		Banned: true,
+	})
+
+	assert.Equal(t, RoleGuest, banned.Role, "le rôle du token fait autorité")
+	assert.Equal(t, TierFree, banned.Tier, "un invité n'a pas d'abonnement")
+	assert.True(t, banned.Banned,
+		"le bannissement doit survivre à l'imposition du rôle invité, sinon la modération ne s'applique pas aux invités")
+}
+
+// Un invité non banni reste évidemment autorisé.
+func TestApplyGuestOverrideLeavesUnbannedAlone(t *testing.T) {
+	clean := applyGuestOverride(AccessProfile{Role: RoleMember, Tier: TierFree})
+	assert.Equal(t, AccessProfile{Role: RoleGuest, Tier: TierFree, Banned: false}, clean)
+}
+
+// Un document Mongo portant `role: admin` ne doit jamais promouvoir une session
+// anonyme : le fournisseur de connexion, signé par Firebase, prime sur la base.
+func TestApplyGuestOverrideCannotBeEscalatedByDatabase(t *testing.T) {
+	forged := applyGuestOverride(AccessProfile{Role: RoleAdmin, Tier: TierPremium})
+
+	assert.Equal(t, RoleGuest, forged.Role,
+		"un document en base ne doit pas pouvoir hisser un invité au-dessus de son rôle")
+	assert.False(t, IsPrivilegedRole(forged.Role))
+}
+
+// ─── #381 — les gardes échouent en fermeture ────────────────────────────────
+
+// Le point de régression : monter un garde sans FirebaseAuthMiddleware laissait
+// passer la requête, parce que `RoleFromContext` repliait sur `member`.
+func TestGuardsFailClosedWithoutAccessProfile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	guards := map[string]gin.HandlerFunc{
+		"RequireAccount": RequireAccount(),
+		"RequireRole":    RequireRole(RoleMember, RoleAdmin),
+	}
+
+	for name, guard := range guards {
+		router := gin.New()
+		// Volontairement AUCUN middleware d'authentification en amont.
+		router.Use(guard)
+		reached := false
+		router.GET("/gardens", func(c *gin.Context) {
+			reached = true
+			c.Status(http.StatusOK)
+		})
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/gardens", nil))
+
+		assert.False(t, reached, "%s ne doit jamais atteindre le handler sans profil", name)
+		assert.Equal(t, http.StatusInternalServerError, w.Code, "%s doit refuser", name)
+		assert.Contains(t, w.Body.String(), "AUTHZ_CONTEXT_MISSING", "%s", name)
+	}
+}
+
+// Les accesseurs de confort, eux, gardent leur repli : ils ne servent qu'à des
+// décisions sans portée de sécurité (choix d'un budget de quota).
+func TestReadAccessorsKeepTheirDefaults(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	assert.Equal(t, RoleMember, RoleFromContext(c))
+	assert.Equal(t, TierFree, TierFromContext(c))
+}

--- a/ArboreBackend/roles_test.go
+++ b/ArboreBackend/roles_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // roles_test.go — issue #377.
@@ -112,5 +115,238 @@ func TestBannedIsIndependentOfRole(t *testing.T) {
 		profile := middleware.AccessProfile{Role: role, Tier: middleware.TierFree, Banned: true}
 		assert.True(t, profile.Banned,
 			"le bannissement de %s ne doit pas être effacé par son rôle", role)
+	}
+}
+
+// ─── #381 — resolveAccessProfile ────────────────────────────────────────────
+//
+// Cette fonction est sur le chemin de CHAQUE requête authentifiée. Elle était
+// jusqu'ici soudée à l'appel Mongo, donc non couverte.
+
+// Cas nominal de POST /users : le document n'existe pas encore, ce n'est pas une
+// erreur et le profil par défaut doit être member/free non banni.
+func TestResolveAccessProfileMissingUserIsNotAnError(t *testing.T) {
+	profile, err := resolveAccessProfile(
+		func(string) (User, error) { return User{}, mongo.ErrNoDocuments },
+		"inconnu", time.Now(),
+	)
+
+	assert.NoError(t, err, "un utilisateur absent est le cas nominal de POST /users")
+	assert.Equal(t, middleware.RoleMember, profile.Role)
+	assert.Equal(t, middleware.TierFree, profile.Tier)
+	assert.False(t, profile.Banned)
+}
+
+// Fail-closed : toute autre erreur de lecture remonte, pour que le middleware
+// réponde 500 au lieu d'accorder un profil par défaut sur panne de base.
+func TestResolveAccessProfilePropagatesReadErrors(t *testing.T) {
+	boom := errors.New("connexion mongo perdue")
+
+	profile, err := resolveAccessProfile(
+		func(string) (User, error) { return User{}, boom },
+		"uid", time.Now(),
+	)
+
+	assert.ErrorIs(t, err, boom, "une panne de base ne doit jamais donner un profil par défaut")
+	assert.Equal(t, middleware.AccessProfile{}, profile)
+}
+
+func TestResolveAccessProfileNormalizesAndCarriesBan(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-time.Hour)
+	valid := now.Add(time.Hour)
+
+	cases := []struct {
+		name       string
+		user       User
+		wantRole   string
+		wantTier   string
+		wantBanned bool
+	}{
+		{
+			name:     "document legacy sans role ni tier",
+			user:     User{UID: "u"},
+			wantRole: middleware.RoleMember, wantTier: middleware.TierFree,
+		},
+		{
+			name:     "role inconnu replie sur member, jamais admin",
+			user:     User{Role: "superuser"},
+			wantRole: middleware.RoleMember, wantTier: middleware.TierFree,
+		},
+		{
+			name:     "admin reconnu",
+			user:     User{Role: "admin"},
+			wantRole: middleware.RoleAdmin, wantTier: middleware.TierFree,
+		},
+		{
+			name:     "premium encore valide",
+			user:     User{Tier: "premium", TierExpiresAt: &valid},
+			wantRole: middleware.RoleMember, wantTier: middleware.TierPremium,
+		},
+		{
+			name:     "premium expiré retombe en free a la lecture",
+			user:     User{Tier: "premium", TierExpiresAt: &expired},
+			wantRole: middleware.RoleMember, wantTier: middleware.TierFree,
+		},
+		{
+			name:     "banni, quel que soit le role",
+			user:     User{Role: "admin", Banned: true},
+			wantRole: middleware.RoleAdmin, wantTier: middleware.TierFree, wantBanned: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user := tc.user
+			profile, err := resolveAccessProfile(
+				func(string) (User, error) { return user, nil },
+				"uid", now,
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantRole, profile.Role)
+			assert.Equal(t, tc.wantTier, profile.Tier)
+			assert.Equal(t, tc.wantBanned, profile.Banned)
+		})
+	}
+}
+
+// Les tags bson doivent correspondre aux noms de champs réellement stockés.
+// Un tag erroné ne casserait aucune compilation : le champ décoderait
+// silencieusement à vide, donc tout le monde retomberait en member/free.
+func TestUserAuthorizationFieldsSurviveBSONRoundTrip(t *testing.T) {
+	expires := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	original := User{
+		UID: "uid-1", Email: "a@b.c", Banned: true,
+		Role: "admin", Tier: "premium",
+		TierSource: "appstore", TierExpiresAt: &expires,
+	}
+
+	raw, err := bson.Marshal(original)
+	assert.NoError(t, err)
+
+	var asMap bson.M
+	assert.NoError(t, bson.Unmarshal(raw, &asMap))
+	for _, field := range []string{"role", "tier", "tierSource", "tierExpiresAt", "banned"} {
+		assert.Contains(t, asMap, field, "le champ %s doit être stocké sous ce nom exact", field)
+	}
+
+	var decoded User
+	assert.NoError(t, bson.Unmarshal(raw, &decoded))
+	assert.Equal(t, "admin", decoded.Role)
+	assert.Equal(t, "premium", decoded.Tier)
+	assert.Equal(t, "appstore", decoded.TierSource)
+	assert.True(t, decoded.Banned)
+	if assert.NotNil(t, decoded.TierExpiresAt) {
+		assert.True(t, expires.Equal(*decoded.TierExpiresAt))
+	}
+}
+
+// ─── #381 — inventaire des routes et leur classement ────────────────────────
+
+// Les trois classes d'accès, telles que `buildRouter` est censé les câbler.
+//
+// Ce que ce test protège : rien ne garantissait qu'une route ajoutée plus tard
+// atterrisse sur le groupe `account` plutôt que sur `protected`. Toute nouvelle
+// route fait désormais échouer ce test, ce qui force son auteur à la classer
+// explicitement ici plutôt qu'à l'ouvrir aux invités par inadvertance.
+//
+// Limite assumée : Gin n'expose pas la chaîne de handlers d'une route, donc ce
+// test vérifie l'INVENTAIRE et son classement déclaré, pas l'attachement effectif
+// du garde. Ce dernier est couvert séparément par les tests de `RequireAccount`
+// et `RequireAdmin` côté middleware. Une vérification bout en bout demanderait
+// un double de token Firebase (hors périmètre de #381).
+var (
+	// Ouvertes sans compte : catalogue, modèles 3D, config, santé, et les deux
+	// proxys Gemini (sur un budget de quota réduit).
+	guestReachableRoutes = []string{
+		"GET /health",
+		"GET /config",
+		"GET /models/:filename",
+		"GET /models/thumbnails/:filename",
+		"GET /plants",
+		"GET /plants/:id",
+		"POST /chat",
+		"POST /diagnose",
+	}
+
+	// Fermées aux invités : tout ce qui suppose un compte durable.
+	accountBoundRoutes = []string{
+		"POST /users",
+		"GET /users/:uid",
+		"POST /users/:uid/photo",
+		"GET /users/:uid/photo",
+		"GET /users/export",
+		"PATCH /users/me",
+		"POST /users/me/apple-link",
+		"DELETE /users",
+		"POST /gardens",
+		"GET /gardens",
+		"GET /gardens/:id",
+		"PUT /gardens/:id",
+		"DELETE /gardens/:id",
+		"POST /consents",
+		"GET /consents",
+		"GET /consents/latest",
+	}
+
+	// Réservées aux administrateurs : écriture catalogue et génération IA.
+	adminOnlyRoutes = []string{
+		"POST /plants",
+		"POST /plants/generate",
+		"POST /plants/generate-multiple",
+		"POST /models/thumbnails/:plantId",
+	}
+)
+
+func TestRouterExposesExactlyTheClassifiedRoutes(t *testing.T) {
+	t.Setenv("ARBORE_API_KEY", "clef-de-test")
+
+	registered := map[string]bool{}
+	for _, r := range buildRouter().Routes() {
+		registered[r.Method+" "+r.Path] = true
+	}
+
+	classified := map[string]bool{}
+	for _, group := range [][]string{guestReachableRoutes, accountBoundRoutes, adminOnlyRoutes} {
+		for _, route := range group {
+			assert.False(t, classified[route], "route classée deux fois : %s", route)
+			classified[route] = true
+		}
+	}
+
+	for route := range classified {
+		assert.True(t, registered[route],
+			"route classée mais absente du routeur : %s (renommée ou supprimée ?)", route)
+	}
+	for route := range registered {
+		assert.True(t, classified[route],
+			"route enregistrée mais non classée : %s — la ranger dans guestReachableRoutes, accountBoundRoutes ou adminOnlyRoutes", route)
+	}
+
+	assert.Equal(t, len(classified), len(registered), "inventaire et classement doivent coïncider")
+}
+
+// Les jardins sont le cas d'usage qui a motivé le groupe `account` : un invité
+// est lié à un seul appareil, la synchronisation n'a pas de sens pour lui.
+func TestGardenAndAccountRoutesAreNeverGuestReachable(t *testing.T) {
+	guestSet := map[string]bool{}
+	for _, route := range guestReachableRoutes {
+		guestSet[route] = true
+	}
+
+	for _, route := range accountBoundRoutes {
+		assert.False(t, guestSet[route],
+			"%s ne doit jamais figurer parmi les routes ouvertes aux invités", route)
+	}
+	for _, route := range adminOnlyRoutes {
+		assert.False(t, guestSet[route],
+			"%s est une route d'administration, jamais ouverte aux invités", route)
+	}
+
+	for _, prefix := range []string{"/gardens", "/consents", "/users"} {
+		for _, route := range guestReachableRoutes {
+			assert.NotContains(t, route, prefix,
+				"aucune route sous %s ne doit être ouverte aux invités", prefix)
+		}
 	}
 }


### PR DESCRIPTION
## 📝 Description

Release de `dev` vers `main`. Deux commits, un seul sujet : les suites de #381, traitées dans #382.

### Ce qui change vraiment

**Le bannissement devient opposable aux invités.** La lecture du profil est désormais faite pour toute identité. La version déployée sautait cette lecture pour les sessions anonymes, ce qui rendait `banned` — seul levier de modération du backend — **structurellement inapplicable** à un invité. Le rôle `guest` est maintenant imposé *après* la lecture et n'écrase que `Role` et `Tier` ; `Banned` survit.

**Les gardes d'autorisation échouent en fermeture.** `RequireAccount` et `RequireRole` lisaient le rôle via `RoleFromContext`, dont le repli `member` les faisait silencieusement autoriser une requête montée sur un groupe sans `FirebaseAuthMiddleware`. Ils refusent désormais en 500 `AUTHZ_CONTEXT_MISSING`.

**Deux zones aveugles sont couvertes.** `resolveAccessProfile` (sur le chemin de chaque requête authentifiée) et le câblage du groupe `account` étaient sans test ; ils le sont maintenant, via l'extraction de `resolveAccessProfile` derrière un `userFinder` et de `buildRouter` hors de `main()`.

## 🎯 Type de changement

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring
- [x] ✅ Tests

## 🔗 Issue liée

Refs #381

## ⚠️ Impact en production

**Aucun changement de comportement observable.** `guest` reste inatteignable tant qu'Anonymous Auth n'est pas activé, donc le correctif de bannissement corrige un chemin encore dormant — c'est précisément le but : lever le prérequis de modération **avant** d'ouvrir l'accès invité.

Le seul changement sur un chemin actif est le fail-closed des gardes, qui ne peut se déclencher que sur une erreur de câblage serveur — situation qui n'existe pas dans le routeur actuel, et que le nouveau test d'inventaire des routes protège désormais.

Coût ajouté : une requête indexée sur `uid` par requête invité. Nul aujourd'hui, puisqu'aucun invité ne peut se connecter.

## 🧪 Tests effectués

Déjà validé sur `dev` : **#382 a eu sa CI verte** (13 checks, 3 skippés côté iOS/AiGenerator faute de fichiers concernés, zéro échec).

11 tests ajoutés, dont un aller-retour BSON qui verrouille les noms de champs stockés — un tag erroné ne casse aucune compilation mais ferait retomber tout le monde en `member`/`free` — et un inventaire des routes classées en trois groupes, qui fait échouer le test tant qu'une route ajoutée n'est pas explicitement classée.

Le delta `main` ↔ `dev` ne contient que du Go backend : `ios_ui`, `ios_ar` et `ai_generator` se skipperont ici. Merge vérifié sans conflit.

## 🚀 Composants affectés

- [x] Backend (Go)