### PR TITLE
fix(rgpd): tronquer les IP journalisées et borner la conservation des logs

### DIFF
--- a/ArboreBackend/httplogging.go
+++ b/ArboreBackend/httplogging.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// httplogging.go — journalisation HTTP à identifiabilité réduite (issue #385).
+//
+// `gin.Default()` embarque le logger par défaut, qui écrit `ClientIP()` sur
+// stdout. Comme `hardenClientIPResolution` fixe `TrustedPlatform = "X-Real-IP"`,
+// cette valeur est l'adresse IP RÉELLE de l'utilisateur final pour tout trafic
+// passant par nginx — donc une donnée personnelle au sens du RGPD (CJUE Breyer,
+// C-582/14), écrite dans les journaux Docker.
+//
+// On garde la valeur de diagnostic d'une IP (distinguer les appelants, repérer
+// une source d'erreurs) en n'en journalisant que le préfixe réseau. Le rate
+// limiting, lui, continue d'utiliser l'IP complète mais uniquement EN MÉMOIRE,
+// dans un compteur purgé à l'expiration de la fenêtre : rien n'en est persisté.
+
+// maskIP réduit une adresse IP à son préfixe réseau.
+//
+//	IPv4 → les trois premiers octets  (92.184.105.42       → 92.184.105.x)
+//	IPv6 → le préfixe /48             (2a01:e0a:1b2:c3::1  → 2a01:e0a:1b2:x)
+//
+// Le /48 IPv6 est l'équivalent usuel du /24 IPv4 : c'est en général le bloc
+// alloué à un abonné, donc le même compromis entre utilité et identifiabilité.
+//
+// Une valeur non parsable est remplacée par "-" plutôt que journalisée telle
+// quelle : une chaîne arbitraire venue d'un en-tête n'a rien à faire dans les
+// journaux.
+func maskIP(raw string) string {
+	parsed := net.ParseIP(raw)
+	if parsed == nil {
+		return "-"
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return fmt.Sprintf("%d.%d.%d.x", v4[0], v4[1], v4[2])
+	}
+	v6 := parsed.To16()
+	if v6 == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%x:%x:%x:x",
+		int(v6[0])<<8|int(v6[1]),
+		int(v6[2])<<8|int(v6[3]),
+		int(v6[4])<<8|int(v6[5]),
+	)
+}
+
+// privacyPreservingLogFormatter reproduit le format lisible de gin, avec l'IP
+// tronquée. Volontairement proche de l'original pour ne pas casser les habitudes
+// de lecture ni un éventuel parsing existant.
+func privacyPreservingLogFormatter(p gin.LogFormatterParams) string {
+	return fmt.Sprintf("[GIN] %s | %3d | %13v | %15s | %-7s %#v\n%s",
+		p.TimeStamp.Format(time.RFC3339),
+		p.StatusCode,
+		p.Latency,
+		maskIP(p.ClientIP),
+		p.Method,
+		p.Path,
+		p.ErrorMessage,
+	)
+}
+
+// newRouterEngine remplace `gin.Default()`.
+//
+// `gin.Default()` = `gin.New()` + `Logger()` + `Recovery()`. On reconstruit la
+// même chose en substituant au logger par défaut celui qui masque l'IP ;
+// `Recovery()` est conservé tel quel — le retirer transformerait n'importe quel
+// panic de handler en connexion coupée sans réponse.
+func newRouterEngine() *gin.Engine {
+	engine := gin.New()
+	engine.Use(gin.LoggerWithFormatter(privacyPreservingLogFormatter))
+	engine.Use(gin.Recovery())
+	return engine
+}

--- a/ArboreBackend/httplogging_test.go
+++ b/ArboreBackend/httplogging_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// httplogging_test.go — issue #385.
+//
+// L'invariant : aucune adresse IP complète ne doit atteindre les journaux.
+
+func TestMaskIPKeepsOnlyTheNetworkPrefix(t *testing.T) {
+	cases := map[string]string{
+		// IPv4 : les trois premiers octets, le dernier masqué.
+		"92.184.105.42": "92.184.105.x",
+		"8.8.8.8":       "8.8.8.x",
+		"127.0.0.1":     "127.0.0.x",
+		"172.18.0.7":    "172.18.0.x",
+		// IPv6 : préfixe /48.
+		"2a01:e0a:1b2:c3d4::1": "2a01:e0a:1b2:x",
+		"::1":                  "0:0:0:x",
+		// IPv4 exprimée en IPv6 mappée : traitée comme de l'IPv4.
+		"::ffff:92.184.105.42": "92.184.105.x",
+	}
+
+	for raw, expected := range cases {
+		assert.Equal(t, expected, maskIP(raw), "maskIP(%q)", raw)
+	}
+}
+
+// Une valeur non parsable vient forcément d'un en-tête manipulable : elle ne
+// doit pas être recopiée telle quelle dans les journaux.
+func TestMaskIPRejectsNonAddresses(t *testing.T) {
+	for _, raw := range []string{"", "   ", "pas-une-ip", "1.2.3", "<script>", "999.999.999.999"} {
+		assert.Equal(t, "-", maskIP(raw), "maskIP(%q) doit être neutralisé", raw)
+	}
+}
+
+// Le test qui compte vraiment : la ligne de journal produite ne contient jamais
+// l'adresse complète.
+func TestLogFormatterNeverEmitsAFullIP(t *testing.T) {
+	full := "92.184.105.42"
+	line := privacyPreservingLogFormatter(ginLogParams(full, "/gardens"))
+
+	assert.NotContains(t, line, full,
+		"l'adresse complète ne doit jamais apparaître dans une ligne de journal")
+	assert.Contains(t, line, "92.184.105.x")
+	assert.Contains(t, line, "/gardens")
+}
+
+func TestLogFormatterHandlesIPv6(t *testing.T) {
+	full := "2a01:e0a:1b2:c3d4::1"
+	line := privacyPreservingLogFormatter(ginLogParams(full, "/plants"))
+
+	assert.NotContains(t, line, "c3d4", "le préfixe /48 ne doit pas laisser filtrer le sous-réseau")
+	assert.Contains(t, line, "2a01:e0a:1b2:x")
+}
+
+// ginLogParams construit un jeu de paramètres de log minimal.
+func ginLogParams(clientIP, path string) gin.LogFormatterParams {
+	return gin.LogFormatterParams{
+		TimeStamp:  time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC),
+		StatusCode: http.StatusOK,
+		Latency:    5 * time.Millisecond,
+		ClientIP:   clientIP,
+		Method:     http.MethodGet,
+		Path:       path,
+	}
+}

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -2069,7 +2069,8 @@ func disconnectMongoDatabases(ctx context.Context) {
 // par `main()` avant l'appel : un test qui n'exerce que le routage et les gardes
 // n'a pas besoin qu'elles soient prêtes, les handlers n'étant jamais atteints.
 func buildRouter() *gin.Engine {
-	router := gin.Default()
+	// Logger à IP tronquée plutôt que gin.Default() (#385).
+	router := newRouterEngine()
 	hardenClientIPResolution(router)
 
 	publicLimiter := middleware.NewWindowLimiter(300, time.Minute)

--- a/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
@@ -21,7 +21,8 @@ struct PrivacyPolicyView: View {
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM3", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM4", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM5", comment: ""),
-                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM6", comment: "")
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM6", comment: ""),
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM7", comment: "")
                 ],
                 themeManager: themeManager
             )
@@ -56,7 +57,8 @@ struct PrivacyPolicyView: View {
                 icon: "archivebox",
                 items: [
                     NSLocalizedString("PRIVACY_SECTION_RETENTION_ITEM1", comment: ""),
-                    NSLocalizedString("PRIVACY_SECTION_RETENTION_ITEM2", comment: "")
+                    NSLocalizedString("PRIVACY_SECTION_RETENTION_ITEM2", comment: ""),
+                    NSLocalizedString("PRIVACY_SECTION_RETENTION_ITEM3", comment: "")
                 ],
                 themeManager: themeManager
             )

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -245,6 +245,7 @@
 "PRIVACY_SECTION_DATA_ITEM4" = "Einwilligungen: Typ, Version, Serverdatum und begrenzte technische App-Informationen.";
 "PRIVACY_SECTION_DATA_ITEM5" = "Bleiben auf deinem Gerät: rohe Kamera- und LiDAR-Bilder, Bewegung und ARKit-Weltkarten. Ein Foto wird nur für Chat oder Diagnose hochgeladen.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Gesundheitsdiagnose & Assistent: Fotos, die du für eine Diagnose sendest, sowie deine Nachrichten werden an unsere Server und anschließend an Google (Gemini) zur Analyse übermittelt, auch außerhalb der Europäischen Union.";
+"PRIVACY_SECTION_DATA_ITEM7" = "Technische Protokolle: Deine IP-Adresse wird verarbeitet, um Missbrauch zu begrenzen und den Dienst abzusichern. Sie wird nie in der Datenbank gespeichert und erscheint in den Server-Protokollen nur gekürzt (zum Beispiel 92.184.105.x).";
 
 // Warum wir sie nutzen
 "PRIVACY_SECTION_USAGE_TITLE" = "Warum wir diese Daten nutzen";
@@ -265,6 +266,7 @@
 "PRIVACY_SECTION_RETENTION_TITLE" = "Aufbewahrung";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Dein Konto, dein Profil und deine Gärten werden aufbewahrt, solange dein Konto besteht.";
 "PRIVACY_SECTION_RETENTION_ITEM2" = "Das Löschen in der App entfernt Firebase-Konto, Profil, Gärten, Einwilligungen, lokalen Chatverlauf und zugehörige frühere geteilte Inhalte.";
+"PRIVACY_SECTION_RETENTION_ITEM3" = "Die technischen Server-Protokolle, die nur gekürzte IP-Adressen enthalten, werden automatisch rotiert: die ältesten werden überschrieben, nichts wird archiviert.";
 
 // Weitergabe
 "PRIVACY_SECTION_SHARING_TITLE" = "Weitergabe & Empfänger";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -264,6 +264,7 @@
 "PRIVACY_SECTION_DATA_ITEM4" = "Consent records: type, version, server date and limited technical app information.";
 "PRIVACY_SECTION_DATA_ITEM5" = "Kept on your device: raw camera and LiDAR images, motion data and ARKit world maps. A photo is uploaded only when you add it to chat or plant diagnosis.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Health diagnosis & assistant: photos you submit for a diagnosis, and your messages, are sent to our servers and then to Google (Gemini) for analysis, including outside the European Union.";
+"PRIVACY_SECTION_DATA_ITEM7" = "Technical logs: your IP address is processed to limit abuse and keep the service secure. It is never stored in the database, and only appears in server logs in truncated form (for example 92.184.105.x).";
 
 // Why we use it
 "PRIVACY_SECTION_USAGE_TITLE" = "Why we use this data";
@@ -284,6 +285,7 @@
 "PRIVACY_SECTION_RETENTION_TITLE" = "Retention";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Your account, profile and gardens are kept while your account exists.";
 "PRIVACY_SECTION_RETENTION_ITEM2" = "Deleting from the app erases the Firebase account, profile, gardens, consents, local chat history and any associated legacy shared content.";
+"PRIVACY_SECTION_RETENTION_ITEM3" = "Server technical logs, which contain only truncated IP addresses, are rotated automatically: the oldest are overwritten and nothing is archived.";
 
 // Sharing
 "PRIVACY_SECTION_SHARING_TITLE" = "Sharing & recipients";

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -245,6 +245,7 @@
 "PRIVACY_SECTION_DATA_ITEM4" = "Consentimientos: tipo, versión, fecha del servidor e información técnica limitada de la app.";
 "PRIVACY_SECTION_DATA_ITEM5" = "Permanecen en tu dispositivo: imágenes brutas de cámara y LiDAR, movimiento y mapas ARKit. Solo se envía una foto si la añades al chat o al diagnóstico.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Diagnóstico de salud y asistente: las fotos que envías para un diagnóstico, así como tus mensajes, se transmiten a nuestros servidores y luego a Google (Gemini) para su análisis, incluso fuera de la Unión Europea.";
+"PRIVACY_SECTION_DATA_ITEM7" = "Registros técnicos: tu dirección IP se trata para limitar los abusos y proteger el servicio. Nunca se guarda en la base de datos y solo aparece truncada en los registros del servidor (por ejemplo 92.184.105.x).";
 
 // Por qué los usamos
 "PRIVACY_SECTION_USAGE_TITLE" = "Por qué usamos estos datos";
@@ -265,6 +266,7 @@
 "PRIVACY_SECTION_RETENTION_TITLE" = "Conservación";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Tu cuenta, tu perfil y tus jardines se conservan mientras exista tu cuenta.";
 "PRIVACY_SECTION_RETENTION_ITEM2" = "Eliminar desde la app borra la cuenta Firebase, el perfil, los jardines, los consentimientos, el chat local y cualquier contenido compartido antiguo asociado.";
+"PRIVACY_SECTION_RETENTION_ITEM3" = "Los registros técnicos del servidor, que solo contienen direcciones IP truncadas, se rotan automáticamente: los más antiguos se sobrescriben y no se archiva nada.";
 
 // Compartición
 "PRIVACY_SECTION_SHARING_TITLE" = "Comparticion y destinatarios";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -264,6 +264,7 @@
 "PRIVACY_SECTION_DATA_ITEM4" = "Consentements : type, version, date serveur et informations techniques limitées de l’application.";
 "PRIVACY_SECTION_DATA_ITEM5" = "Restent sur ton appareil : images brutes de la caméra et du LiDAR, mouvement et cartes spatiales ARKit. Une photo n’est envoyée que si tu l’ajoutes au chatbot ou au diagnostic.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Diagnostic santé & assistant : les photos que tu envoies pour un diagnostic, ainsi que tes messages, sont transmis à nos serveurs puis à Google (Gemini) pour être analysés, y compris hors de l'Union européenne.";
+"PRIVACY_SECTION_DATA_ITEM7" = "Journaux techniques : ton adresse IP est traitée pour limiter les abus et sécuriser le service. Elle n’est jamais enregistrée en base, et n’apparaît dans les journaux serveur que tronquée (par exemple 92.184.105.x).";
 
 // Pourquoi nous les utilisons
 "PRIVACY_SECTION_USAGE_TITLE" = "Pourquoi nous utilisons ces données";
@@ -284,6 +285,7 @@
 "PRIVACY_SECTION_RETENTION_TITLE" = "Conservation";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Ton compte, ton profil et tes jardins sont conservés tant que ton compte existe.";
 "PRIVACY_SECTION_RETENTION_ITEM2" = "La suppression depuis l’app efface le compte Firebase, le profil, les jardins, les consentements, l’historique local du chatbot et tout ancien contenu partagé associé.";
+"PRIVACY_SECTION_RETENTION_ITEM3" = "Les journaux techniques du serveur, qui ne contiennent que des adresses IP tronquées, font l’objet d’une rotation automatique : les plus anciens sont écrasés et rien n’est archivé.";
 
 // Partage
 "PRIVACY_SECTION_SHARING_TITLE" = "Partage & destinataires";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,17 @@ services:
       dockerfile: Dockerfile
     container_name: arbore-ai-generator
     restart: unless-stopped
+    # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
+    # limite : les journaux d'accès contiennent des adresses IP (tronquées
+    # depuis #385, mais des données personnelles tout de même) et seraient
+    # conservés indéfiniment, faute de politique de conservation — contraire au
+    # principe de limitation de la conservation (RGPD art. 5(1)(e)).
+    # 3 fichiers de 10 Mo = fenêtre glissante bornée, les plus anciens écrasés.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     init: true
     read_only: true
     mem_limit: 1g
@@ -49,6 +60,17 @@ services:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
     container_name: arbore-backend
     restart: unless-stopped
+    # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
+    # limite : les journaux d'accès contiennent des adresses IP (tronquées
+    # depuis #385, mais des données personnelles tout de même) et seraient
+    # conservés indéfiniment, faute de politique de conservation — contraire au
+    # principe de limitation de la conservation (RGPD art. 5(1)(e)).
+    # 3 fichiers de 10 Mo = fenêtre glissante bornée, les plus anciens écrasés.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     init: true
     read_only: true
     mem_limit: 1g
@@ -132,6 +154,17 @@ services:
       dockerfile: Dockerfile
     container_name: arbore-web
     restart: unless-stopped
+    # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
+    # limite : les journaux d'accès contiennent des adresses IP (tronquées
+    # depuis #385, mais des données personnelles tout de même) et seraient
+    # conservés indéfiniment, faute de politique de conservation — contraire au
+    # principe de limitation de la conservation (RGPD art. 5(1)(e)).
+    # 3 fichiers de 10 Mo = fenêtre glissante bornée, les plus anciens écrasés.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     init: true
     read_only: true
     mem_limit: 768m


### PR DESCRIPTION
## 📝 Description

Traite les trois correctifs de #385. Question soulevée en préparant l'activation de l'accès invité : **« anonyme » au sens de Firebase n'est pas « anonyme » au sens du RGPD**. L'auth anonyme produit un identifiant pseudonyme stable, pas un anonymat irréversible (considérant 26), et l'IP est une donnée personnelle depuis l'arrêt CJUE *Breyer* (C-582/14). Le règlement s'applique donc pleinement aux sessions invité.

La base légale était déjà bonne et la minimisation aussi. **Le trou était la conservation.**

### Ce qui était déjà conforme

- `POST /consents` **efface l'IP** avant enregistrement (`main.go:892`), délibérément
- Le rate limiter ne l'utilise qu'**en mémoire**, purgée à l'expiration de la fenêtre
- La finalité est déclarée (`PRIVACY_SECTION_USAGE_ITEM3`) sur la base des intérêts légitimes (`PRIVACY_SECTION_LEGAL_ITEM2`) — art. 6(1)(f), considérant 49

### 1. Journal applicatif — IP tronquée

`gin.Default()` écrivait `ClientIP()` sur stdout. Comme `hardenClientIPResolution` fixe `TrustedPlatform = "X-Real-IP"`, c'était **l'adresse réelle de l'utilisateur final** pour tout trafic passant par nginx.

Remplacé par `newRouterEngine()` — même composition que `gin.Default()` (Logger + **Recovery conservé**) avec un formateur qui ne journalise que le préfixe réseau :

| Entrée | Journalisé |
|---|---|
| `92.184.105.42` | `92.184.105.x` |
| `2a01:e0a:1b2:c3d4::1` | `2a01:e0a:1b2:x` (préfixe /48) |
| valeur non parsable | `-` |

Le /48 IPv6 est l'équivalent usuel du /24 IPv4 : c'est en général le bloc alloué à un abonné. Une valeur non parsable vient forcément d'un en-tête manipulable, elle n'est pas recopiée telle quelle.

Le rate limiting continue d'utiliser l'IP **complète**, mais uniquement en mémoire : rien n'en est persisté, et c'est ce qui préserve son efficacité.

### 2. Conservation — rotation Docker

Aucune rotation n'était configurée : pas de section `logging:` dans `docker-compose.yml`, pas de `/etc/docker/daemon.json` sur le VPS. Le driver `json-file` croissait sans limite, et les journaux ne disparaissaient qu'à la recréation d'un conteneur — un effet de bord, pas une politique. Avant le déploiement de ce matin, `web` et `ai-generator` tournaient **depuis 5 semaines**.

`max-size: 10m` / `max-file: 3` sur les trois services : fenêtre glissante bornée et démontrable, conforme à l'art. 5(1)(e).

### 3. Politique de confidentialité

Deux entrées ajoutées **dans les 4 langues** : le traitement de l'IP et sa troncature côté données collectées, la rotation des journaux côté conservation. Parité vérifiée par `check-translations.sh` (1559 clés partout).

## 🎯 Type de changement

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## 🔗 Issue liée

Closes #385

## ⚠️ Action requise hors de ce dépôt

**`Arbore_SiteVitrine` (arbore.app/privacy, FR + EN) doit recevoir la même modification.** Les deux textes doivent rester cohérents : la politique publiée sur le site fait foi, celle de l'app la reflète. Je ne peux pas la modifier depuis ce dépôt.

## ✅ Checklist

- [x] Mon code suit les conventions du projet
- [x] J'ai effectué une auto-revue de mon code
- [x] J'ai commenté mon code, notamment dans les zones difficiles
- [x] J'ai mis à jour la documentation si nécessaire
- [x] Mes changements ne génèrent pas de nouveaux warnings
- [x] J'ai ajouté des tests
- [x] Les tests unitaires passent localement

## 🧪 Tests effectués

4 tests ajoutés, dont celui qui compte : **la ligne de journal produite ne contient jamais l'adresse complète**, vérifié en IPv4 et en IPv6 sur le vrai formateur.

`go vet`, suite complète, `golangci-lint` (0 issue) et `check-translations.sh` verts.

## 🚀 Composants affectés

- [x] Backend (Go)
- [x] iOS UI (Swift/SwiftUI)
- [x] CI/CD
- [x] Documentation
