### PR TITLE
fix(backend): exclure /health du journal d'accès

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,7 @@ linters:
         - conflit
         - appareil
         - correspondant
+        - continuent
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/httplogging.go
+++ b/ArboreBackend/httplogging.go
@@ -66,6 +66,20 @@ func privacyPreservingLogFormatter(p gin.LogFormatterParams) string {
 	)
 }
 
+// accessLogSkippedPaths liste les routes exclues du journal d'accès (issue #388).
+//
+// Mesuré en production le 2026-09-02 : `/health` représentait 233 des 244
+// lignes du journal, soit 95 %. Le healthcheck Docker interroge la route en
+// continu, ce qui noie le trafic réel — les 429 du rate limiter, les 5xx — dans
+// un bruit sans valeur d'analyse.
+//
+// À taille de fenêtre de rotation égale, cette exclusion multiplie par ~20 la
+// profondeur d'historique réellement exploitable.
+//
+// Seul le journal d'ACCÈS est concerné : `Recovery()` et les erreurs
+// applicatives continuent d'écrire sur stdout quelle que soit la route.
+var accessLogSkippedPaths = []string{"/health"}
+
 // newRouterEngine remplace `gin.Default()`.
 //
 // `gin.Default()` = `gin.New()` + `Logger()` + `Recovery()`. On reconstruit la
@@ -74,7 +88,10 @@ func privacyPreservingLogFormatter(p gin.LogFormatterParams) string {
 // panic de handler en connexion coupée sans réponse.
 func newRouterEngine() *gin.Engine {
 	engine := gin.New()
-	engine.Use(gin.LoggerWithFormatter(privacyPreservingLogFormatter))
+	engine.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		Formatter: privacyPreservingLogFormatter,
+		SkipPaths: accessLogSkippedPaths,
+	}))
 	engine.Use(gin.Recovery())
 	return engine
 }

--- a/ArboreBackend/httplogging_test.go
+++ b/ArboreBackend/httplogging_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -70,4 +72,37 @@ func ginLogParams(clientIP, path string) gin.LogFormatterParams {
 		Method:     http.MethodGet,
 		Path:       path,
 	}
+}
+
+// ─── #388 — /health exclu du journal d'accès ────────────────────────────────
+
+// Mesuré en prod : 95 % des lignes du journal étaient des healthchecks. Les
+// exclure préserve la profondeur d'historique pour le trafic qui a une valeur
+// d'analyse.
+func TestAccessLogSkipsHealthButNothingElse(t *testing.T) {
+	assert.Contains(t, accessLogSkippedPaths, "/health")
+	assert.Len(t, accessLogSkippedPaths, 1,
+		"n'exclure que le healthcheck : toute autre route exclue serait un angle mort d'analyse")
+}
+
+// Vérifie le comportement réel du routeur, pas seulement la constante : une
+// requête sur /health ne doit produire aucune ligne, une requête ordinaire si.
+func TestRouterEngineOmitsHealthFromAccessLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var logged bytes.Buffer
+	previous := gin.DefaultWriter
+	gin.DefaultWriter = &logged
+	defer func() { gin.DefaultWriter = previous }()
+
+	engine := newRouterEngine()
+	engine.GET("/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+	engine.GET("/plants", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/health", nil))
+	assert.Empty(t, logged.String(), "/health ne doit produire aucune ligne de journal d'accès")
+
+	engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/plants", nil))
+	assert.Contains(t, logged.String(), "/plants",
+		"le trafic ordinaire doit rester journalisé")
 }


### PR DESCRIPTION
## 📝 Description

Point 1 de #388. Mesuré en production le 2026-09-02 :

```
lignes GIN totales : 244
dont "/health"     : 233   (95 %)
débit backend      : ~500 Ko/jour → fenêtre de 30 Mo ≈ 60 jours
```

Le healthcheck Docker noie le trafic qui a une valeur d'analyse — les 429 du rate limiter, les 5xx — dans un bruit inexploitable. À taille de fenêtre égale, l'exclusion multiplie par ~20 la profondeur d'historique utile.

**Seul le journal d'accès est concerné.** `Recovery()` et les erreurs applicatives continuent d'écrire sur stdout quelle que soit la route : on ne perd aucune trace de crash.

## 🎯 Type de changement

- [x] 🐛 Bug fix

## 🔗 Issue liée

Refs #388 (point 1 sur 2 ; le point 2, Sentry sur le backend Go, reste ouvert)

## 🧪 Tests effectués

**CI volontairement sautée sur autorisation explicite** (trafic de test nul, vérification faite directement en production après déploiement). Vérification locale complète en substitut :

```
go vet ./...                                    ✅
go test ./... -race                             ✅
golangci-lint run ./...                         0 issues
GOTOOLCHAIN=go1.25.14 govulncheck ./...         0 vulnérabilité appelée
```

2 tests ajoutés, dont un qui exerce le **routeur réel** plutôt que la constante : une requête sur `/health` ne produit aucune ligne, une requête sur `/plants` en produit une.

## 🚀 Composants affectés

- [x] Backend (Go)
- [x] CI/CD