### PR TITLE
feat(ios): lever le gate invité sur la création de jardin

### DIFF
--- a/ArboreUi/ArboreUi/LoginAuth/LocalDataOwnership.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/LocalDataOwnership.swift
@@ -75,9 +75,26 @@ enum LocalDataOwnership {
 
     /// Attribue un identifiant à la session courante.
     ///
-    /// Sans effet en session anonyme : voir `currentSessionIsAnonymous`.
+    /// **Les invités sont admis ici, contrairement à la migration.** La
+    /// distinction est essentielle et vaut d'être explicitée :
+    ///
+    ///   - `claim` est appelée à la **création** du contenu. L'invité en est
+    ///     l'auteur, il n'y a personne à qui le cacher. Le lui refuser le
+    ///     rendrait invisible à ses propres yeux dès le rafraîchissement
+    ///     suivant, puisque `isVisibleInCurrentSession` masque tout contenu
+    ///     sans propriétaire en session anonyme.
+    ///   - La migration, elle, attribue un contenu **préexistant** dont
+    ///     l'auteur est inconnu. Un invité ne doit jamais se l'approprier :
+    ///     l'uid anonyme est purgé par Firebase au bout de 30 jours, ce qui
+    ///     rendrait le jardin définitivement invisible à son véritable auteur.
+    ///     C'est `isVisibleInCurrentSession` qui l'interdit, en sortant avant
+    ///     d'appeler `claim`.
+    ///
+    /// Conséquence assumée : le jardin d'un invité disparaît avec son compte
+    /// anonyme. C'est cohérent avec le fait qu'un invité qui crée un compte
+    /// repart de zéro tant que `linkWithCredential` n'existe pas (#391).
     static func claim(_ identifier: String) {
-        guard let uid = currentUID, !currentSessionIsAnonymous else { return }
+        guard let uid = currentUID else { return }
         var table = load()
         guard table[identifier] != uid else { return }
         table[identifier] = uid

--- a/ArboreUi/ArboreUi/Views/HomeView.swift
+++ b/ArboreUi/ArboreUi/Views/HomeView.swift
@@ -5,8 +5,6 @@ struct HomeView: View {
     @State private var gardens: [GardenDTO] = []
     @State private var goToQuestionnaire = false
     @State private var goToAllGardens = false
-    /// #391 — invitation à créer un compte, pour les actions fermées aux invités.
-    @State private var showAccountRequired = false
     @State private var showChat = false
     @EnvironmentObject var themeManager: ThemeManager
 
@@ -47,9 +45,6 @@ struct HomeView: View {
             .navigationBarHidden(true)
             .onAppear {
                 Task { await fetchGardens() }
-            }
-            .accountRequiredAlert(isPresented: $showAccountRequired) {
-                GuestSession.exitToAuthentication()
             }
             .fullScreenCover(item: $gardenToOpen) { g in
                 GardenARPlacementView(
@@ -178,15 +173,17 @@ private extension HomeView {
             }
 
             Button {
-                // #391 — gate EN AMONT plutôt qu'un 403 en fin de parcours.
-                // Le wizard pré-crée le jardin en base à l'étape scan : pour un
-                // invité, l'échec arriverait après le questionnaire ET le tracé
-                // AR du périmètre, soit plusieurs minutes de travail perdues.
-                if GuestSession.isGuest {
-                    showAccountRequired = true
-                } else {
-                    goToQuestionnaire = true
-                }
+                // #393 — le gate invité est levé. Il existait parce que le
+                // wizard pré-crée le jardin en base à l'étape scan et que
+                // `POST /gardens` répondait alors 403 à un invité : l'échec
+                // serait tombé après le questionnaire ET le tracé AR du
+                // périmètre, soit plusieurs minutes perdues.
+                //
+                // La route est désormais ouverte aux sessions anonymes, le
+                // parcours aboutit donc. Un invité qui crée ensuite un compte
+                // repart en revanche de zéro, `linkWithCredential` n'existant
+                // pas encore (#391, section 4).
+                goToQuestionnaire = true
             } label: {
                 HStack(spacing: 10) {
                     Text(L10n.t("COMMON_START"))


### PR DESCRIPTION
Dernière pièce de #393 côté iOS. Le backend est déployé (`db00308`) : `/gardens` accepte les sessions anonymes, le gate client n'a plus de raison d'être.

## Le gate

`HomeView` bloquait l'invité **avant** le questionnaire. Ce n'était pas de la prudence excessive : le wizard pré-crée le jardin en base à l'étape scan, donc un 403 serait tombé après le questionnaire **et** le tracé AR du périmètre — plusieurs minutes de travail perdues. La route étant ouverte, le parcours aboutit.

## Le correctif qui n'était pas optionnel

Lever le gate seul aurait produit **un invité incapable de voir son propre jardin**.

`claim()` refusait les sessions anonymes. À la création, la scène était écrite sans propriétaire ; au rafraîchissement suivant `isVisibleInCurrentSession` masque tout contenu sans propriétaire en session anonyme. Le jardin disparaissait à l'instant même où il venait d'être créé.

`claim()` admet désormais les invités. La distinction avec la migration est le point important :

| | Qui l'appelle | Invité admis ? |
|---|---|---|
| `claim` explicite | à la **création** du contenu | ✅ l'invité en est l'auteur, personne à qui le cacher |
| `claim` implicite | migration d'un contenu **préexistant** d'auteur inconnu | ❌ l'uid anonyme est purgé à 30 jours, le jardin deviendrait invisible à son véritable auteur |

L'avertissement de #394 est préservé là où il a un sens, levé là où il n'en avait pas. `isVisibleInCurrentSession` sort avant d'appeler `claim` pour une session anonyme — la garde tient toujours.

## Ce que cela coûte, assumé

Le jardin d'un invité disparaît avec sa session anonyme, et ses fichiers locaux restent sur le disque sans propriétaire atteignable. Décision prise en connaissance de cause : tant que `linkWithCredential` n'existe pas (#391 §4), un invité qui crée un compte repart de zéro.

⚠️ **Aucun avertissement n'est affiché à l'utilisateur.** Premier point à reprendre si la beta publique montre que la perte surprend.

## Vérifications

- `BUILD SUCCEEDED`
- `LocalDataOwnershipTests` + `GuestAccessTests` : `TEST SUCCEEDED`

Non couvert : aucun test ne vérifie qu'un invité voit le jardin qu'il vient de créer. `LocalDataOwnership` lit `Auth.auth().currentUser` par des propriétés statiques non doublables — c'est le prérequis d'injectabilité déjà consigné dans #394. La vérification est manuelle, sur un build TestFlight.

## Suite

Le build 26 n'a pas ce changement ; un nouveau build est nécessaire pour que les testeurs en voient l'effet.

Refs #393, #391