### PR TITLE
fix(ops): donner au job de réconciliation l'accès au socket docker

### DIFF
--- a/ArboreBackend/scripts/reconcile-guests.sh
+++ b/ArboreBackend/scripts/reconcile-guests.sh
@@ -43,9 +43,24 @@ if ! command -v docker > /dev/null 2>&1; then
     exit 2
 fi
 
+# Préfixe de privilège, sur le motif de deploy.sh : sur le VPS l'utilisateur
+# `fedora` n'est pas dans le groupe `docker`, et le cron tourne sous cet
+# utilisateur. Sans ce préfixe le job échouerait chaque semaine sur un
+# « permission denied » du socket. Détecté plutôt que codé en dur, pour rester
+# utilisable sur une machine où docker tourne sans privilège.
+DOCKER_PRIVILEGE=()
+if ! docker info > /dev/null 2>&1; then
+    if sudo -n docker info > /dev/null 2>&1; then
+        DOCKER_PRIVILEGE=( sudo )
+    else
+        echo "[reconcile-guests] socket docker inaccessible, y compris via sudo" >&2
+        exit 5
+    fi
+fi
+
 # Le conteneur doit tourner : `docker exec` sur un conteneur arrêté échouerait
 # avec un message peu lisible dans un journal de cron.
-if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2> /dev/null)" != "true" ]]; then
+if [[ "$("${DOCKER_PRIVILEGE[@]}" docker inspect -f '{{.State.Running}}' "$CONTAINER" 2> /dev/null)" != "true" ]]; then
     echo "[reconcile-guests] conteneur '$CONTAINER' absent ou arrêté" >&2
     exit 3
 fi
@@ -59,6 +74,6 @@ printf '[reconcile-guests] %s UTC — démarrage (%s)\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MODE"
 
 # Pas de -t : sortie non interactive, adaptée à la redirection cron.
-docker exec -i "$CONTAINER" /app/main -reconcile-guests ${APPLY:+"$APPLY"}
+"${DOCKER_PRIVILEGE[@]}" docker exec -i "$CONTAINER" /app/main -reconcile-guests ${APPLY:+"$APPLY"}
 
 printf '[reconcile-guests] %s UTC — terminé\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
Le script `reconcile-guests.sh` appelait `docker` sans privilège. Sur le VPS, l'utilisateur `fedora` n'est pas membre du groupe `docker` — et c'est sous cet utilisateur que tourne le cron.

**L'entrée hebdomadaire aurait donc échoué chaque semaine sur un « permission denied » du socket**, sans que personne ne s'en aperçoive avant de lire le journal. Un job de purge silencieusement mort est pire qu'un job absent : on croit la conservation des données bornée alors qu'elle ne l'est pas.

Repéré en préparant le premier passage en simulation, qui a dû être lancé par un `sudo docker exec` direct.

## Le correctif

Préfixe de privilège sur le motif de `deploy.sh`, mais **détecté plutôt que codé en dur** :

```bash
DOCKER_PRIVILEGE=()
if ! docker info > /dev/null 2>&1; then
    if sudo -n docker info > /dev/null 2>&1; then
        DOCKER_PRIVILEGE=( sudo )
    else
        echo "[reconcile-guests] socket docker inaccessible, y compris via sudo" >&2
        exit 5
    fi
fi
```

Le script reste ainsi utilisable sur une machine où docker tourne sans privilège, et échoue avec un message lisible plutôt qu'un refus de socket brut.

## Premier passage en production, déjà effectué

Le job a tourné manuellement sur le VPS pendant la préparation de ce correctif :

| | Firebase | uid Mongo | orphelins | épargnés (grâce) |
|---|---|---|---|---|
| simulation | 254 | 28 | 2 | 0 |
| `--apply` | 254 | 28 | 2 | 0 |
| contrôle | 254 | 26 | **0** | 0 |

Supprimés : 2 jardins, 2 documents utilisateur, 0 consentement. Snapshot Mongo du 2026-09-03T17-19-19Z en couverture. Le second passage confirme l'idempotence.

Refs #393