### PR TITLE
release: levée du gate invité et accès docker du job de réconciliation

### DIFF
--- a/ArboreBackend/scripts/reconcile-guests.sh
+++ b/ArboreBackend/scripts/reconcile-guests.sh
@@ -43,9 +43,24 @@ if ! command -v docker > /dev/null 2>&1; then
     exit 2
 fi
 
+# Préfixe de privilège, sur le motif de deploy.sh : sur le VPS l'utilisateur
+# `fedora` n'est pas dans le groupe `docker`, et le cron tourne sous cet
+# utilisateur. Sans ce préfixe le job échouerait chaque semaine sur un
+# « permission denied » du socket. Détecté plutôt que codé en dur, pour rester
+# utilisable sur une machine où docker tourne sans privilège.
+DOCKER_PRIVILEGE=()
+if ! docker info > /dev/null 2>&1; then
+    if sudo -n docker info > /dev/null 2>&1; then
+        DOCKER_PRIVILEGE=( sudo )
+    else
+        echo "[reconcile-guests] socket docker inaccessible, y compris via sudo" >&2
+        exit 5
+    fi
+fi
+
 # Le conteneur doit tourner : `docker exec` sur un conteneur arrêté échouerait
 # avec un message peu lisible dans un journal de cron.
-if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2> /dev/null)" != "true" ]]; then
+if [[ "$("${DOCKER_PRIVILEGE[@]}" docker inspect -f '{{.State.Running}}' "$CONTAINER" 2> /dev/null)" != "true" ]]; then
     echo "[reconcile-guests] conteneur '$CONTAINER' absent ou arrêté" >&2
     exit 3
 fi
@@ -59,6 +74,6 @@ printf '[reconcile-guests] %s UTC — démarrage (%s)\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MODE"
 
 # Pas de -t : sortie non interactive, adaptée à la redirection cron.
-docker exec -i "$CONTAINER" /app/main -reconcile-guests ${APPLY:+"$APPLY"}
+"${DOCKER_PRIVILEGE[@]}" docker exec -i "$CONTAINER" /app/main -reconcile-guests ${APPLY:+"$APPLY"}
 
 printf '[reconcile-guests] %s UTC — terminé\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/ArboreUi/ArboreUi/LoginAuth/LocalDataOwnership.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/LocalDataOwnership.swift
@@ -75,9 +75,26 @@ enum LocalDataOwnership {
 
     /// Attribue un identifiant à la session courante.
     ///
-    /// Sans effet en session anonyme : voir `currentSessionIsAnonymous`.
+    /// **Les invités sont admis ici, contrairement à la migration.** La
+    /// distinction est essentielle et vaut d'être explicitée :
+    ///
+    ///   - `claim` est appelée à la **création** du contenu. L'invité en est
+    ///     l'auteur, il n'y a personne à qui le cacher. Le lui refuser le
+    ///     rendrait invisible à ses propres yeux dès le rafraîchissement
+    ///     suivant, puisque `isVisibleInCurrentSession` masque tout contenu
+    ///     sans propriétaire en session anonyme.
+    ///   - La migration, elle, attribue un contenu **préexistant** dont
+    ///     l'auteur est inconnu. Un invité ne doit jamais se l'approprier :
+    ///     l'uid anonyme est purgé par Firebase au bout de 30 jours, ce qui
+    ///     rendrait le jardin définitivement invisible à son véritable auteur.
+    ///     C'est `isVisibleInCurrentSession` qui l'interdit, en sortant avant
+    ///     d'appeler `claim`.
+    ///
+    /// Conséquence assumée : le jardin d'un invité disparaît avec son compte
+    /// anonyme. C'est cohérent avec le fait qu'un invité qui crée un compte
+    /// repart de zéro tant que `linkWithCredential` n'existe pas (#391).
     static func claim(_ identifier: String) {
-        guard let uid = currentUID, !currentSessionIsAnonymous else { return }
+        guard let uid = currentUID else { return }
         var table = load()
         guard table[identifier] != uid else { return }
         table[identifier] = uid

--- a/ArboreUi/ArboreUi/Views/HomeView.swift
+++ b/ArboreUi/ArboreUi/Views/HomeView.swift
@@ -5,8 +5,6 @@ struct HomeView: View {
     @State private var gardens: [GardenDTO] = []
     @State private var goToQuestionnaire = false
     @State private var goToAllGardens = false
-    /// #391 — invitation à créer un compte, pour les actions fermées aux invités.
-    @State private var showAccountRequired = false
     @State private var showChat = false
     @EnvironmentObject var themeManager: ThemeManager
 
@@ -47,9 +45,6 @@ struct HomeView: View {
             .navigationBarHidden(true)
             .onAppear {
                 Task { await fetchGardens() }
-            }
-            .accountRequiredAlert(isPresented: $showAccountRequired) {
-                GuestSession.exitToAuthentication()
             }
             .fullScreenCover(item: $gardenToOpen) { g in
                 GardenARPlacementView(
@@ -178,15 +173,17 @@ private extension HomeView {
             }
 
             Button {
-                // #391 — gate EN AMONT plutôt qu'un 403 en fin de parcours.
-                // Le wizard pré-crée le jardin en base à l'étape scan : pour un
-                // invité, l'échec arriverait après le questionnaire ET le tracé
-                // AR du périmètre, soit plusieurs minutes de travail perdues.
-                if GuestSession.isGuest {
-                    showAccountRequired = true
-                } else {
-                    goToQuestionnaire = true
-                }
+                // #393 — le gate invité est levé. Il existait parce que le
+                // wizard pré-crée le jardin en base à l'étape scan et que
+                // `POST /gardens` répondait alors 403 à un invité : l'échec
+                // serait tombé après le questionnaire ET le tracé AR du
+                // périmètre, soit plusieurs minutes perdues.
+                //
+                // La route est désormais ouverte aux sessions anonymes, le
+                // parcours aboutit donc. Un invité qui crée ensuite un compte
+                // repart en revanche de zéro, `linkWithCredential` n'existant
+                // pas encore (#391, section 4).
+                goToQuestionnaire = true
             } label: {
                 HStack(spacing: 10) {
                     Text(L10n.t("COMMON_START"))


### PR DESCRIPTION
Promotion `dev` → `main` pour déploiement. Deux changements.

## iOS — levée du gate invité (#393, #391)

`/gardens` étant ouvert aux sessions anonymes depuis le déploiement précédent, le gate client de `HomeView` n'a plus lieu d'être. Un invité peut désormais aller au bout du parcours de création.

Le correctif qui l'accompagnait n'était pas optionnel : `claim()` refusait les sessions anonymes, si bien qu'un invité n'aurait pas vu le jardin qu'il venait de créer — la scène était écrite sans propriétaire, et `isVisibleInCurrentSession` masque tout contenu sans propriétaire en session anonyme. `claim()` admet maintenant les invités à la **création**, la migration d'un contenu préexistant leur restant interdite.

Déjà livré aux testeurs en **build 27** sur TestFlight.

## Ops — accès docker du job de réconciliation (#393)

Le script appelait `docker` sans privilège alors que l'utilisateur `fedora` n'est pas dans le groupe `docker`. **Le cron hebdomadaire aurait échoué chaque semaine en silence.** Préfixe détecté plutôt que codé en dur.

Ce déploiement est le prérequis à l'installation du cron.

## Premier passage du job, déjà effectué en production

| | Firebase | uid Mongo | orphelins |
|---|---|---|---|
| simulation | 254 | 28 | 2 |
| `--apply` | 254 | 28 | 2 |
| contrôle | 254 | 26 | **0** |

Supprimés : 2 jardins, 2 documents utilisateur. Snapshot `2026-09-03T17-19-19Z` en couverture.

## Suite

Installation de l'entrée cron hebdomadaire après ce déploiement. Anomalies de données relevées au passage : #398.