### PR TITLE
release: configuration système déclarative

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -42,7 +42,7 @@ SNAPSHOT_RETENTION_DAYS=14
 DOCKER_PRIVILEGE=( sudo )
 DOCKER_COMPOSE=( "${DOCKER_PRIVILEGE[@]}" docker compose )
 
-step() { printf '%b[%s/6]%b %s\n' "$YELLOW" "$1" "$NC" "$2"; }
+step() { printf '%b[%s/7]%b %s\n' "$YELLOW" "$1" "$NC" "$2"; }
 ok()   { printf '%b✅ %s%b\n' "$GREEN" "$1" "$NC"; }
 fail() { printf '%b❌ %s%b\n' "$RED" "$1" "$NC" >&2; }
 warn() { printf '%b⚠️  %s%b\n' "$YELLOW" "$1" "$NC"; }
@@ -72,7 +72,7 @@ require_prereqs() {
     [ "$missing" -eq 0 ] || exit 3
 }
 
-# ───── [1/6] Git pull ─────────────────────────────────────────────
+# ───── [1/7] Git pull ─────────────────────────────────────────────
 #
 # Données hors bande : fichiers que git suit encore (ils ont été committés avant
 # que la règle `.gitignore` n'existe) mais qui sont en réalité gérés directement
@@ -154,7 +154,96 @@ do_git_pull() {
     echo
 }
 
-# ───── [2/6] Pre-deploy DB snapshot ───────────────────────────────
+# ───── [2/7] Configuration système déclarative ────────────────────
+#
+# `ops/` est la source de vérité de tout ce qui vit hors des conteneurs :
+# entrées cron, unités systemd, scripts privilégiés. Cette étape les
+# applique à CHAQUE déploiement, de façon idempotente.
+#
+# Pourquoi : ces éléments étaient auparavant posés à la main en suivant un
+# runbook, donc invisibles au dépôt et impossibles à vérifier. La doc a
+# dérivé sans que personne ne le voie — elle a décrit un seul cron pendant
+# des mois alors que la machine en avait deux (#393, #400, #401).
+#
+# Conséquence assumée : une modification faite à la main sur la machine est
+# ÉCRASÉE au déploiement suivant. C'est le comportement voulu — le dépôt
+# fait autorité.
+do_apply_ops() {
+    step 2 "Configuration système (ops/)..."
+
+    if [ ! -d "$SCRIPT_DIR/ops" ]; then
+        warn "ops/ absent — étape ignorée (checkout antérieur à #401 ?)"
+        echo
+        return 0
+    fi
+
+    # --- Crontab ---
+    # `__ARBORE_ROOT__` rend le fichier indépendant de l'emplacement du
+    # checkout, condition pour qu'un second environnement puisse l'utiliser.
+    if [ -f "$SCRIPT_DIR/ops/crontab" ]; then
+        local rendered previous
+        rendered="$(mktemp)"
+        sed "s|__ARBORE_ROOT__|$SCRIPT_DIR|g" "$SCRIPT_DIR/ops/crontab" > "$rendered"
+
+        previous="$(crontab -l 2>/dev/null || true)"
+        if [ "$previous" = "$(cat "$rendered")" ]; then
+            ok "Crontab déjà conforme"
+        else
+            # Sauvegarde avant écrasement : une entrée posée à la main serait
+            # perdue autrement, et on veut pouvoir la retrouver.
+            if [ -n "$previous" ]; then
+                printf '%s\n' "$previous" > "$SCRIPT_DIR/logs/crontab.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+            fi
+            crontab "$rendered"
+            ok "Crontab installé ($(grep -cE '^[^#]' "$rendered" | tr -d ' ') entrées)"
+        fi
+        rm -f "$rendered"
+    fi
+
+    # --- Scripts privilégiés + unités systemd ---
+    # Non bloquant : sans sudo, le déploiement applicatif doit continuer.
+    if ! sudo -n true 2>/dev/null; then
+        warn "sudo indisponible — systemd et /usr/local/sbin non appliqués"
+        echo
+        return 0
+    fi
+
+    local changed=0
+    for src in "$SCRIPT_DIR"/ops/sbin/*.sh; do
+        [ -e "$src" ] || continue
+        local dst="/usr/local/sbin/$(basename "$src")"
+        if ! sudo cmp -s "$src" "$dst" 2>/dev/null; then
+            sudo install -m 0755 "$src" "$dst"
+            changed=1
+        fi
+    done
+
+    local units_changed=0
+    for src in "$SCRIPT_DIR"/ops/systemd/*; do
+        [ -e "$src" ] || continue
+        local dst="/etc/systemd/system/$(basename "$src")"
+        if ! sudo cmp -s "$src" "$dst" 2>/dev/null; then
+            sudo install -m 0644 "$src" "$dst"
+            units_changed=1
+        fi
+    done
+
+    if [ "$units_changed" -eq 1 ]; then
+        sudo systemctl daemon-reload
+        for src in "$SCRIPT_DIR"/ops/systemd/*.service "$SCRIPT_DIR"/ops/systemd/*.timer; do
+            [ -e "$src" ] || continue
+            sudo systemctl enable "$(basename "$src")" > /dev/null 2>&1 || true
+        done
+        ok "Unités systemd mises à jour et activées"
+    elif [ "$changed" -eq 1 ]; then
+        ok "Scripts /usr/local/sbin mis à jour"
+    else
+        ok "systemd et scripts déjà conformes"
+    fi
+    echo
+}
+
+# ───── [3/7] Pre-deploy DB snapshot ───────────────────────────────
 #
 # Mongo Atlas M0 (tier gratuit) n'a pas de backup automatique. Ce
 # mongodump local sert de filet de sécurité juste avant tout redémarrage
@@ -164,7 +253,7 @@ do_git_pull() {
 # est déplacé dans backups/daily/. Si l'une des étapes échoue, on abort
 # pour ne pas déployer une nouvelle version sans filet.
 do_db_snapshot() {
-    step 2 "Pre-deploy DB snapshot..."
+    step 3 "Pre-deploy DB snapshot..."
 
     local mongo_uri
     mongo_uri="$(grep '^MONGODB_URI=' "$SCRIPT_DIR/.env" | sed 's/^MONGODB_URI=//' || true)"
@@ -210,11 +299,11 @@ do_db_snapshot() {
     echo
 }
 
-# ───── [3/6] Docker compose build ─────────────────────────────────
+# ───── [4/7] Docker compose build ─────────────────────────────────
 do_docker_build() {
     local git_sha
     git_sha="$(git rev-parse HEAD)"
-    step 3 "Docker compose build (commit ${git_sha:0:7})..."
+    step 4 "Docker compose build (commit ${git_sha:0:7})..."
     # GIT_COMMIT est injecté dans le binaire backend puis renvoyé par GET /health :
     # c'est ce qui rend une dérive prod ↔ main détectable d'un simple curl (#341).
     # L'assignation vient après DOCKER_PRIVILEGE, cf. le commentaire à sa définition.
@@ -226,9 +315,9 @@ do_docker_build() {
     echo
 }
 
-# ───── [4/6] Docker compose up ────────────────────────────────────
+# ───── [5/7] Docker compose up ────────────────────────────────────
 do_docker_up() {
-    step 4 "Redémarrage des containers..."
+    step 5 "Redémarrage des containers..."
     if ! "${DOCKER_COMPOSE[@]}" up -d backend ai-generator web; then
         fail "docker compose up a échoué"
         exit 1
@@ -237,15 +326,15 @@ do_docker_up() {
     echo
 }
 
-# ───── [5/6] Logs de démarrage ────────────────────────────────────
+# ───── [6/7] Logs de démarrage ────────────────────────────────────
 do_show_logs() {
-    step 5 "Logs de démarrage (10 dernières lignes)..."
+    step 6 "Logs de démarrage (10 dernières lignes)..."
     sleep 5
     "${DOCKER_COMPOSE[@]}" logs --tail 10 backend 2>&1 || true
     echo
 }
 
-# ───── [6/6] Health check ─────────────────────────────────────────
+# ───── [7/7] Health check ─────────────────────────────────────────
 #
 # Le backend expose /health en HTTP plain sur :8080 à ce stade
 # (cf. issue #121 pour la migration HTTPS). Le check est bloquant :
@@ -279,7 +368,7 @@ check_web() {
 }
 
 do_health_check() {
-    step 6 "Health check..."
+    step 7 "Health check..."
     local attempts=0
     local max_attempts=10
     local http_code=""
@@ -314,6 +403,7 @@ main() {
     banner
     require_prereqs
     do_git_pull
+    do_apply_ops
     do_db_snapshot
     do_docker_build
     do_docker_up

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -335,85 +335,61 @@ checkout cannot overwrite or delete them.
 
 ---
 
-## 9. Scheduled jobs (cron)
+## 9. Scheduled jobs and system configuration
 
-Three entries, all logged under `logs/`.
+> **Nothing to install by hand.** `deploy.sh` applies `ops/` on every deploy
+> (step 2/7): cron entries, systemd units, privileged scripts. A change made
+> directly on the machine is **overwritten** on the next deploy — the repository
+> is authoritative.
+>
+> To change a scheduled job: edit `ops/crontab`, then deploy.
 
-### 9.1 Test DB cleanup — daily
+Applied contents, detailed in [`ops/README.md`](../../../ops/README.md):
+
+| Job | Frequency |
+|---|---|
+| `cleanup-test-db.sh` | daily, 04:00 UTC |
+| `cleanup-test-users.sh` (#160) | Sunday 04:00 UTC |
+| `reconcile-guests.sh --apply` (#393) | Sunday 05:00 UTC |
+| `cf-http-firewall.service` | at boot |
+| `cf-update-ranges.timer` | Sunday 04:00 UTC |
+
+The previous crontab is saved to `logs/crontab.bak.<timestamp>` before any
+overwrite.
+
+### Verify after a deploy
 
 ```bash
-mkdir -p /home/fedora/Arbore/logs
-touch /home/fedora/Arbore/logs/cleanup-test-db.log
-chmod +x /home/fedora/Arbore/scripts/cleanup-test-db.sh
-
-(crontab -l 2>/dev/null; echo "0 4 * * * /home/fedora/Arbore/scripts/cleanup-test-db.sh >> /home/fedora/Arbore/logs/cleanup-test-db.log 2>&1") | crontab -
 crontab -l
+systemctl is-enabled cf-http-firewall.service cf-update-ranges.timer
 ```
 
-Manual validation (may print "skip" if a CI run is in progress, that's OK):
+### Firebase ↔ Mongo reconciliation — first run
+
+The job deletes production data on the word of an external system. **Run it in
+simulation mode before trusting the cron**, which passes `--apply`:
 
 ```bash
-/home/fedora/Arbore/scripts/cleanup-test-db.sh
-```
-
-The script checks that no GitHub Actions CI run is in progress before
-dropping the DB. It uses `gh` if authenticated, otherwise `curl` without a token (since
-the repo is public, the Actions API is readable without auth).
-
-### 9.2 Test account cleanup — weekly
-
-Purges the `@arbore.test` users accumulated by CI (#160).
-
-```bash
-touch /home/fedora/Arbore/logs/cleanup-test-users.log
-chmod +x /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh
-
-(crontab -l 2>/dev/null; echo "0 4 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh >> /home/fedora/Arbore/logs/cleanup-test-users.log 2>&1") | crontab -
-```
-
-### 9.3 Firebase ↔ Mongo reconciliation — weekly
-
-Deletes Mongo data whose `uid` no longer exists in Firebase Auth.
-Automatic cleanup of inactive anonymous accounts, enabled on 2026-09-02,
-removes a guest account after 30 days; without this job its gardens and
-consents would remain in the database with no identifiable owner — nobody
-to request their erasure, and no retention period (#393).
-
-The job runs **inside the already-deployed backend container**: there it
-finds `MONGODB_URI`, the Firebase service account mounted at
-`/run/secrets`, and the same purge function as GDPR account deletion.
-Nothing to build on the host.
-
-> **Run it in simulation mode once before installing the cron.**
-> Without `--apply`, the script counts and logs without deleting anything.
-
-```bash
-chmod +x /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh
-
-# 1. Simulation: deletes nothing, prints the totals.
+# Deletes nothing: counts and logs.
 /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh
-
-# 2. If the numbers look sound, real deletion.
-/home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh --apply
-
-# 3. Only then, the cron.
-touch /home/fedora/Arbore/logs/reconcile-guests.log
-(crontab -l 2>/dev/null; echo "0 5 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh --apply >> /home/fedora/Arbore/logs/reconcile-guests.log 2>&1") | crontab -
 ```
 
-The job is a production eraser driven by an external system. Four guards
-make that acceptable, and it **exits with an error without deleting
-anything** if any one of them is not satisfied:
+Four guards protect it, and it **exits with an error without deleting anything**
+if any one of them is not satisfied:
 
 | Guard | What it prevents |
 |---|---|
-| Fail-closed on any Firebase error | Reading "I don't know" as "delete" |
-| Refusing an empty Firebase enumeration | Wiping the database on a bad service account |
-| 7-day grace period | Deleting an account created after the Firebase snapshot |
-| Simulation by default | A deletion triggered by accident |
+| Fail-closed on any Firebase error | reading "I don't know" as "delete" |
+| Refusing an empty Firebase enumeration | wiping the database on a bad service account |
+| 7-day grace period | deleting an account created after the Firebase snapshot |
+| Simulation by default | a deletion triggered by accident |
 
-Logs contain totals only, never a `uid`: a `uid` is personal data, and the
-log has its own retention period (#385).
+Logs contain totals only, never a `uid`: a `uid` is personal data, and the log
+has its own retention period (#385).
+
+⚠️ **No guard protects against pointing at the wrong Firebase project.** On any
+environment other than production, check `FIREBASE_SERVICE_ACCOUNT_PATH` and
+`MONGODB_URI` before any `--apply`.
 
 ---
 
@@ -448,7 +424,8 @@ Check off these items before considering the VPS operational:
 - [ ] `curl -fsS http://localhost:3000/` → 200 OK (web)
 - [ ] `curl -fsS http://<VPS_IP>/health` → 200 OK (via nginx)
 - [ ] `mongosh "$MONGODB_URI" --quiet --eval 'db.users.countDocuments()'` → integer > 0
-- [ ] `crontab -l` contains all three entries: `cleanup-test-db.sh`, `cleanup-test-users.sh`, `reconcile-guests.sh`
+- [ ] `crontab -l` contains all three entries, installed by `deploy.sh` from `ops/crontab` — never by hand
+- [ ] `systemctl is-enabled cf-http-firewall.service cf-update-ranges.timer` → `enabled`
 - [ ] `/home/fedora/Arbore/scripts/cleanup-test-db.sh` finishes with exit 0
 - [ ] `ls /home/fedora/Arbore/backups/daily/` does not crash (the folder is created on the first `deploy.sh`)
 - [ ] A test PR on GitHub triggers the CI; the tests pass while

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -335,87 +335,61 @@ nouveau checkout de release ne puisse ni les écraser ni les supprimer.
 
 ---
 
-## 9. Tâches planifiées (cron)
+## 9. Tâches planifiées et configuration système
 
-Trois entrées, toutes journalisées sous `logs/`.
+> **Rien à installer à la main.** `deploy.sh` applique `ops/` à chaque
+> déploiement (étape 2/7) : entrées cron, unités systemd, scripts privilégiés.
+> Une modification faite directement sur la machine est **écrasée** au
+> déploiement suivant — le dépôt fait autorité.
+>
+> Pour changer une tâche planifiée : éditer `ops/crontab`, puis déployer.
 
-### 9.1 Cleanup de la DB de test — quotidien
+Contenu appliqué, détaillé dans [`ops/README.md`](../../../ops/README.md) :
+
+| Tâche | Fréquence |
+|---|---|
+| `cleanup-test-db.sh` | quotidienne, 04:00 UTC |
+| `cleanup-test-users.sh` (#160) | dimanche 04:00 UTC |
+| `reconcile-guests.sh --apply` (#393) | dimanche 05:00 UTC |
+| `cf-http-firewall.service` | au démarrage |
+| `cf-update-ranges.timer` | dimanche 04:00 UTC |
+
+Le crontab précédent est sauvegardé dans `logs/crontab.bak.<horodatage>` avant
+tout écrasement.
+
+### Vérifier après un déploiement
 
 ```bash
-mkdir -p /home/fedora/Arbore/logs
-touch /home/fedora/Arbore/logs/cleanup-test-db.log
-chmod +x /home/fedora/Arbore/scripts/cleanup-test-db.sh
-
-(crontab -l 2>/dev/null; echo "0 4 * * * /home/fedora/Arbore/scripts/cleanup-test-db.sh >> /home/fedora/Arbore/logs/cleanup-test-db.log 2>&1") | crontab -
 crontab -l
+systemctl is-enabled cf-http-firewall.service cf-update-ranges.timer
 ```
 
-Validation manuelle (peut afficher "skip" si une CI tourne, c'est OK) :
+### Réconciliation Firebase ↔ Mongo — première exécution
+
+Le job supprime des données de production sur la foi d'un système externe. **Le
+faire tourner en simulation avant de se fier au cron**, qui lui passe `--apply` :
 
 ```bash
-/home/fedora/Arbore/scripts/cleanup-test-db.sh
-```
-
-Le script vérifie qu'aucune CI GitHub Actions n'est en cours avant de
-droper la DB. Il utilise `gh` si authentifié, sinon `curl` sans token (le
-dépôt étant public, l'API Actions est lisible sans auth).
-
-### 9.2 Cleanup des comptes de test — hebdomadaire
-
-Purge les utilisateurs `@arbore.test` accumulés par la CI (#160).
-
-```bash
-touch /home/fedora/Arbore/logs/cleanup-test-users.log
-chmod +x /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh
-
-(crontab -l 2>/dev/null; echo "0 4 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/cleanup-test-users.sh >> /home/fedora/Arbore/logs/cleanup-test-users.log 2>&1") | crontab -
-```
-
-### 9.3 Réconciliation Firebase ↔ Mongo — hebdomadaire
-
-Supprime les données Mongo dont l'`uid` n'existe plus dans Firebase Auth.
-Le nettoyage automatique des comptes anonymes inactifs, activé le
-2026-09-02, supprime un compte invité après 30 jours ; sans ce job, ses
-jardins et consentements resteraient en base sans propriétaire
-identifiable, donc sans personne pour en demander l'effacement et sans
-durée de conservation (#393).
-
-Le job s'exécute **dans le conteneur backend déjà déployé** : il y trouve
-`MONGODB_URI`, le service account Firebase monté en `/run/secrets`, et la
-même fonction de purge que la suppression de compte RGPD. Rien à builder
-côté hôte.
-
-> **Faire un premier passage en simulation avant d'installer le cron.**
-> Sans `--apply`, le script compte et journalise sans rien supprimer.
-
-```bash
-chmod +x /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh
-
-# 1. Simulation : ne supprime rien, affiche les totaux.
+# Ne supprime rien : compte et journalise.
 /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh
-
-# 2. Si les chiffres sont sains, suppression réelle.
-/home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh --apply
-
-# 3. Puis seulement, le cron.
-touch /home/fedora/Arbore/logs/reconcile-guests.log
-(crontab -l 2>/dev/null; echo "0 5 * * 0 /home/fedora/Arbore/ArboreBackend/scripts/reconcile-guests.sh --apply >> /home/fedora/Arbore/logs/reconcile-guests.log 2>&1") | crontab -
 ```
 
-Le job est un effaceur de production piloté par un système externe. Quatre
-gardes le rendent acceptable, et il **sort en erreur sans rien supprimer**
-si l'une d'elles n'est pas satisfaite :
+Quatre gardes le protègent, et il **sort en erreur sans rien supprimer** si
+l'une n'est pas satisfaite :
 
 | Garde | Ce qu'elle empêche |
 |---|---|
-| Fail-closed sur toute erreur Firebase | Interpréter « je ne sais pas » comme « supprime » |
-| Refus d'une énumération Firebase vide | Vider la base si le service account est mauvais |
-| Période de grâce de 7 jours | Supprimer un compte créé après le snapshot Firebase |
-| Simulation par défaut | Une suppression déclenchée par inadvertance |
+| Fail-closed sur toute erreur Firebase | interpréter « je ne sais pas » comme « supprime » |
+| Refus d'une énumération Firebase vide | vider la base si le service account est mauvais |
+| Période de grâce de 7 jours | supprimer un compte créé après le snapshot Firebase |
+| Simulation par défaut | une suppression déclenchée par inadvertance |
 
-Les journaux ne contiennent que des totaux, jamais d'`uid` : un `uid` est
-une donnée personnelle, et le journal a sa propre durée de conservation
-(#385).
+Les journaux ne contiennent que des totaux, jamais d'`uid` : un `uid` est une
+donnée personnelle, et le journal a sa propre durée de conservation (#385).
+
+⚠️ **Aucune garde ne protège contre un pointage vers le mauvais projet
+Firebase.** Sur un environnement autre que la production, vérifier
+`FIREBASE_SERVICE_ACCOUNT_PATH` et `MONGODB_URI` avant tout `--apply`.
 
 ---
 
@@ -450,7 +424,8 @@ Cocher ces points avant de considérer le VPS opérationnel :
 - [ ] `curl -fsS http://localhost:3000/` → 200 OK (web)
 - [ ] `curl -fsS http://<VPS_IP>/health` → 200 OK (via nginx)
 - [ ] `mongosh "$MONGODB_URI" --quiet --eval 'db.users.countDocuments()'` → entier > 0
-- [ ] `crontab -l` contient les trois entrées : `cleanup-test-db.sh`, `cleanup-test-users.sh`, `reconcile-guests.sh`
+- [ ] `crontab -l` contient les trois entrées, posées par `deploy.sh` depuis `ops/crontab` — jamais à la main
+- [ ] `systemctl is-enabled cf-http-firewall.service cf-update-ranges.timer` → `enabled`
 - [ ] `/home/fedora/Arbore/scripts/cleanup-test-db.sh` finit en exit 0
 - [ ] `ls /home/fedora/Arbore/backups/daily/` ne plante pas (le dossier est créé au 1er `deploy.sh`)
 - [ ] Une PR de test sur GitHub déclenche la CI ; les tests passent en

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,45 @@
+# `ops/` — configuration système déclarative
+
+Source de vérité de tout ce qui vit **hors des conteneurs** : entrées cron, unités systemd, scripts privilégiés.
+
+`deploy.sh` applique ce répertoire à **chaque déploiement**, de façon idempotente (étape 2/7).
+
+## Pourquoi
+
+Ces éléments étaient posés à la main en suivant un runbook. Ils n'existaient donc que sous deux formes — de la prose dans la documentation, et un état sur la machine — sans que rien ne puisse comparer les deux.
+
+Résultat : `vps-bootstrap.md` a décrit **un seul cron** pendant des mois alors que la machine en avait **deux**. La dérive a été découverte par hasard (#393). Ni la CI, qui n'a pas accès au VPS, ni une relecture, qui ne lit que le dépôt, ne pouvaient la voir.
+
+Avec ce répertoire, la dérive n'est plus détectée : elle est **impossible**.
+
+## Conséquence à connaître
+
+**Une modification faite à la main sur la machine est écrasée au déploiement suivant.**
+
+C'est le comportement voulu. Pour changer une entrée cron ou une unité systemd, on modifie le fichier ici et on déploie. Le crontab précédent est sauvegardé dans `logs/crontab.bak.<horodatage>` avant tout écrasement.
+
+## Contenu
+
+| Chemin | Installé vers | Rôle |
+|---|---|---|
+| `crontab` | crontab de l'utilisateur de déploiement | 3 tâches planifiées |
+| `systemd/cf-http-firewall.service` | `/etc/systemd/system/` | restreint nginx :80 aux IP Cloudflare |
+| `systemd/cf-update-ranges.service` | `/etc/systemd/system/` | rafraîchit les plages IP Cloudflare |
+| `systemd/cf-update-ranges.timer` | `/etc/systemd/system/` | déclenche le rafraîchissement, dimanche 04:00 UTC |
+| `sbin/cf-http-firewall.sh` | `/usr/local/sbin/` | applique les règles iptables |
+| `sbin/cf-update-ranges.sh` | `/usr/local/sbin/` | récupère et valide les plages Cloudflare |
+
+## `__ARBORE_ROOT__`
+
+`crontab` contient ce jeton, remplacé à l'installation par la racine réelle du checkout. Le fichier reste ainsi valable quel que soit l'emplacement du dépôt — condition pour qu'un second environnement puisse l'utiliser sans le modifier.
+
+## Ce qui n'est PAS ici
+
+- **Les secrets** — hors dépôt par conception. Voir #401 §6 bis (piste SOPS + age).
+- **La configuration nginx** — pas encore déclarée, à traiter.
+- **`/etc/cf-http-firewall/cf-ranges-v4.txt`** — donnée générée par `cf-update-ranges.sh`, pas une configuration.
+- **Le provisionnement initial** de la machine — voir `docs/fr/operations/vps-bootstrap.md`.
+
+## Références
+
+#401 (objectif d'ensemble) · #400 (proposition initiale) · #393 (dérive découverte)

--- a/ops/crontab
+++ b/ops/crontab
@@ -1,0 +1,19 @@
+# Tâches planifiées Arbore — source de vérité.
+#
+# Ce fichier est INSTALLÉ par deploy.sh à chaque déploiement. Ne pas éditer le
+# crontab de la machine à la main : la modification serait écrasée au
+# déploiement suivant, sans avertissement.
+#
+# `__ARBORE_ROOT__` est remplacé par la racine du dépôt au moment de
+# l'installation, pour que le fichier reste valable quel que soit
+# l'emplacement du checkout.
+
+# Cleanup de la DB de test, chaque nuit à 04:00 UTC (saute si une CI tourne).
+0 4 * * * __ARBORE_ROOT__/scripts/cleanup-test-db.sh >> __ARBORE_ROOT__/logs/cleanup-test-db.log 2>&1
+
+# Cleanup des comptes @arbore.test accumulés par la CI (#160), dimanche 04:00 UTC.
+0 4 * * 0 __ARBORE_ROOT__/ArboreBackend/scripts/cleanup-test-users.sh >> __ARBORE_ROOT__/logs/cleanup-test-users.log 2>&1
+
+# Réconciliation Firebase <-> Mongo (#393), dimanche 05:00 UTC.
+# ATTENTION : --apply supprime réellement. Sans ce drapeau, le job simule.
+0 5 * * 0 __ARBORE_ROOT__/ArboreBackend/scripts/reconcile-guests.sh --apply >> __ARBORE_ROOT__/logs/reconcile-guests.log 2>&1

--- a/ops/sbin/cf-http-firewall.sh
+++ b/ops/sbin/cf-http-firewall.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Durcissement reseau de l'origine Arbore (idempotent, ne touche jamais :22) :
+#  - nginx :80  -> autorise uniquement les IP Cloudflare (chaine CF-HTTP)
+#  - :8080 (API Go) et :8000 (AI generator) -> pas d'acces externe direct
+#    (DOCKER-USER v4+v6, scope -i eth0 ; loopback + inter-conteneurs preserves)
+set -euo pipefail
+
+EXT_IF="eth0"
+RANGES_FILE="/etc/cf-http-firewall/cf-ranges-v4.txt"
+
+# Fallback code en dur : utilise si le fichier manque/est invalide, pour que
+# le boot ne casse JAMAIS meme si l'update auto a foire.
+CF_FALLBACK=(
+173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22
+141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20
+197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13
+104.24.0.0/14 172.64.0.0/13 131.0.72.0/22
+)
+
+CF_RANGES=()
+if [ -f "$RANGES_FILE" ]; then
+  mapfile -t CF_RANGES < <(grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$' "$RANGES_FILE" || true)
+fi
+# Garde-fou : si liste vide/trop courte, on retombe sur le fallback (jamais de DROP-all).
+if [ "${#CF_RANGES[@]}" -lt 5 ]; then CF_RANGES=("${CF_FALLBACK[@]}"); fi
+
+# --- nginx :80 : Cloudflare uniquement ---
+iptables -N CF-HTTP 2>/dev/null || true
+iptables -F CF-HTTP
+for cidr in "${CF_RANGES[@]}"; do iptables -A CF-HTTP -s "$cidr" -j ACCEPT; done
+iptables -A CF-HTTP -s 127.0.0.1 -j ACCEPT
+iptables -A CF-HTTP -j DROP
+iptables -C INPUT -p tcp --dport 80 -j CF-HTTP 2>/dev/null || \
+  iptables -A INPUT -p tcp --dport 80 -j CF-HTTP
+iptables -C INPUT -p tcp --dport 443 -j CF-HTTP 2>/dev/null || \
+  iptables -A INPUT -p tcp --dport 443 -j CF-HTTP
+
+# --- :8080 / :8000 : pas d'acces externe direct (v4 + v6) ---
+for fw in iptables ip6tables; do
+  for port in 8080 8000; do
+    $fw -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null || \
+      $fw -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
+  done
+done
+
+echo "cf-http-firewall applied OK (${#CF_RANGES[@]} CF ranges)"

--- a/ops/sbin/cf-update-ranges.sh
+++ b/ops/sbin/cf-update-ranges.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Rafraichit la liste des plages IPv4 Cloudflare utilisee par le firewall
+# d'origine. Refuse toute liste suspecte (fetch KO, page d'erreur, compte
+# anormal) et rollback automatiquement si l'API ne repond plus apres apply.
+set -euo pipefail
+
+RANGES_FILE="/etc/cf-http-firewall/cf-ranges-v4.txt"
+URL="https://www.cloudflare.com/ips-v4"
+TMP="$(mktemp)"; trap 'rm -f "$TMP" "$TMP.norm"' EXIT
+
+# 1. Fetch (echec => on garde l'existant, pas d'erreur bloquante).
+if ! curl -fsS -m 20 "$URL" -o "$TMP"; then
+  echo "cf-update: fetch KO, on garde les plages actuelles" >&2; exit 0
+fi
+
+# 2. Validation stricte : que des CIDR IPv4, aucune ligne parasite, compte sain.
+mapfile -t NEW < <(grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$' "$TMP" || true)
+TOTAL=$(grep -cve '^[[:space:]]*$' "$TMP" || true)
+if [ "${#NEW[@]}" -lt 5 ] || [ "${#NEW[@]}" -gt 50 ] || [ "$TOTAL" -ne "${#NEW[@]}" ]; then
+  echo "cf-update: reponse suspecte (valides=${#NEW[@]}, total=$TOTAL), abort" >&2; exit 0
+fi
+
+# 3. Pas de changement => rien a faire.
+printf '%s\n' "${NEW[@]}" | sort > "$TMP.norm"
+if [ -f "$RANGES_FILE" ] && diff -q <(sort "$RANGES_FILE") "$TMP.norm" >/dev/null 2>&1; then
+  echo "cf-update: aucune evolution des plages"; exit 0
+fi
+
+# 4. Backup + ecriture + application.
+[ -f "$RANGES_FILE" ] && cp -f "$RANGES_FILE" "$RANGES_FILE.bak"
+printf '%s\n' "${NEW[@]}" > "$RANGES_FILE"
+systemctl restart cf-http-firewall.service
+sleep 2
+
+# 5. Health-check via Cloudflare ; rollback si l'API ne repond plus.
+code=$(curl -s -m 15 -o /dev/null -w '%{http_code}' https://api.arbore.app/health || echo 000)
+if [ "$code" != "200" ]; then
+  echo "cf-update: health-check KO ($code) -> ROLLBACK" >&2
+  if [ -f "$RANGES_FILE.bak" ]; then mv -f "$RANGES_FILE.bak" "$RANGES_FILE"; else rm -f "$RANGES_FILE"; fi
+  systemctl restart cf-http-firewall.service
+  exit 1
+fi
+echo "cf-update: plages mises a jour (${#NEW[@]} CIDR), health OK"

--- a/ops/systemd/cf-http-firewall.service
+++ b/ops/systemd/cf-http-firewall.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restrict nginx :80 (origin) to Cloudflare IPs
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/cf-http-firewall.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/cf-update-ranges.service
+++ b/ops/systemd/cf-update-ranges.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Refresh Cloudflare IP ranges for the origin firewall
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/cf-update-ranges.sh

--- a/ops/systemd/cf-update-ranges.timer
+++ b/ops/systemd/cf-update-ranges.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly refresh of Cloudflare IP ranges
+
+[Timer]
+OnCalendar=Sun *-*-* 04:00:00
+RandomizedDelaySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Promotion `dev` → `main` pour déploiement. Un seul changement fonctionnel : #402.

## Ce que ce déploiement fait de nouveau

`deploy.sh` gagne une **étape 2/7** qui applique `ops/` — entrées cron, unités systemd, scripts privilégiés — de façon idempotente, avant le snapshot Mongo.

**C'est le premier passage réel de cette étape.** Elle n'a pas pu être testée autrement : elle écrase le crontab et touche systemd.

## Pourquoi le risque est mesuré

- L'essai à blanc donne un crontab **identique aux trois entrées actuelles** — le passage sera fonctionnellement neutre, seuls les commentaires changeront.
- Les cinq fichiers versionnés ont été vérifiés par empreinte SHA-256 : **identiques à l'octet près** à ce qui tourne déjà en production.
- Le crontab précédent est sauvegardé dans `logs/crontab.bak.<horodatage>` avant tout écrasement.
- L'étape est **non bloquante sans sudo** : le déploiement applicatif continue quoi qu'il arrive.

## À vérifier juste après

```bash
crontab -l
systemctl is-enabled cf-http-firewall.service cf-update-ranges.timer
ls logs/crontab.bak.*
curl -fsS http://localhost:8080/health
```

## ⚠️ À partir de maintenant

**Une modification du crontab ou des unités systemd faite à la main sur le VPS sera écrasée au déploiement suivant.** Pour en changer une : éditer `ops/crontab` ou `ops/systemd/`, puis déployer.

Refs #401, #400