### PR TITLE
fix(ops): ré-exécuter deploy.sh quand il se met à jour lui-même

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,6 +33,14 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Empreinte du script avant tout pull, pour détecter qu'il s'est mis à jour
+# lui-même (cf. do_git_pull).
+SELF_SHA_BEFORE_PULL="$(sha256sum "$0" 2>/dev/null | cut -d" " -f1 || echo unknown)"
+
+# Arguments du script capturés au niveau global : `do_git_pull` est appelée
+# sans paramètres, donc `$@` y serait vide et la ré-exécution les perdrait.
+SCRIPT_ARGS=("$@")
+
 SNAPSHOT_DIR="$SCRIPT_DIR/backups/daily"
 SNAPSHOT_RETENTION_DAYS=14
 # Préfixe de privilège isolé du reste de la commande : il faut pouvoir insérer
@@ -151,6 +159,28 @@ do_git_pull() {
         exit 1
     fi
     ok "Git pull réussi"
+
+    # Le script vient peut-être de se remplacer lui-même. bash lit le fichier
+    # au fil de l'exécution : sans ré-exécution, on continuerait avec l'ANCIENNE
+    # version, et toute modification de deploy.sh ne prendrait effet qu'au
+    # déploiement SUIVANT. Constaté en production le 2026-09-05 — l'étape
+    # `ops/` nouvellement ajoutée n'avait pas tourné, et rien ne le signalait
+    # hormis les libellés « [2/6] » au lieu de « [2/7] ».
+    #
+    # ARBORE_DEPLOY_REEXECED garde contre une boucle : après ré-exécution, le
+    # script ne se relance pas une seconde fois.
+    if [ -z "${ARBORE_DEPLOY_REEXECED:-}" ]; then
+        local after
+        after="$(sha256sum "$0" 2>/dev/null | cut -d" " -f1 || true)"
+        if [ -n "$after" ] && [ "$after" != "$SELF_SHA_BEFORE_PULL" ]; then
+            warn "deploy.sh a été mis à jour par le pull — ré-exécution avec la nouvelle version"
+            echo
+            export ARBORE_DEPLOY_REEXECED=1
+            # Forme `${x[@]+...}` : sans elle, un tableau vide déclencherait
+            # « unbound variable » sous `set -u`.
+            exec "$0" ${SCRIPT_ARGS[@]+"${SCRIPT_ARGS[@]}"}
+        fi
+    fi
     echo
 }
 

--- a/ops/crontab
+++ b/ops/crontab
@@ -4,9 +4,10 @@
 # crontab de la machine à la main : la modification serait écrasée au
 # déploiement suivant, sans avertissement.
 #
-# `__ARBORE_ROOT__` est remplacé par la racine du dépôt au moment de
-# l'installation, pour que le fichier reste valable quel que soit
-# l'emplacement du checkout.
+# Les chemins absolus ci-dessous sont écrits à l'installation à partir de la
+# racine réelle du checkout : le fichier versionné reste donc valable quel que
+# soit l'emplacement du dépôt. (Le jeton substitué n'est pas cité ici — il le
+# serait aussi, et ce commentaire n'aurait plus de sens.)
 
 # Cleanup de la DB de test, chaque nuit à 04:00 UTC (saute si une CI tourne).
 0 4 * * * __ARBORE_ROOT__/scripts/cleanup-test-db.sh >> __ARBORE_ROOT__/logs/cleanup-test-db.log 2>&1


### PR DESCRIPTION
Deux défauts révélés par le **premier déploiement réel** de #402. Aucun des deux n'était visible avant de voir le script tourner.

## 1. `deploy.sh` exécutait son ancienne version

`git pull` remplace `deploy.sh` pendant que bash l'exécute. bash lisant le fichier au fil de l'exécution, la suite du déploiement se déroule avec l'**ancienne** version.

L'étape `ops/` tout juste ajoutée n'a donc pas tourné au premier passage. Le seul indice :

```
[1/6] Git pull...                 ← devrait être [1/7]
[2/6] Pre-deploy DB snapshot...   ← devrait être [2/7] Configuration système
```

Sans ces libellés, le déploiement aurait été annoncé réussi alors que sa nouveauté n'avait pas été appliquée.

### La portée dépasse ce cas

**Toute modification de `deploy.sh` ne prenait effet qu'au déploiement suivant.** Un correctif poussé en urgence — un rollback, une garde ajoutée après incident — aurait été silencieusement ignoré au moment précis où il comptait le plus.

### Correction

Le script compare son empreinte SHA-256 avant et après le pull, et se ré-exécute s'il a changé. `ARBORE_DEPLOY_REEXECED` garde contre la boucle infinie.

Deux subtilités qui ont demandé une seconde passe :

- **Les arguments** sont capturés dans `SCRIPT_ARGS` au niveau global. `do_git_pull` est appelée sans paramètres, donc `$@` y est vide : une première version de ce correctif aurait perdu les arguments à la ré-exécution.
- **La forme `${x[@]+"${x[@]}"}`** évite un `unbound variable` sur tableau vide sous `set -u`.

Vérifié en isolation, sur un script jetable reproduisant la logique :

```
-- sans argument --
  détection OK → ré-exécution (args: aucun)
  seconde passe : pas de boucle, args préservés (aucun)
-- avec arguments --
  détection OK → ré-exécution (args: alpha beta)
  seconde passe : pas de boucle, args préservés (alpha beta)
```

## 2. Un commentaire qui s'autodétruisait

L'en-tête de `ops/crontab` expliquait le rôle du jeton `__ARBORE_ROOT__`… en le citant. Le `sed` d'installation le remplaçait donc aussi, et le crontab installé en production affirme actuellement :

> `/home/fedora/Arbore` est remplacé par la racine du dépôt au moment de l'installation

Reformulé sans citer le jeton.

## Effet différé, à connaître

Le `deploy.sh` actuellement en production est **encore celui qui ne se ré-exécute pas**. Le prochain déploiement installera ce correctif ; c'est celui d'**après** qui en bénéficiera.

Concrètement : au prochain déploiement, vérifier que les libellés affichent bien `[n/7]`. S'ils affichent `[n/6]`, c'est que l'ancien script tourne encore et qu'un second passage est nécessaire — exactement ce qui s'est produit ici.

## État de la production après #402

Déployé et vérifié le 2026-09-05 :

```
crontab      3 entrées installées depuis ops/
sauvegarde   logs/crontab.bak.20260905T132843Z (651 o)
unités       cf-http-firewall enabled + active · cf-update-ranges.timer enabled
santé        200 OK · commit 39d36c6 = main
```

Refs #401