### PR TITLE
release: ré-exécution de deploy.sh après auto-mise à jour

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,6 +33,14 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Empreinte du script avant tout pull, pour détecter qu'il s'est mis à jour
+# lui-même (cf. do_git_pull).
+SELF_SHA_BEFORE_PULL="$(sha256sum "$0" 2>/dev/null | cut -d" " -f1 || echo unknown)"
+
+# Arguments du script capturés au niveau global : `do_git_pull` est appelée
+# sans paramètres, donc `$@` y serait vide et la ré-exécution les perdrait.
+SCRIPT_ARGS=("$@")
+
 SNAPSHOT_DIR="$SCRIPT_DIR/backups/daily"
 SNAPSHOT_RETENTION_DAYS=14
 # Préfixe de privilège isolé du reste de la commande : il faut pouvoir insérer
@@ -151,6 +159,28 @@ do_git_pull() {
         exit 1
     fi
     ok "Git pull réussi"
+
+    # Le script vient peut-être de se remplacer lui-même. bash lit le fichier
+    # au fil de l'exécution : sans ré-exécution, on continuerait avec l'ANCIENNE
+    # version, et toute modification de deploy.sh ne prendrait effet qu'au
+    # déploiement SUIVANT. Constaté en production le 2026-09-05 — l'étape
+    # `ops/` nouvellement ajoutée n'avait pas tourné, et rien ne le signalait
+    # hormis les libellés « [2/6] » au lieu de « [2/7] ».
+    #
+    # ARBORE_DEPLOY_REEXECED garde contre une boucle : après ré-exécution, le
+    # script ne se relance pas une seconde fois.
+    if [ -z "${ARBORE_DEPLOY_REEXECED:-}" ]; then
+        local after
+        after="$(sha256sum "$0" 2>/dev/null | cut -d" " -f1 || true)"
+        if [ -n "$after" ] && [ "$after" != "$SELF_SHA_BEFORE_PULL" ]; then
+            warn "deploy.sh a été mis à jour par le pull — ré-exécution avec la nouvelle version"
+            echo
+            export ARBORE_DEPLOY_REEXECED=1
+            # Forme `${x[@]+...}` : sans elle, un tableau vide déclencherait
+            # « unbound variable » sous `set -u`.
+            exec "$0" ${SCRIPT_ARGS[@]+"${SCRIPT_ARGS[@]}"}
+        fi
+    fi
     echo
 }
 

--- a/ops/crontab
+++ b/ops/crontab
@@ -4,9 +4,10 @@
 # crontab de la machine à la main : la modification serait écrasée au
 # déploiement suivant, sans avertissement.
 #
-# `__ARBORE_ROOT__` est remplacé par la racine du dépôt au moment de
-# l'installation, pour que le fichier reste valable quel que soit
-# l'emplacement du checkout.
+# Les chemins absolus ci-dessous sont écrits à l'installation à partir de la
+# racine réelle du checkout : le fichier versionné reste donc valable quel que
+# soit l'emplacement du dépôt. (Le jeton substitué n'est pas cité ici — il le
+# serait aussi, et ce commentaire n'aurait plus de sens.)
 
 # Cleanup de la DB de test, chaque nuit à 04:00 UTC (saute si une CI tourne).
 0 4 * * * __ARBORE_ROOT__/scripts/cleanup-test-db.sh >> __ARBORE_ROOT__/logs/cleanup-test-db.log 2>&1


### PR DESCRIPTION
Promotion `dev` → `main`. Un seul changement : #404.

## Ce que ça corrige

`deploy.sh` se remplaçait lui-même au `git pull` puis continuait d'exécuter l'**ancienne** version. Conséquence générale : **toute modification de `deploy.sh` ne prenait effet qu'au déploiement suivant** — y compris un correctif poussé en urgence.

Constaté en production le 2026-09-05 : l'étape `ops/` de #402 n'avait pas tourné au premier passage, seuls les libellés `[2/6]` au lieu de `[2/7]` le trahissaient.

## ⚠️ Effet différé sur CE déploiement

Le `deploy.sh` en production est encore celui qui ne se ré-exécute pas. **Ce déploiement installera le correctif mais n'en bénéficiera pas.**

Attendu :

```
[1/6] ...   ← ancien script, normal pour ce passage
```

Un **second passage** de `deploy.sh` est donc nécessaire pour appliquer `ops/`, comme lors du déploiement de #402. À partir du suivant, la ré-exécution sera automatique.

## Vérification après les deux passages

```bash
crontab -l                # 3 entrées, commentaire d'en-tête corrigé
ls logs/crontab.bak.*
curl -fsS http://localhost:8080/health
```

Le commentaire d'en-tête du crontab installé ne doit plus contenir la phrase absurde « `/home/fedora/Arbore` est remplacé par la racine du dépôt ».

Refs #401