### PR TITLE
feat(ops): refuser un déploiement depuis la mauvaise branche

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -106,6 +106,23 @@ is_out_of_band() {
 do_git_pull() {
     step 1 "Git pull..."
 
+    # Garde-fou de branche (#384). `git pull --ff-only` suit la branche COURANTE
+    # du checkout : si quelqu'un en laisse une autre en place sur la machine, le
+    # script la déploierait sans rien signaler. La dérive ne serait visible qu'en
+    # aval, par le commit exposé dans /health.
+    #
+    # Paramétrable plutôt que codé en dur : #401 vise plusieurs environnements,
+    # et une machine de staging déploierait légitimement `dev`. La production ne
+    # définit pas la variable et refuse donc tout sauf `main`.
+    local expected_branch="${ARBORE_DEPLOY_BRANCH:-main}"
+    local current_branch
+    current_branch="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$current_branch" != "$expected_branch" ]; then
+        fail "Checkout sur '$current_branch', attendu '$expected_branch' — déploiement refusé"
+        fail "Pour déployer une autre branche : ARBORE_DEPLOY_BRANCH=<branche> ./deploy.sh"
+        exit 1
+    fi
+
     # Trois catégories, traitées différemment :
     #   - fichier SUIVI modifié hors données hors bande  → bloquant (du code)
     #   - fichier SUIVI modifié sous un chemin hors bande → toléré, signalé

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -312,6 +312,20 @@ git rev-parse origin/main                               # what should be running
 From now on, subsequent deployments go through
 `./deploy.sh` (which takes a Mongo snapshot before each rebuild).
 
+**Branch guard.** `deploy.sh` refuses to deploy when the checkout is not on the
+expected branch (#384). `git pull --ff-only` follows the **current** branch: a
+working branch left in place on the machine would be deployed with nothing
+signalling it, and the drift would only surface downstream, in the commit exposed
+by `/health`.
+
+The expected branch defaults to `main` and is changed with
+`ARBORE_DEPLOY_BRANCH` — parameterised rather than hard-coded, so a staging
+environment can deploy `dev` without editing the script (#401):
+
+```bash
+ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
 **Checkout guard.** `deploy.sh` refuses to deploy when a git-**tracked** file is
 modified — that is uncommitted code, hence a silent divergence. It does
 however **tolerate** two things: untracked files (they cannot break a

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -312,6 +312,20 @@ git rev-parse origin/main                               # ce qui devrait tourner
 À partir de maintenant, les déploiements suivants passent par
 `./deploy.sh` (qui prend un snapshot Mongo avant chaque rebuild).
 
+**Garde-fou de branche.** `deploy.sh` refuse de déployer si le checkout n'est pas
+sur la branche attendue (#384). `git pull --ff-only` suit la branche **courante** :
+une branche de travail laissée en place sur la machine serait déployée sans que
+rien ne le signale, et la dérive n'apparaîtrait qu'en aval, dans le commit exposé
+par `/health`.
+
+La branche attendue est `main` par défaut, et se change par
+`ARBORE_DEPLOY_BRANCH` — paramétrable plutôt que codée en dur, pour qu'un
+environnement de staging puisse déployer `dev` sans modifier le script (#401) :
+
+```bash
+ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
 **Garde-fou du checkout.** `deploy.sh` refuse de déployer si un fichier **suivi**
 par git est modifié — c'est du code non committé, donc une divergence
 silencieuse. En revanche il **tolère** deux choses : les fichiers non suivis (ils


### PR DESCRIPTION
Volet 2 de #384. Le volet 1 — protection de branche — est **déjà appliqué** sur `main`, cf. commentaire de l'issue.

## Le problème

`deploy.sh` exécutait `git pull --ff-only` **sans argument de branche** : il suivait donc la branche courante du checkout. Une branche de travail laissée en place sur la machine aurait été déployée sans que rien ne le signale, et la dérive n'aurait été visible qu'en aval — dans le commit exposé par `/health`, après coup.

## Écart avec l'issue, assumé

L'issue proposait de coder `main` en dur :

```bash
if [ "$current_branch" != "main" ]; then
```

Ce serait contradictoire avec **#401**, qui vise plusieurs environnements : une machine de staging déploiera légitimement `dev`.

La branche attendue est donc lue dans `ARBORE_DEPLOY_BRANCH`, avec `main` par défaut :

```bash
local expected_branch="${ARBORE_DEPLOY_BRANCH:-main}"
```

**La propriété recherchée par #384 est préservée** — la production ne définit pas la variable et refuse tout sauf `main` — tandis qu'un futur environnement n'aura pas à modifier le script.

## Vérifié en isolation

```
-- prod sur main --        ✅ 'main' accepté (attendu 'main')
-- prod sur une autre --   ❌ Checkout sur 'feat/truc', attendu 'main' — refusé
-- staging sur dev --      ✅ 'dev' accepté (attendu 'dev')
-- staging sur main --     ❌ Checkout sur 'main', attendu 'dev' — refusé
```

Le message d'erreur indique la commande de contournement, pour qu'un refus légitime ne se transforme pas en séance de lecture du script.

## Documentation

Section « Garde-fou de branche » ajoutée à `vps-bootstrap.md`, FR et EN, à côté du garde-fou du checkout existant. Drift-check vert.

Refs #384, #401