### PR TITLE
feat(ops): poser le mécanisme de secrets chiffrés (SOPS + age)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,21 @@ fastlane/README.md
 # Local working notes (not part of the project).
 /state.md
 /jury-greenlight.md
+
+# ─── Secrets : seuls les fichiers CHIFFRÉS sont versionnés (#401) ─────────────
+# Filet contre un `git add` malheureux : tout ce qui ressemble à un secret en
+# clair sous ops/secrets/ est ignoré. Les `*.enc.*` sont explicitement réadmis.
+# La règle `secrets/` (plus haut) exclut le RÉPERTOIRE : git ne peut alors pas
+# réintégrer les fichiers qu'il contient. Il faut donc le réadmettre d'abord,
+# puis exclure son contenu, puis réadmettre ce qui doit être versionné.
+!ops/secrets/
+ops/secrets/*
+!ops/secrets/README.md
+!ops/secrets/env.template
+!ops/secrets/*.enc.env
+!ops/secrets/*.enc.json
+!ops/secrets/*.enc.p8
+!ops/secrets/*.enc.key
+# Clés privées age, où qu'elles traînent.
+*.agekey
+age-key*.txt

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,22 @@
+# Configuration SOPS — chiffrement des secrets versionnés (#401 §6 bis).
+#
+# SOPS chiffre les VALEURS et laisse les CLÉS en clair. L'inventaire des
+# secrets est donc versionné et lisible en revue de PR ; les valeurs ne le
+# sont pas. C'est cette propriété qui rend tenable le critère de #401 : une
+# machine neuve sait QUOI lui fournir, sans que le dépôt révèle les valeurs.
+#
+# Une clé age par environnement. La clé PRIVÉE ne vit jamais dans le dépôt —
+# c'est le seul secret restant à poser à la main sur une machine neuve.
+#
+# Les destinataires ci-dessous sont des clés PUBLIQUES : les publier est sans
+# risque, c'est leur raison d'être.
+
+creation_rules:
+  # Remplacer `age1...` par la clé publique produite par `age-keygen`.
+  # Tant que ces valeurs sont des marqueurs, aucun chiffrement n'est possible —
+  # c'est voulu : mieux vaut échouer que chiffrer vers une clé fantôme.
+  - path_regex: ^ops/secrets/prod\.enc\.(env|json|p8|key)$
+    age: "REMPLACER_PAR_LA_CLE_PUBLIQUE_AGE_PROD"
+
+  - path_regex: ^ops/secrets/dev\.enc\.(env|json|p8|key)$
+    age: "REMPLACER_PAR_LA_CLE_PUBLIQUE_AGE_DEV"

--- a/ops/secrets/README.md
+++ b/ops/secrets/README.md
@@ -1,0 +1,106 @@
+# `ops/secrets/` — secrets chiffrés, inventaire en clair
+
+## Le principe
+
+SOPS chiffre les **valeurs** et laisse les **clés** en clair :
+
+```yaml
+MONGODB_URI: ENC[AES256_GCM,data:x8Kd...,type:str]
+GEMINI_API_KEY: ENC[AES256_GCM,data:9fQm...,type:str]
+```
+
+L'inventaire est donc versionné, diffable, lisible en revue de PR. Les valeurs ne le sont pas.
+
+C'est cette propriété qui rend tenable le critère de #401 : **une machine neuve sait quoi lui fournir, sans que le dépôt révèle les valeurs.**
+
+## Ce qui est ici, et ce qui n'y est pas
+
+| Fichier | Versionné | Contenu |
+|---|---|---|
+| `env.template` | ✅ | inventaire des 24 variables, aucune valeur |
+| `prod.enc.env` | ✅ | valeurs de production, **chiffrées** |
+| `dev.enc.env` | ✅ | valeurs de dev, **chiffrées** |
+| clé privée `age` | ❌ **jamais** | le seul secret à poser à la main |
+
+## Mise en place — à faire une fois
+
+### 1. Installer l'outillage
+
+```bash
+brew install sops age          # macOS
+sudo dnf install -y age && \
+  curl -sSL https://github.com/getsops/sops/releases/latest/download/sops-v3.x.x.linux.amd64 \
+  -o /usr/local/bin/sops && sudo chmod +x /usr/local/bin/sops   # Fedora / VPS
+```
+
+### 2. Générer une paire de clés par environnement
+
+```bash
+age-keygen -o ~/.config/sops/age/arbore-prod.txt
+```
+
+La sortie affiche la clé **publique** (`age1...`). La clé **privée** est dans le fichier — elle ne doit jamais entrer dans le dépôt, ni dans un message, ni dans un presse-papier partagé.
+
+### 3. Renseigner `.sops.yaml`
+
+Remplacer les marqueurs `REMPLACER_PAR_LA_CLE_PUBLIQUE_AGE_*` par les clés publiques produites.
+
+> Tant que les marqueurs sont en place, tout chiffrement échoue. C'est voulu : mieux vaut une erreur qu'un fichier chiffré vers une clé fantôme, indéchiffrable.
+
+### 4. Chiffrer les valeurs réelles
+
+**Depuis le VPS, sans que les valeurs transitent ailleurs :**
+
+```bash
+cd /home/fedora/Arbore
+cp .env /tmp/prod.env                       # copie de travail
+sops --encrypt /tmp/prod.env > ops/secrets/prod.enc.env
+shred -u /tmp/prod.env                      # effacement de la copie claire
+```
+
+Puis les trois fichiers secrets :
+
+```bash
+sops --encrypt /home/fedora/arbore-data/secrets/firebase-adminsdk.json \
+  > ops/secrets/prod.enc.json
+sops --encrypt /home/fedora/arbore-data/secrets/apple-siwa.p8 \
+  > ops/secrets/prod.enc.p8
+sops --encrypt /home/fedora/arbore-data/secrets/master-encryption.key \
+  > ops/secrets/prod.enc.key
+```
+
+### 5. Vérifier avant de commiter
+
+```bash
+grep -c "ENC\[" ops/secrets/prod.enc.env    # doit valoir le nombre de secrets
+grep -E "mongodb\+srv|AIza|sk-" ops/secrets/prod.enc.env && echo "⚠️ FUITE" || echo "✅ propre"
+```
+
+Le second contrôle cherche des motifs de secrets en clair. **S'il trouve quelque chose, ne pas commiter.**
+
+## Usage courant
+
+```bash
+sops ops/secrets/prod.enc.env               # éditer (déchiffre, rouvre, rechiffre)
+sops --decrypt ops/secrets/prod.enc.env     # afficher en clair
+```
+
+## Le problème d'amorçage, irréductible
+
+Il reste à poser la clé privée sur une machine neuve. **Aucun système n'y échappe** — Vault a son jeton de descellement, AWS son rôle d'instance.
+
+Mais on passe de **24 valeurs à poser à la main à une seule**. C'est le minimum théorique.
+
+## ⚠️ Deux pièges
+
+**Ne jamais déchiffrer `MASTER_ENCRYPTION_KEY` vers l'environnement.** Le code préfère déjà `MASTER_ENCRYPTION_KEY_PATH` parce qu'une variable est lisible par `docker inspect` et `/proc/<pid>/environ` — or cette clé déchiffre les refresh tokens Apple (audit #338 constat 4). Le déploiement doit écrire un **fichier**.
+
+**Un projet Firebase par environnement.** Le job de réconciliation (#393) tourne chaque dimanche avec `--apply` et compare les uid Firebase à une base Mongo. Pointé vers le mauvais couple, **il vide la mauvaise base**. Aucune de ses quatre gardes ne couvre ce cas.
+
+## État
+
+Le **mécanisme** est en place ; **aucune valeur réelle n'est encore chiffrée**. Les étapes 1 à 5 restent à exécuter, et l'intégration à `deploy.sh` viendra ensuite — elle ne peut pas être écrite ni testée avant qu'un fichier chiffré existe.
+
+## Références
+
+#401 §6 bis (choix de SOPS et alternatives écartées) · #338 constat 4 · #393

--- a/ops/secrets/env.template
+++ b/ops/secrets/env.template
@@ -1,0 +1,57 @@
+# Inventaire des variables d'environnement — modèle, sans aucune valeur.
+#
+# Ce fichier répond à une question précise : « que faut-il fournir à une
+# machine neuve ? » Il est versionné, les valeurs ne le sont pas.
+#
+# Les secrets réels vivent dans `prod.enc.env` / `dev.enc.env`, chiffrés par
+# SOPS. Voir README.md de ce répertoire.
+#
+# Colonne de droite : 🔒 secret · ⚙️ configuration (non sensible)
+
+# ── Base de données ───────────────────────────────────────────────────────
+MONGODB_URI=                          # 🔒 URI Atlas, contient les credentials
+MONGODB_URI_TEST=                     # 🔒 idem, base de test (#159)
+
+# ── Authentification de l'API ─────────────────────────────────────────────
+ARBORE_API_KEY=                       # 🔒 clé API des clients
+ARBORE_API_KEY_TEST=                  # 🔒 sélectionne la base de test
+ARBORE_ADMIN_UIDS=                    # ⚙️ uid admins, séparés par des virgules
+
+# ── Firebase ──────────────────────────────────────────────────────────────
+FIREBASE_SERVICE_ACCOUNT_PATH=        # ⚙️ CHEMIN vers le JSON, pas le JSON
+                                      #    ⚠️ un projet Firebase PAR environnement (#401 §6)
+
+# ── Chiffrement au repos ──────────────────────────────────────────────────
+MASTER_ENCRYPTION_KEY_PATH=           # ⚙️ chemin — PRÉFÉRÉ à la variable
+MASTER_ENCRYPTION_KEY_HOST_PATH=      # ⚙️ chemin côté hôte, monté par compose
+MASTER_ENCRYPTION_KEY=                # 🔒 repli déconseillé : une variable est
+                                      #    lisible par `docker inspect` et
+                                      #    /proc/<pid>/environ, or cette clé
+                                      #    déchiffre les refresh tokens Apple
+                                      #    (audit #338 constat 4)
+
+# ── Sign in with Apple ────────────────────────────────────────────────────
+APPLE_TEAM_ID=                        # ⚙️
+APPLE_KEY_ID=                         # ⚙️
+APPLE_SIWA_CLIENT_ID=                 # ⚙️
+APPLE_SIWA_KEY_PATH=                  # ⚙️ chemin vers le .p8, pas son contenu
+
+# ── Fournisseurs d'IA ─────────────────────────────────────────────────────
+AI_PROVIDER=                          # ⚙️ gemini | mistral | openai
+GEMINI_MODEL=                         # ⚙️
+GEMINI_API_KEY=                       # 🔒
+MISTRAL_API_KEY=                      # 🔒
+OPENAI_API_KEY=                       # 🔒
+
+# ── Divers ────────────────────────────────────────────────────────────────
+UNSPLASH_ACCESS_KEY=                  # 🔒
+THUMBNAILS_DIR=                       # ⚙️
+THUMBNAIL_UPLOAD_ALLOWED_UIDS=        # ⚙️
+MODELS_HOST_PATH=                     # ⚙️ hors du checkout git (#341)
+GIN_MODE=                             # ⚙️ release en production
+PORT=                                 # ⚙️
+
+# ── Fichiers, hors de ce modèle ───────────────────────────────────────────
+# Trois secrets sont des FICHIERS, pas des variables. Ils vivent dans
+# `arbore-data/secrets/` et seront chiffrés séparément :
+#   firebase-adminsdk.json · apple-siwa.p8 · master-encryption.key


### PR DESCRIPTION
Étape 4 de #401. Aucune valeur secrète dans ce commit.

## La contradiction que ça résout

Le critère de #401 impose deux choses en apparence incompatibles : les secrets ne peuvent pas être dans le dépôt, mais une machine neuve doit savoir **quoi** lui fournir.

SOPS chiffre les **valeurs** et laisse les **clés** en clair :

```yaml
MONGODB_URI: ENC[AES256_GCM,data:x8Kd...,type:str]
GEMINI_API_KEY: ENC[AES256_GCM,data:9fQm...,type:str]
```

L'inventaire devient versionné, diffable, lisible en revue de PR. Les valeurs ne le sont pas.

## Contenu

| Fichier | Rôle |
|---|---|
| `.sops.yaml` | règles de chiffrement, une clé `age` par environnement |
| `ops/secrets/README.md` | procédure complète, pièges inclus |
| `ops/secrets/env.template` | inventaire des **24 variables**, aucune valeur |
| `.gitignore` | garde-fou anti-fuite |

L'inventaire distingue **10 secrets de 14 variables de configuration**, chacun annoté de sa nature.

## Ce que cette PR ne fait PAS, délibérément

**Aucune valeur réelle n'est chiffrée.** Les secrets de production ne transitent ni par une machine de développement ni par un historique de conversation : le mécanisme est posé ici, les valeurs seront injectées **depuis le VPS**, où elles sont déjà. Le README donne la procédure, avec `shred` de la copie de travail et deux contrôles avant commit — dont une recherche de motifs de secrets en clair.

**L'intégration à `deploy.sh` n'est pas écrite.** Elle ne peut être ni rédigée ni testée avant qu'un fichier chiffré existe. L'écrire à l'aveugle mettrait du code non éprouvé sur le chemin critique du déploiement.

## Le garde-fou `.gitignore` — deux essais nécessaires

La première version ignorait à tort `README.md` et les `*.enc.*`.

**Cause** : une règle préexistante (`secrets/`, ligne 133) exclut tout répertoire de ce nom. Or git **ne peut pas réintégrer un fichier dont un répertoire parent est exclu** — les négations `!ops/secrets/README.md` restaient sans effet. Il faut réadmettre le répertoire d'abord, puis exclure son contenu, puis réadmettre les fichiers voulus.

Vérifié après correction :

```
prod.env (clair)  ignoré
test.agekey       ignoré
prod.enc.env      versionnable
README.md         versionnable
env.template      versionnable
```

Sans ce test, la PR aurait livré un garde-fou protégeant la mauvaise chose.

## Deux pièges documentés dans le README

**`MASTER_ENCRYPTION_KEY` doit être déchiffrée vers un FICHIER**, jamais vers l'environnement : une variable est lisible par `docker inspect` et `/proc/<pid>/environ`, or cette clé déchiffre les refresh tokens Apple (audit #338 constat 4). Le code préfère déjà `MASTER_ENCRYPTION_KEY_PATH` pour cette raison.

**Un projet Firebase par environnement.** Le job de réconciliation (#393) tourne chaque dimanche avec `--apply` et compare les uid Firebase à une base Mongo. Pointé vers le mauvais couple, il vide la mauvaise base — et aucune de ses quatre gardes ne couvre ce cas.

## Suite

Installer `sops` et `age`, générer une paire de clés, renseigner `.sops.yaml`, chiffrer depuis le VPS. Tant que les marqueurs `REMPLACER_PAR_LA_CLE_PUBLIQUE_AGE_*` sont en place, **tout chiffrement échoue** — mieux vaut une erreur qu'un fichier chiffré vers une clé fantôme, indéchiffrable.

Refs #401, #338, #393