### PR TITLE
fix(backend): décompter les URL signées et borner le mois sous le palier gratuit

### DIFF
--- a/ArboreBackend/storage_guard.go
+++ b/ArboreBackend/storage_guard.go
@@ -30,10 +30,12 @@ import (
 //
 // Ce que la garde protège, et ce qu'elle ne protège PAS
 // ------------------------------------------------------
-// Elle borne ce que le BACKEND demande au stockage. Elle ne borne pas les
-// téléchargements que les clients font directement via URL signée — ceux-là
-// sont bornés en amont, chaque URL exigeant une requête authentifiée au
-// backend, elle-même limitée par `apiLimiter`.
+// Elle borne les opérations FACTURÉES : les lectures directes comme les URL
+// signées, chacune produisant exactement une lecture chez le fournisseur.
+//
+// Elle ne borne pas ce qu'un client fait d'une URL déjà obtenue — mais une URL
+// expire en quinze minutes et n'autorise qu'un objet, donc la fenêtre d'abus
+// reste étroite.
 //
 // Le compteur est en mémoire, donc par processus et remis à zéro au
 // redémarrage. C'est un filet contre l'emballement, pas une comptabilité.
@@ -121,10 +123,22 @@ func (g *guardedStorage) Put(ctx context.Context, obj StorageObject, data []byte
 }
 
 func (g *guardedStorage) PresignedURL(ctx context.Context, obj StorageObject, ttl time.Duration) (string, error) {
-	// Une URL signée ne coûte AUCUNE opération au stockage : elle est calculée
-	// localement, sans appel réseau. Elle n'est donc pas décomptée — la borner
-	// reviendrait à limiter ce qui ne coûte rien, et pousserait le handler vers
-	// le service direct, lui bien plus coûteux.
+	// DÉCOMPTÉE, contrairement à ce qu'une première version supposait.
+	//
+	// Générer la signature ne coûte rien : elle est calculée localement, sans
+	// appel réseau. Mais elle AUTORISE un téléchargement, et ce téléchargement
+	// est une opération facturée par le stockage.
+	//
+	// Ne pas la décompter rendait la garde inerte en production : avec un
+	// support qui sait signer, `serveStorageObject` emprunte cette voie et
+	// n'appelle jamais `Open` — le seul chemin qui était compté. La garde
+	// n'aurait alors protégé que le cas où elle était inutile.
+	//
+	// Une signature vaut donc exactement une opération, comme une lecture
+	// directe : les deux produisent une lecture facturée.
+	if err := g.allow(); err != nil {
+		return "", err
+	}
 	return g.inner.PresignedURL(ctx, obj, ttl)
 }
 
@@ -164,13 +178,24 @@ func envInt64(name string, fallback int64) int64 {
 
 // storageGuardFromEnv lit la configuration des gardes.
 //
-// Les défauts sont dimensionnés sur l'usage réel : 124 modèles, un catalogue
-// stable, une beta interne. Ils laissent une marge large tout en
-// arrêtant un emballement — une boucle qui demanderait mille fichiers par
-// minute serait coupée.
+// Le défaut de 200 opérations par minute vient d'un calcul, pas d'une intuition.
+// Soutenu un mois entier, il plafonne à ~8,6 millions d'opérations :
+//
+//	200 × 60 × 24 × 30 = 8 640 000
+//
+// soit sous le palier gratuit de 10 millions de lectures mensuelles de
+// Cloudflare R2. Le pire cas est donc borné à une facture nulle, ce qui est
+// une propriété plus forte que « ça devrait aller ».
+//
+// La marge reste large : le pic réaliste d'une beta — quelques dizaines
+// d'utilisateurs chargeant chacun quelques dizaines de modèles — se compte en
+// dizaines d'opérations par minute, pas en centaines.
+//
+// Sur un MinIO local, où l'opération ne coûte rien, relever franchement : ce
+// calcul n'y a aucun sens.
 func storageGuardFromEnv() storageGuardConfig {
 	return storageGuardConfig{
-		MaxOpsPerWindow: envInt("STORAGE_MAX_OPS_PER_MINUTE", 600),
+		MaxOpsPerWindow: envInt("STORAGE_MAX_OPS_PER_MINUTE", 200),
 		Window:          time.Minute,
 		MaxObjectBytes:  envInt64("STORAGE_MAX_OBJECT_BYTES", 200<<20), // 200 Mio
 	}

--- a/ArboreBackend/storage_guard_test.go
+++ b/ArboreBackend/storage_guard_test.go
@@ -108,21 +108,51 @@ func TestGuardRejectsOversizedBeforeCountingIt(t *testing.T) {
 	}
 }
 
-// TestGuardDoesNotThrottlePresign : une URL signée est calculée localement,
-// sans appel réseau ni facturation. La décompter pousserait le handler vers le
-// service direct, lui bien plus coûteux — l'inverse du but recherché.
-func TestGuardDoesNotThrottlePresign(t *testing.T) {
+// TestGuardThrottlesPresign verrouille la correction d'un défaut de conception.
+//
+// Une première version ne décomptait PAS les signatures, au motif qu'elles sont
+// calculées localement. C'était confondre le coût de fabriquer la clé avec
+// celui d'ouvrir la porte : une URL signée AUTORISE un téléchargement, et ce
+// téléchargement est facturé.
+//
+// Pire, la garde en devenait inerte : avec un support qui sait signer,
+// `serveStorageObject` emprunte cette voie et n'appelle jamais `Open` — le seul
+// chemin alors compté. Elle n'aurait protégé que le cas où elle était inutile.
+func TestGuardThrottlesPresign(t *testing.T) {
 	inner := &countingStorage{}
-	g := newGuardedStorage(inner, storageGuardConfig{MaxOpsPerWindow: 1, Window: time.Minute})
+	g := newGuardedStorage(inner, storageGuardConfig{MaxOpsPerWindow: 3, Window: time.Minute})
 	obj := StorageObject{Bucket: BucketModelsHeavy, Name: "gros.usdz"}
 
-	for i := range 20 {
+	for i := range 3 {
 		if _, err := g.PresignedURL(context.Background(), obj, 0); err != nil {
-			t.Fatalf("signature %d refusée: %v", i+1, err)
+			t.Fatalf("signature %d devrait passer: %v", i+1, err)
 		}
 	}
-	if inner.presigns != 20 {
-		t.Errorf("presigns = %d, attendu 20", inner.presigns)
+	if _, err := g.PresignedURL(context.Background(), obj, 0); !errors.Is(err, ErrStorageQuotaExceeded) {
+		t.Fatalf("la 4e signature devrait être refusée, obtenu %v", err)
+	}
+	if inner.presigns != 3 {
+		t.Errorf("le support a signé %d fois, attendu 3 — la garde laisse passer", inner.presigns)
+	}
+}
+
+// TestGuardCountsPresignAndOpenTogether : les deux voies produisent chacune une
+// lecture facturée, elles doivent donc puiser au MÊME budget. Les compter
+// séparément doublerait l'exposition réelle.
+func TestGuardCountsPresignAndOpenTogether(t *testing.T) {
+	inner := &countingStorage{}
+	g := newGuardedStorage(inner, storageGuardConfig{MaxOpsPerWindow: 2, Window: time.Minute})
+	obj := StorageObject{Bucket: BucketModelsLight, Name: "m.usdz"}
+
+	if _, err := g.PresignedURL(context.Background(), obj, 0); err != nil {
+		t.Fatalf("signature: %v", err)
+	}
+	if _, _, err := g.Open(context.Background(), obj); err != nil {
+		t.Fatalf("lecture: %v", err)
+	}
+	// Budget épuisé : les deux voies partagent le compteur.
+	if _, err := g.PresignedURL(context.Background(), obj, 0); !errors.Is(err, ErrStorageQuotaExceeded) {
+		t.Fatal("signature + lecture doivent puiser au même budget")
 	}
 }
 
@@ -147,11 +177,11 @@ func TestGuardConfigFromEnv(t *testing.T) {
 	// Une valeur absurde doit retomber sur le défaut plutôt que de désactiver
 	// la garde : une faute de frappe ne doit pas ouvrir les vannes.
 	t.Setenv("STORAGE_MAX_OPS_PER_MINUTE", "abc")
-	if got := storageGuardFromEnv().MaxOpsPerWindow; got != 600 {
-		t.Errorf("valeur illisible → défaut attendu 600, obtenu %d", got)
+	if got := storageGuardFromEnv().MaxOpsPerWindow; got != 200 {
+		t.Errorf("valeur illisible → défaut attendu 200, obtenu %d", got)
 	}
 	t.Setenv("STORAGE_MAX_OPS_PER_MINUTE", "-5")
-	if got := storageGuardFromEnv().MaxOpsPerWindow; got != 600 {
-		t.Errorf("valeur négative → défaut attendu 600, obtenu %d", got)
+	if got := storageGuardFromEnv().MaxOpsPerWindow; got != 200 {
+		t.Errorf("valeur négative → défaut attendu 200, obtenu %d", got)
 	}
 }

--- a/docs/en/operations/asset-storage.md
+++ b/docs/en/operations/asset-storage.md
@@ -118,7 +118,7 @@ beyond configured thresholds. A runaway on local disk is not free either: it
 saturates I/O and masks the defect causing it.
 
 ```
-STORAGE_MAX_OPS_PER_MINUTE   default 600; 0 = unlimited
+STORAGE_MAX_OPS_PER_MINUTE   default 200; 0 = unlimited
 STORAGE_MAX_OBJECT_BYTES     default 200 MiB
 ```
 
@@ -128,9 +128,24 @@ variable to raise — a threshold set too low will not degrade service silently.
 
 On a local MinIO, raise it generously: operations cost nothing there.
 
-> The guard protects against an **acute** runaway, not against moderate but
-> sustained overuse. The counter is in memory, per process, reset on restart. A
-> billing alert on the provider side remains useful.
+The guard counts **direct reads and presigned URLs alike**: each produces
+exactly one billable operation. An earlier version exempted presigning, which
+made the guard inert — with a store that can sign, that is the only path taken.
+
+The default of 200 per minute comes from a calculation:
+
+```
+200 × 60 × 24 × 30 = 8,640,000 operations/month
+R2 free tier       = 10,000,000
+```
+
+**Sustained at the ceiling for a whole month, the cost stays zero.** That is a
+stronger property than "it should be fine". A realistic beta peak is measured in
+tens of operations per minute, not hundreds.
+
+> The counter is in memory, per process, reset on restart. Repeated restarts
+> would therefore loosen the monthly bound. A billing alert on the provider side
+> remains useful.
 
 ## References
 

--- a/docs/fr/operations/stockage-assets.md
+++ b/docs/fr/operations/stockage-assets.md
@@ -118,7 +118,7 @@ au-delà de seuils configurés. Un emballement sur disque n'est pas gratuit non
 plus : il sature les entrées-sorties et masque le défaut qui le provoque.
 
 ```
-STORAGE_MAX_OPS_PER_MINUTE   défaut 600 ; 0 = illimité
+STORAGE_MAX_OPS_PER_MINUTE   défaut 200 ; 0 = illimité
 STORAGE_MAX_OBJECT_BYTES     défaut 200 Mio
 ```
 
@@ -129,9 +129,25 @@ silence.
 
 Sur un MinIO local, relever largement : l'opération n'y coûte rien.
 
-> La garde protège d'un emballement **aigu**, pas d'une surconsommation modérée
-> mais soutenue. Le compteur est en mémoire, par processus, remis à zéro au
-> redémarrage. Une alerte de facturation côté fournisseur reste utile.
+La garde décompte **les lectures directes comme les URL signées** : chacune
+produit exactement une opération facturée. Une première version épargnait les
+signatures, ce qui la rendait inerte — avec un support qui sait signer, c'est la
+seule voie empruntée.
+
+Le défaut de 200 par minute vient d'un calcul :
+
+```
+200 × 60 × 24 × 30 = 8 640 000 opérations/mois
+palier gratuit R2  = 10 000 000
+```
+
+**Soutenu un mois entier au plafond, le coût reste nul.** C'est une propriété
+plus forte que « ça devrait aller ». Le pic réaliste d'une beta se compte en
+dizaines d'opérations par minute, pas en centaines.
+
+> Le compteur est en mémoire, par processus, remis à zéro au redémarrage.
+> Plusieurs redémarrages rapprochés relâcheraient donc la borne mensuelle. Une
+> alerte de facturation côté fournisseur reste utile.
 
 ## Références
 

--- a/ops/secrets/env.template
+++ b/ops/secrets/env.template
@@ -80,7 +80,8 @@ STORAGE_S3_USE_SSL=                   # ⚙️ défaut true ; « false » pour M
 
 # Garde-fou contre l'emballement, appliqué à TOUS les supports — disque
 # compris : une boucle sature les entrées-sorties même sans facturation.
-STORAGE_MAX_OPS_PER_MINUTE=           # ⚙️ défaut 600 ; 0 = illimité
+STORAGE_MAX_OPS_PER_MINUTE=           # ⚙️ défaut 200 → 8,6 M/mois, sous le
+                                      #    palier gratuit R2 de 10 M ; 0 = illimité
 STORAGE_MAX_OBJECT_BYTES=             # ⚙️ défaut 200 Mio
 
 # ── Divers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Deux défauts de la garde livrée en #416, révélés par une question simple : *« as-tu testé les limites, je ne veux pas de surprise de facture ? »*

## 1. La garde était inerte en production

Les URL signées n'étaient pas décomptées, au motif qu'elles sont **calculées localement, sans appel réseau**.

C'était confondre le coût de **fabriquer la clé** avec celui d'**ouvrir la porte**. Une URL signée autorise un téléchargement, et ce téléchargement est facturé par le stockage.

### La conséquence était pire que la sous-estimation

Avec un support qui sait signer, `serveStorageObject` emprunte cette voie et **n'appelle jamais `Open`** — le seul chemin qui était compté.

**La garde n'aurait donc protégé que le disque local**, c'est-à-dire le seul cas où elle ne sert à rien.

Une signature vaut désormais une opération, au même budget qu'une lecture directe : les deux produisent exactement une lecture facturée.

## 2. Le défaut ne bornait pas la facture

```
ancien  600 op/min soutenu  →  25,9 M/mois   ← 2,5× le palier gratuit
nouveau 200 op/min soutenu  →   8,6 M/mois   ← sous les 10 M
```

Le nouveau défaut vient d'un calcul :

```
200 × 60 × 24 × 30 = 8 640 000 opérations/mois
palier gratuit R2  = 10 000 000
```

**Soutenu au plafond pendant un mois entier, le coût reste nul.** C'est une propriété vérifiable, pas un « ça devrait aller ».

La marge reste large : le pic réaliste d'une beta se compte en **dizaines** d'opérations par minute, pas en centaines. Sur un MinIO local, où l'opération ne coûte rien, ce calcul n'a aucun sens — relever franchement.

## Ce qui reste non borné

Le compteur est **en mémoire, par processus, remis à zéro au redémarrage**. Plusieurs redémarrages rapprochés relâcheraient la borne mensuelle.

Une alerte de facturation côté fournisseur reste utile — c'est écrit dans le runbook.

## Le test verrouillait l'erreur

`TestGuardDoesNotThrottlePresign` affirmait que **vingt signatures passaient avec une limite de une**. Il était vert.

Un test peut verrouiller une faute aussi solidement qu'une propriété. Remplacé par `TestGuardThrottlesPresign`, et complété par `TestGuardCountsPresignAndOpenTogether` — les deux voies doivent puiser au même budget, les compter séparément doublerait l'exposition réelle.

```
TestGuardStopsAtLimit                     ✅
TestGuardResetsAfterWindow                ✅
TestGuardRejectsOversizedBeforeCountingIt ✅
TestGuardThrottlesPresign                 ✅  ← corrigé
TestGuardCountsPresignAndOpenTogether     ✅  ← nouveau
TestGuardDisabledWhenZero                 ✅
TestGuardConfigFromEnv                    ✅
```

```
build · vet · golangci-lint 0 issue · suite verte · drift-check vert
```

Documentation FR et EN mises à jour avec le raisonnement de la borne.

Refs #401