### PR TITLE
fix(ops): transmettre les variables de stockage au conteneur backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,21 @@ services:
       # constat 5) : le web passe par son proxy Next.js côté serveur.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
       - APPLE_TEAM_ID=${APPLE_TEAM_ID:-}
+      # Stockage des assets 3D (#401 étape 5). `docker compose` ne transmet au
+      # conteneur QUE les variables listées ici : le `.env` sert à la
+      # substitution ${VAR} dans ce fichier, pas à peupler l'environnement du
+      # conteneur. Sans ces lignes, le backend retombe silencieusement sur
+      # `filesystem` — ce qui masque l'absence de configuration au lieu de la
+      # signaler.
+      - STORAGE_PROVIDER=${STORAGE_PROVIDER:-}
+      - STORAGE_S3_ENDPOINT=${STORAGE_S3_ENDPOINT:-}
+      - STORAGE_S3_BUCKET=${STORAGE_S3_BUCKET:-}
+      - STORAGE_S3_REGION=${STORAGE_S3_REGION:-}
+      - STORAGE_S3_ACCESS_KEY=${STORAGE_S3_ACCESS_KEY:-}
+      - STORAGE_S3_SECRET_KEY=${STORAGE_S3_SECRET_KEY:-}
+      - STORAGE_S3_USE_SSL=${STORAGE_S3_USE_SSL:-}
+      - STORAGE_MAX_OPS_PER_MINUTE=${STORAGE_MAX_OPS_PER_MINUTE:-}
+      - STORAGE_MAX_OBJECT_BYTES=${STORAGE_MAX_OBJECT_BYTES:-}
       - APPLE_KEY_ID=${APPLE_KEY_ID:-}
       - APPLE_SIWA_CLIENT_ID=${APPLE_SIWA_CLIENT_ID:-}
       - APPLE_SIWA_KEY_PATH=/run/secrets/apple-siwa.p8


### PR DESCRIPTION
La bascule sur R2 (#419, #420) **n'avait aucun effet**. Après déploiement, le backend annonçait toujours :

```
📦 Stockage des assets : filesystem+garde
```

alors que le `.env` de l'hôte portait bien `STORAGE_PROVIDER=r2`.

## La cause

`docker compose` ne transmet au conteneur que les variables **explicitement listées** dans `environment:`. Le `.env` sert à la substitution `${VAR}` **dans** le fichier compose, pas à peupler l'environnement du conteneur.

```
.env sur l'hôte              STORAGE_PROVIDER=r2
variables dans le conteneur  0
docker-compose.yml           aucune mention de STORAGE
```

`MODELS_HOST_PATH` fonctionnait, lui, parce qu'il est utilisé dans la section `volumes` — là où la substitution compose s'applique. **Cette réussite partielle a masqué l'omission.**

## Pourquoi ça n'a rien cassé, et pourquoi c'est plus grave

Faute de configuration, `initStorageProvider` retombe sur `filesystem`. Le service a donc continué de fonctionner normalement, **à travers trois déploiements successifs**.

Un défaut qui casse se voit tout de suite. Un défaut qui fait silencieusement autre chose que ce qu'on croit se découvre bien plus tard, et par hasard — ici, parce que j'ai vérifié le journal de démarrage au lieu de me fier au « déploiement terminé ✅ ».

## Correction

Les neuf variables `STORAGE_*` sont ajoutées au service backend, avec un défaut vide pour que l'absence de configuration reste un cas normal.

Un commentaire dans le fichier explique la règle — la prochaine variable ajoutée au `.env` tomberait sinon dans le même piège.

## Après déploiement, à vérifier

```bash
sudo docker exec arbore-backend printenv STORAGE_PROVIDER   # attendu : r2
sudo docker logs arbore-backend | grep "Stockage des assets"
#   attendu : 📦 Stockage des assets : s3(...)+garde
```

Puis une redirection **302** sur une route de modèle, et non les octets.

Refs #401