### PR TITLE
release: transmettre les variables de stockage au conteneur

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,21 @@ services:
       # constat 5) : le web passe par son proxy Next.js côté serveur.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
       - APPLE_TEAM_ID=${APPLE_TEAM_ID:-}
+      # Stockage des assets 3D (#401 étape 5). `docker compose` ne transmet au
+      # conteneur QUE les variables listées ici : le `.env` sert à la
+      # substitution ${VAR} dans ce fichier, pas à peupler l'environnement du
+      # conteneur. Sans ces lignes, le backend retombe silencieusement sur
+      # `filesystem` — ce qui masque l'absence de configuration au lieu de la
+      # signaler.
+      - STORAGE_PROVIDER=${STORAGE_PROVIDER:-}
+      - STORAGE_S3_ENDPOINT=${STORAGE_S3_ENDPOINT:-}
+      - STORAGE_S3_BUCKET=${STORAGE_S3_BUCKET:-}
+      - STORAGE_S3_REGION=${STORAGE_S3_REGION:-}
+      - STORAGE_S3_ACCESS_KEY=${STORAGE_S3_ACCESS_KEY:-}
+      - STORAGE_S3_SECRET_KEY=${STORAGE_S3_SECRET_KEY:-}
+      - STORAGE_S3_USE_SSL=${STORAGE_S3_USE_SSL:-}
+      - STORAGE_MAX_OPS_PER_MINUTE=${STORAGE_MAX_OPS_PER_MINUTE:-}
+      - STORAGE_MAX_OBJECT_BYTES=${STORAGE_MAX_OBJECT_BYTES:-}
       - APPLE_KEY_ID=${APPLE_KEY_ID:-}
       - APPLE_SIWA_CLIENT_ID=${APPLE_SIWA_CLIENT_ID:-}
       - APPLE_SIWA_KEY_PATH=/run/secrets/apple-siwa.p8


### PR DESCRIPTION
Promotion `dev` → `main`. Correctif de #421.

## Le défaut

La bascule sur R2 (#420) **n'avait aucun effet**. `docker compose` ne transmet au conteneur que les variables listées dans `environment:` — le `.env` sert à la substitution `${VAR}` dans le fichier compose, pas à peupler l'environnement du conteneur.

```
.env sur l'hôte              STORAGE_PROVIDER=r2
variables dans le conteneur  0
```

Faute de configuration, le backend retombait sur `filesystem`. Le service fonctionnait donc normalement, **à travers trois déploiements**, ce qui a masqué l'omission.

## Ce déploiement rend la bascule effective

C'est lui qui fera réellement servir les modèles depuis R2.

## À vérifier immédiatement après

```bash
sudo docker exec arbore-backend printenv STORAGE_PROVIDER   # attendu : r2
sudo docker logs arbore-backend | grep "Stockage des assets"
#   attendu : 📦 Stockage des assets : s3(...)+garde
```

Puis une **redirection 302** sur une route de modèle, et non les octets.

## Retour arrière

Les 4,7 Go sont toujours sur le disque, dans `arbore-data/models`. `STORAGE_PROVIDER=filesystem` et un déploiement suffisent à revenir en arrière.

Refs #401