### PR TITLE
feat(ops): MinIO local pour l'environnement de développement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,9 +222,56 @@ services:
 
 
 
+  # ─────────────────────────────────────────────
+  # 🪣  MinIO — simulateur S3 local, DÉVELOPPEMENT UNIQUEMENT
+  # ─────────────────────────────────────────────
+  #
+  # Sous le profil `dev` : ce service ne démarre JAMAIS en production, où
+  # `docker compose up` est lancé sans profil. La production utilise
+  # Cloudflare R2 (#401 étape 5).
+  #
+  #   docker compose --profile dev up -d minio
+  #
+  # Le même `StorageProvider` sert les deux : MinIO et R2 parlent le protocole
+  # S3. Seules deux valeurs changent — l'endpoint et `USE_SSL=false`.
+  #
+  # Les identifiants ci-dessous sont des valeurs de développement, volontairement
+  # en clair : elles ne donnent accès qu'à un conteneur local sans données
+  # réelles. Les surcharger via l'environnement si besoin.
+  minio:
+    image: minio/minio:latest
+    container_name: arbore-minio
+    profiles: ["dev"]
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:-arbore-dev}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-arbore-dev-secret}
+    ports:
+      - "9000:9000"   # API S3
+      - "9001:9001"   # console web
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - arbore-net
+
 # ─────────────────────────────────────────────
 # 🔌  Réseau interne
 # ─────────────────────────────────────────────
 networks:
   arbore-net:
     driver: bridge
+
+# ─────────────────────────────────────────────
+# 💾  Volumes
+# ─────────────────────────────────────────────
+volumes:
+  # Données MinIO du poste de développement. Jamais créé en production : le
+  # service qui l'utilise est sous le profil `dev`.
+  minio-data:

--- a/docs/en/operations/asset-storage.md
+++ b/docs/en/operations/asset-storage.md
@@ -147,7 +147,42 @@ tens of operations per minute, not hundreds.
 > would therefore loosen the monthly bound. A billing alert on the provider side
 > remains useful.
 
+## The development environment — local MinIO
+
+MinIO is an S3-compatible server you run yourself. In development it replaces R2
+with no account, no outbound network and no cost — the same `StorageProvider`
+serves both.
+
+```bash
+docker compose --profile dev up -d minio
+```
+
+The service sits under the **`dev` profile**: it never starts in production,
+where `docker compose up` runs without a profile. Verifiable:
+
+```bash
+docker compose config --services                # ai-generator backend web
+docker compose --profile dev config --services  # + minio
+```
+
+Web console on `:9001`, S3 API on `:9000`. Create the `arbore-assets` bucket on
+first use.
+
+Configuration lives in `ops/secrets/dev.enc.env`, encrypted to the **`dev`** age
+key — distinct from production's, so a leak of one does not compromise the
+other. Only two values differ from R2:
+
+```
+STORAGE_S3_ENDPOINT=minio:9000
+STORAGE_S3_USE_SSL=false
+```
+
+The guard ceiling is raised to 5000 operations per minute: the calculation
+justifying 200 in production comes from R2's free tier and is meaningless on a
+local service.
+
 ## References
+
 
 #401 step 5 (abstraction and quotas) · #341 (assets outside the git checkout) ·
 [`ops/secrets/README.md`](../../../ops/secrets/README.md) (SOPS procedure)

--- a/docs/fr/operations/stockage-assets.md
+++ b/docs/fr/operations/stockage-assets.md
@@ -149,7 +149,42 @@ dizaines d'opérations par minute, pas en centaines.
 > Plusieurs redémarrages rapprochés relâcheraient donc la borne mensuelle. Une
 > alerte de facturation côté fournisseur reste utile.
 
+## L'environnement de développement — MinIO local
+
+MinIO est un serveur compatible S3 que l'on exécute soi-même. En développement,
+il remplace R2 sans compte, sans réseau sortant et sans coût — le même
+`StorageProvider` sert les deux.
+
+```bash
+docker compose --profile dev up -d minio
+```
+
+Le service est sous le **profil `dev`** : il ne démarre jamais en production, où
+`docker compose up` est lancé sans profil. Vérifiable :
+
+```bash
+docker compose config --services                # ai-generator backend web
+docker compose --profile dev config --services  # + minio
+```
+
+Console web sur `:9001`, API S3 sur `:9000`. Créer le seau `arbore-assets` à la
+première utilisation.
+
+La configuration vit dans `ops/secrets/dev.enc.env`, chiffrée vers la clé age
+**`dev`** — distincte de celle de production, de sorte qu'une fuite de l'une ne
+compromette pas l'autre. Deux valeurs seulement la distinguent de R2 :
+
+```
+STORAGE_S3_ENDPOINT=minio:9000
+STORAGE_S3_USE_SSL=false
+```
+
+Le plafond de la garde y est relevé à 5000 opérations par minute : le calcul qui
+justifie 200 en production vient du palier gratuit de R2, et n'a aucun sens sur
+un service local.
+
 ## Références
+
 
 #401 étape 5 (abstraction et quotas) · #341 (assets hors du checkout git) ·
 [`ops/secrets/README.md`](../../../ops/secrets/README.md) (procédure SOPS)

--- a/ops/secrets/dev.enc.env
+++ b/ops/secrets/dev.enc.env
@@ -1,0 +1,23 @@
+#ENC[AES256_GCM,data:nqEtceWQLYz/YaMw72wV/Q9o57X1IGCBfhMfe7NBa1yhJeOPRJ8xyiF5wZ8xRNen1Ydlfg==,iv:NcBsC95WCeMJ8mNscxZ5y73ql51GKdMN2NyK5aiZlxs=,tag:XbShsBO/51m3Av++N/KuoA==,type:comment]
+#
+#ENC[AES256_GCM,data:8uwf1gSXHAkZeeyTs57RiMsbUqYqe7sIKI5HpOp8B9sVQBdkR9sDW1XGuz+03/UbQXXBe8gZjaa9+lupbPkzBaEyWsXQppN1pCLseg/p,iv:dPeexhci5nL8AsY2gkjNLzq7oiKuqK6AStwLDtndqNM=,tag:MBH8trzyUgDvrl4qvHKzNQ==,type:comment]
+#ENC[AES256_GCM,data:oSL8lKk7drpuOkTkrh3SeIfc+LjvrVTki7Jw9NIPht+wUTQ=,iv:YWvmnzgtS5a9XSrWg1kp5CwtBYYcFv5z2LgtWFdHBjg=,tag:z1LHhWEKeiabDJeK5kzeww==,type:comment]
+#
+#ENC[AES256_GCM,data:9rEYbO2bdS8py88WSs75zlUGevFqoVe5d0n7W0UzQZKABXdOCxCZKNtQQGzrMRocL6EM+Ib+xBI805T/px8jehqjCqPWDzRkpw==,iv:8flXnVX/Az13+koy4h87AMhFp8rQ7ufZeFONDmiQGnc=,tag:f18/dbeVsTV/6lcBkxB43A==,type:comment]
+#ENC[AES256_GCM,data:V2yMus149o5gVcRg7Mc0Cd2tcwyVa5lu52pvPjfOHvMrK1wiN4Z8TtHZnTS+q71hL6DveGgI9KjazMXq,iv:P90kZejmIyHLMwHoifOAZky5NX0XolDZNbWd3uVpfXQ=,tag:kcFdJoGarqz86gz70PHupA==,type:comment]
+STORAGE_PROVIDER=ENC[AES256_GCM,data:o1KDTAw=,iv:P5L4NNC9eaE8Gm57Y/I7m3ghT8UHMU1zTWrgkHhfUiY=,tag:AqK2BnpGihvgOb9CqWCAig==,type:str]
+STORAGE_S3_ENDPOINT=ENC[AES256_GCM,data:rUpxbYnOsg7HUg==,iv:ZkkS75nDkoGnnIkd8ZCaLPxGw3WeDLi868K73chh3As=,tag:VNEe2jKH2doCvrLW/ZOhXg==,type:str]
+STORAGE_S3_BUCKET=ENC[AES256_GCM,data:q0bcfGNnSuQmWaTDOg==,iv:7LeBy8zVZqJcLHfnByx2SzxRD00KMJf+8O+0DSzXxWQ=,tag:v4uTC2PwI5mhnqfiCyZ5eA==,type:str]
+STORAGE_S3_REGION=ENC[AES256_GCM,data:z8gXtA==,iv:bb4F2axFEwxS5qW4UNSkd7JiX6m0hHrYbsJmkw4fxiM=,tag:AWHVpTwfNS4j2RCK1Wn++A==,type:str]
+STORAGE_S3_ACCESS_KEY=ENC[AES256_GCM,data:nPH4WGfqgO+Rvw==,iv:FodUdCM4ulrZ3jwlfLELJykyBrwm+nEJ9vP83Djt74c=,tag:eO68zcWrWWbTyOXiV+bHrA==,type:str]
+STORAGE_S3_SECRET_KEY=ENC[AES256_GCM,data:ZWvgrQ0I8eSsG94pjl77TY4=,iv:sCQYUrLv0Ue93zegrB/aTeh6Z4aWBiLOCrMs4+M7pqM=,tag:xRI3OT+Tab7EI2Ty6WCuhw==,type:str]
+STORAGE_S3_USE_SSL=ENC[AES256_GCM,data:7wk8Ca8=,iv:yrbmqzavj+uAEH6omUhsyTE5UBzKIKsFvuY9Oq87Hlw=,tag:Jt24fcS9+qzb9IgGpDZvLQ==,type:str]
+#ENC[AES256_GCM,data:MEFKtx4x3+47FYec+EDFtCMfBHAXrC/o7sLs7O5xUgQsB9bnp2xY5wDb3C04HedbFZULglwct6KBtXVjMndRNYsSlSiz+AmgyA==,iv:wTagmtXGtK9OZnj/rhIZwSOKf1FoVY3dzZba6JdBPPw=,tag:9RG9RTBIvS85XNb/eRSnTw==,type:comment]
+#ENC[AES256_GCM,data:5Zo3jiLd5B1vTnUIoAvCg1YdGhq/9g2U/z28XUVPX5FAEimOHwcWlgMhw7fs/iHv/htcRsTVlZ294+E=,iv:uwbzNsJ0h6R5quAuYr1l4NBkD5IcKGNNiv/bVQrNOn4=,tag:SEe5QoSyWK9sEWqgFtQ88g==,type:comment]
+STORAGE_MAX_OPS_PER_MINUTE=ENC[AES256_GCM,data:avGEYw==,iv:fz1WwFggGK224pxopGGfplanHC/9foUZZTkhZJVxQuQ=,tag:/A+8TpXMIg6Gm9Xn7rSvog==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkcVF0TUV2eEtLdEZteTlj\nYU81SWFsSmI2aUZPeGpURjYvOGNGKzVFdlJjCml1Uk90dTRVeUdpUWtmNXlRK3lw\neEF6TmRIRWNEZnJacndFeGw2KzFMNzAKLS0tIHh4SlVodytiSEEyMzFqV2dIaWN4\nRXEycUsrNGEzdWk3SFJoUnM2dlVwKzQKHhgrqDvtzWrmlEbSBPS6ss4Y6sb+6+wz\n4D7kdZjIAEgs9de0uxpSR1pBCeoP9BvCi5lu4B2qz+bhPyWXYf6TmQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1kz62ge9c0c4t6waz3wlrwke2mtr70hgff0c5xmdg5pagpm6mpuyqnrdzwt
+sops_lastmodified=2026-09-07T11:33:48Z
+sops_mac=ENC[AES256_GCM,data:L7I88ydoMmUE0vpG4RFbwDY57PDq3xH2BJJjYYu2q0v3bBcZgcuCgw6a31sKyEI0eWGALmG5sdhJQ56bBuufiwEZ4N631NSwBxpjFlNi/onyBHvwZfL/ZbvxhL09h3BGNUnR5VEygOWLz17lQgIHXDREHIeyZJD42tE/KF4XhxU=,iv:RCoJI7c3zZbedHz560KMZSw8C64QZZOBSqd6dN3Hzw0=,tag:nPQlgDrC1TY3lW5EnhPRWA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3


### PR DESCRIPTION
Un simulateur S3 sur le poste de développement : pas de compte, pas de réseau sortant, pas de coût. Le même `StorageProvider` sert MinIO et R2 — seuls l'endpoint et `USE_SSL` diffèrent.

```bash
docker compose --profile dev up -d minio
```

## Sous profil, pour que la production l'ignore

Le service est déclaré sous le profil `dev`. `docker compose up` sans profil ne le démarre pas, et le volume `minio-data` n'est jamais créé sur le VPS.

**Vérifié plutôt que supposé :**

```
docker compose config --services                → ai-generator backend web
docker compose --profile dev config --services  → + minio
```

## Une clé par environnement

`ops/secrets/dev.enc.env` est chiffré vers la clé age **`dev`**, distincte de celle de production.

**Vérifié : la clé de production est REFUSÉE sur ce fichier.** Une fuite de l'une ne compromet donc pas l'autre — c'est ce qui justifiait de générer deux paires.

## Un choix assumé

Les identifiants MinIO sont **en clair** dans le fichier compose, comme valeurs par défaut. Ils ne donnent accès qu'à un conteneur local sans données réelles ; les chiffrer donnerait une fausse impression de secret là où il n'y en a pas.

## Seuil de garde relevé

```
production  200 op/min    ← calibré sur le palier gratuit R2
dev        5000 op/min    ← l'opération locale est gratuite
```

Le calcul qui justifie 200 vient de R2 ; il n'a aucun sens sur un service local.

## Documentation

Section « environnement de développement » ajoutée aux deux runbooks, avec les commandes de vérification du profil. Drift-check vert.

Refs #401