### PR TITLE
feat(ops): verser la configuration nginx dans le dépôt

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -282,6 +282,69 @@ apply_secrets() {
     fi
 }
 
+# apply_nginx — installe la configuration du reverse-proxy.
+#
+# Validée par `nginx -t` AVANT rechargement : une configuration fautive
+# interrompt le déploiement sans toucher au service en cours. Sans cette
+# vérification, un rechargement sur une syntaxe invalide couperait le site.
+#
+# Sans effet si nginx n'est pas installé — une machine qui n'en a pas se
+# déploie comme avant.
+apply_nginx() {
+    local src_dir="$SCRIPT_DIR/ops/nginx"
+    [ -d "$src_dir" ] || return 0
+
+    if ! command -v nginx > /dev/null 2>&1; then
+        warn "nginx absent — configuration non appliquée"
+        return 0
+    fi
+    if ! sudo -n true 2>/dev/null; then
+        warn "sudo indisponible — configuration nginx non appliquée"
+        return 0
+    fi
+
+    local changed=0 src name dst backup_dir
+    backup_dir="$SCRIPT_DIR/logs/nginx.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+
+    for src in "$src_dir"/*.conf; do
+        [ -e "$src" ] || continue
+        name="$(basename "$src")"
+        dst="/etc/nginx/conf.d/$name"
+        if sudo cmp -s "$src" "$dst" 2>/dev/null; then
+            continue
+        fi
+        # Sauvegarde avant écrasement : un réglage posé à la main reste
+        # récupérable.
+        if [ -f "$dst" ]; then
+            mkdir -p "$backup_dir"
+            sudo cp -a "$dst" "$backup_dir/$name" 2>/dev/null || true
+        fi
+        sudo install -m 0644 "$src" "$dst"
+        changed=1
+    done
+
+    if [ "$changed" -eq 0 ]; then
+        ok "nginx déjà conforme"
+        return 0
+    fi
+
+    # Validation APRÈS installation mais AVANT rechargement : nginx ne sait
+    # tester qu'une arborescence en place. En cas d'échec, on restaure.
+    if ! sudo nginx -t > /dev/null 2>&1; then
+        fail "Configuration nginx invalide — restauration"
+        if [ -d "$backup_dir" ]; then
+            for name in "$backup_dir"/*; do
+                [ -e "$name" ] && sudo install -m 0644 "$name" "/etc/nginx/conf.d/$(basename "$name")"
+            done
+        fi
+        sudo nginx -t > /dev/null 2>&1 && fail "État précédent restauré" || fail "ATTENTION : nginx reste invalide"
+        return 1
+    fi
+
+    sudo systemctl reload nginx
+    ok "nginx mis à jour et rechargé"
+}
+
 # ───── [2/7] Configuration système déclarative ────────────────────
 #
 # `ops/` est la source de vérité de tout ce qui vit hors des conteneurs :
@@ -357,6 +420,7 @@ do_apply_ops() {
     done
 
     apply_secrets
+    apply_nginx
 
     if [ "$units_changed" -eq 1 ]; then
         sudo systemctl daemon-reload

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -312,6 +312,20 @@ git rev-parse origin/main                               # what should be running
 From now on, subsequent deployments go through
 `./deploy.sh` (which takes a Mongo snapshot before each rebuild).
 
+**nginx configuration.** Versioned in `ops/nginx/` and applied by `deploy.sh`,
+validated with `nginx -t` **before** reloading — a faulty configuration aborts
+the deploy without cutting the running service.
+
+⚠️ The **certificates** `/etc/ssl/cloudflare/origin.{pem,key}` stay out of the
+repository: they are secrets. A fresh machine must receive them before the
+`listen 443` blocks work, otherwise nginx will refuse to start.
+
+⚠️ **MongoDB Atlas IP allowlist.** A test from an outside machine suggests the
+cluster is not IP-restricted. **Confirm in the Atlas dashboard** (*Network
+Access*) before any migration: if a restriction exists, a fresh machine would be
+refused and the backend would fail at startup on the Mongo connection — a
+symptom that does not point to its cause.
+
 **Branch guard.** `deploy.sh` refuses to deploy when the checkout is not on the
 expected branch (#384). `git pull --ff-only` follows the **current** branch: a
 working branch left in place on the machine would be deployed with nothing

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -312,6 +312,20 @@ git rev-parse origin/main                               # ce qui devrait tourner
 À partir de maintenant, les déploiements suivants passent par
 `./deploy.sh` (qui prend un snapshot Mongo avant chaque rebuild).
 
+**Configuration nginx.** Versionnée dans `ops/nginx/` et appliquée par
+`deploy.sh`, validée par `nginx -t` **avant** rechargement — une configuration
+fautive interrompt le déploiement sans couper le service en cours.
+
+⚠️ Les **certificats** `/etc/ssl/cloudflare/origin.{pem,key}` restent hors dépôt :
+ce sont des secrets. Une machine neuve doit les recevoir avant que les blocs
+`listen 443` ne fonctionnent, faute de quoi nginx refusera de démarrer.
+
+⚠️ **Liste blanche MongoDB Atlas.** Un test depuis une machine extérieure indique
+que le cluster n'est pas restreint par IP. **À confirmer dans le tableau de bord
+Atlas** (*Network Access*) avant toute migration : si une restriction existe, une
+machine neuve serait refusée et le backend échouerait au démarrage sur la
+connexion Mongo — un symptôme qui n'oriente pas vers sa cause.
+
 **Garde-fou de branche.** `deploy.sh` refuse de déployer si le checkout n'est pas
 sur la branche attendue (#384). `git pull --ff-only` suit la branche **courante** :
 une branche de travail laissée en place sur la machine serait déployée sans que

--- a/ops/nginx/README.md
+++ b/ops/nginx/README.md
@@ -1,0 +1,14 @@
+# `ops/nginx/` — configuration du reverse-proxy
+
+Appliquée par `deploy.sh` vers `/etc/nginx/conf.d/`, validée par `nginx -t`
+**avant** rechargement. Une configuration invalide interrompt le déploiement
+sans toucher au service en cours.
+
+## Ce qui n'est PAS ici
+
+Les **certificats** `/etc/ssl/cloudflare/origin.{pem,key}` — ce sont des
+secrets, et ils restent hors dépôt. Une machine neuve doit les recevoir avant
+que les blocs `listen 443` ne fonctionnent ; nginx refusera de démarrer sinon.
+
+C'est le troisième geste manuel d'une migration, après l'installation de Docker
+et la pose de la clé age.

--- a/ops/nginx/arbore.conf
+++ b/ops/nginx/arbore.conf
@@ -1,0 +1,53 @@
+# Issue #121 — TLS termination via Cloudflare.
+# Cloudflare resolves api.arbore.app and forwards to this origin.
+# :80 kept active during the Flexible -> Full(strict) transition (zero downtime).
+# Real client IPs arrive in CF-Connecting-IP / X-Forwarded-For headers.
+
+# Production vhost over HTTP (Cloudflare Flexible). Kept live during transition.
+server {
+    listen 80;
+    server_name api.arbore.app;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+# Production vhost over TLS — Cloudflare Origin certificate. Used once the
+# Cloudflare SSL mode is switched to Full (strict). Firewall restricts :443
+# to Cloudflare IPs (same CF-HTTP chain as :80).
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.arbore.app;
+
+    ssl_certificate     /etc/ssl/cloudflare/origin.pem;
+    ssl_certificate_key /etc/ssl/cloudflare/origin.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+# Catch-all on IP — kept for direct dev access (debug builds), no Host header
+# constraint. Same upstream.
+server {
+    listen 80 default_server;
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/ops/nginx/web.conf
+++ b/ops/nginx/web.conf
@@ -1,0 +1,71 @@
+# web.arbore.app — reverse-proxy vers le conteneur Next.js (arbore-web, :3000).
+# + proxy des chemins réservés Firebase (/__/auth/, /__/firebase/) pour un
+#   authDomain custom. sub_filter recolore la page handler Firebase (boutons
+#   MDL indigo #3f51b5 / accent #ff4081 -> vert Arbore #234632).
+
+map $http_upgrade $connection_upgrade { default upgrade; "" close; }
+
+server {
+    listen 80;
+    server_name web.arbore.app;
+
+    location /__/auth/ {
+        proxy_pass https://arbore-b1986.firebaseapp.com;
+        proxy_set_header Host arbore-b1986.firebaseapp.com;
+        proxy_set_header Accept-Encoding "";
+        proxy_ssl_server_name on;
+        proxy_cookie_flags ~ samesite=none secure;
+        sub_filter_once off;
+        sub_filter_types *;
+        sub_filter '#3f51b5' '#234632';
+        sub_filter '#ff4081' '#234632';
+    }
+    location /__/firebase/ {
+        proxy_pass https://arbore-b1986.firebaseapp.com;
+        proxy_set_header Host arbore-b1986.firebaseapp.com;
+        proxy_ssl_server_name on;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name web.arbore.app;
+
+    ssl_certificate     /etc/ssl/cloudflare/origin.pem;
+    ssl_certificate_key /etc/ssl/cloudflare/origin.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location /__/auth/ {
+        proxy_pass https://arbore-b1986.firebaseapp.com;
+        proxy_set_header Host arbore-b1986.firebaseapp.com;
+        proxy_set_header Accept-Encoding "";
+        proxy_ssl_server_name on;
+        proxy_cookie_flags ~ samesite=none secure;
+        sub_filter_once off;
+        sub_filter_types *;
+        sub_filter '#3f51b5' '#234632';
+        sub_filter '#ff4081' '#234632';
+    }
+    location /__/firebase/ {
+        proxy_pass https://arbore-b1986.firebaseapp.com;
+        proxy_set_header Host arbore-b1986.firebaseapp.com;
+        proxy_ssl_server_name on;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}


### PR DESCRIPTION
Dernière lacune révélée par la **répétition de migration** (#401 étape 6) : la configuration du reverse-proxy vivait sur la machine et nulle part ailleurs.

Une machine neuve n'aurait eu ni terminaison TLS ni proxy — exactement la situation du crontab avant #400.

```
ops/nginx/arbore.conf   api.arbore.app  → backend :8080
ops/nginx/web.conf      web.arbore.app  → Next.js :3000
                        + proxy des chemins Firebase /__/auth/
```

Récupérées depuis le VPS et **vérifiées par empreinte SHA-256** : identiques à l'octet près à ce qui tourne.

## Validation AVANT rechargement

`apply_nginx` installe, lance `nginx -t`, et ne recharge **que si la configuration est valide**. En cas d'échec elle restaure la version précédente et interrompt le déploiement.

Sans cette vérification, une syntaxe fautive couperait le site pendant qu'un déploiement s'annoncerait réussi.

L'étape est sans effet si nginx est absent ou si sudo manque : une machine sans reverse-proxy se déploie comme avant.

## Pourquoi cette lacune avait échappé

nginx est un **service de l'hôte**, pas un conteneur — vérifié : aucun conteneur nginx, service systemd actif, `proxy_pass` vers `127.0.0.1`.

Il échappait donc au raisonnement « tout ce qui tourne est dans `docker-compose.yml` ». Même angle mort que pour le crontab et les unités systemd : **ce qui vit hors des conteneurs était invisible**.

`ops/` couvre désormais les trois.

## Ce qui reste hors dépôt, par conception

Les certificats `/etc/ssl/cloudflare/origin.{pem,key}` sont des secrets. Une machine neuve doit les recevoir avant que les blocs `listen 443` ne fonctionnent — nginx refuserait de démarrer sinon. Documenté.

## MongoDB Atlas

Un test TCP depuis une machine **extérieure au VPS** montre le port 27017 joignable : le cluster n'est vraisemblablement pas restreint par IP.

Une connexion TCP n'étant pas une authentification, c'est un **indice, pas une preuve**. La documentation demande de confirmer dans le tableau de bord Atlas (*Network Access*).

Si une restriction existait, une machine neuve serait refusée et le backend échouerait au démarrage sur Mongo — un symptôme qui n'oriente pas vers sa cause.

## Après cette PR, une migration demande trois gestes manuels

```
1. installer Docker, nginx et les paquets   documenté
2. poser la clé age privée                   secret d'amorçage irréductible
3. poser les certificats Cloudflare          secrets, hors dépôt
```

Tout le reste se reconstitue depuis le dépôt.

Refs #401