### PR TITLE
chore(release): pare-feu d'origine sur le chemin conteneur, rejeu des services oneshot

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -439,6 +439,32 @@ do_apply_ops() {
     else
         ok "systemd et scripts déjà conformes"
     fi
+
+    # Rejouer les services `oneshot` quand leur script ou leur unité a changé.
+    #
+    # Sans ceci, installer un script ne l'exécute jamais : le fichier change sur
+    # disque, le comportement pas. Un correctif de pare-feu resterait sans effet
+    # jusqu'au prochain redémarrage de la machine — et rien ne le signalerait.
+    # C'est le mode d'échec de #341 appliqué à ops/ (#434).
+    #
+    # Restreint aux `oneshot` : rejouer un service au long cours couperait le
+    # service qu'il rend. Ceux-ci sont idempotents par conception, et
+    # cf-http-firewall.sh porte sa propre liste de repli, donc il ne dépend pas
+    # d'un rafraîchissement préalable des plages.
+    if [ "$changed" -eq 1 ] || [ "$units_changed" -eq 1 ]; then
+        local unit name replayed=0
+        for unit in "$SCRIPT_DIR"/ops/systemd/*.service; do
+            [ -e "$unit" ] || continue
+            grep -q '^Type=oneshot' "$unit" || continue
+            name="$(basename "$unit")"
+            if sudo systemctl restart "$name" 2>/dev/null; then
+                replayed=$((replayed + 1))
+            else
+                warn "$name n'a pas pu être rejoué — voir journalctl -u $name"
+            fi
+        done
+        [ "$replayed" -gt 0 ] && ok "Services oneshot rejoués : $replayed"
+    fi
     echo
 }
 

--- a/ops/sbin/cf-http-firewall.sh
+++ b/ops/sbin/cf-http-firewall.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Durcissement reseau de l'origine Arbore (idempotent, ne touche jamais :22) :
-#  - nginx :80  -> autorise uniquement les IP Cloudflare (chaine CF-HTTP)
+#  - :80 et :443 -> autorise uniquement les IP Cloudflare, sur les DEUX chemins :
+#      * nginx sur l'hote      -> chaine CF-HTTP accrochee a INPUT
+#      * nginx en conteneur    -> chaine CF-DOCKER accrochee a DOCKER-USER
+#    Le trafic destine a un conteneur ne traverse PAS INPUT (il passe par
+#    FORWARD/DOCKER-USER). Ne proteger que INPUT laisserait donc l'origine
+#    ouverte des que nginx passerait en conteneur -- sans aucune erreur, le
+#    site continuant de fonctionner (#434).
 #  - :8080 (API Go) et :8000 (AI generator) -> pas d'acces externe direct
 #    (DOCKER-USER v4+v6, scope -i eth0 ; loopback + inter-conteneurs preserves)
 set -euo pipefail
@@ -35,6 +41,34 @@ iptables -C INPUT -p tcp --dport 80 -j CF-HTTP 2>/dev/null || \
 iptables -C INPUT -p tcp --dport 443 -j CF-HTTP 2>/dev/null || \
   iptables -A INPUT -p tcp --dport 443 -j CF-HTTP
 
+# --- :80 / :443 vers un CONTENEUR : Cloudflare uniquement ---
+#
+# Chaine distincte de CF-HTTP, et ce n'est pas une duplication : dans
+# DOCKER-USER il faut RETURN et non ACCEPT. Un ACCEPT serait terminal pour tout
+# le hook FORWARD et court-circuiterait les propres regles de Docker (suivi de
+# connexion, isolation inter-reseaux). RETURN rend la main a DOCKER-USER, qui
+# poursuit normalement.
+#
+# Inerte tant que nginx ecoute sur l'hote : aucun trafic :80/:443 n'est alors
+# forwarde vers un conteneur. La regle devient active le jour ou nginx bascule.
+iptables -N CF-DOCKER 2>/dev/null || true
+iptables -F CF-DOCKER
+for cidr in "${CF_RANGES[@]}"; do iptables -A CF-DOCKER -s "$cidr" -j RETURN; done
+iptables -A CF-DOCKER -j DROP
+for port in 80 443; do
+  iptables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER 2>/dev/null || \
+    iptables -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER
+done
+
+# IPv6 vers un conteneur sur :80/:443 : DROP sec. Les enregistrements DNS de
+# l'origine sont des A (IPv4) -- Cloudflare joint donc l'origine en v4, et il
+# n'existe aucun chemin v6 legitime. Fail-closed, coherent avec le traitement
+# de :8080 et :8000 ci-dessous.
+for port in 80 443; do
+  ip6tables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null || \
+    ip6tables -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
+done
+
 # --- :8080 / :8000 : pas d'acces externe direct (v4 + v6) ---
 for fw in iptables ip6tables; do
   for port in 8080 8000; do
@@ -43,4 +77,4 @@ for fw in iptables ip6tables; do
   done
 done
 
-echo "cf-http-firewall applied OK (${#CF_RANGES[@]} CF ranges)"
+echo "cf-http-firewall applied OK (${#CF_RANGES[@]} CF ranges, INPUT + DOCKER-USER)"


### PR DESCRIPTION
Promotion de #436.

Deux correctifs silencieux, préconditions de #434 :

- le pare-feu d'origine n'accrochait `CF-HTTP` que sur `INPUT` ; le trafic vers un conteneur passe par `DOCKER-USER`. La chaîne `CF-DOCKER` couvre ce second chemin, avec `RETURN` et non `ACCEPT` pour ne pas court-circuiter les règles de Docker.
- `apply_ops` installait les scripts sans jamais rejouer les services `oneshot` : un correctif restait sans effet jusqu'au prochain redémarrage.

**Inerte** : nginx écoute sur l'hôte, aucun trafic `:80`/`:443` n'est forwardé vers un conteneur. Le déploiement doit donc ne rien changer — c'est la vérification recherchée avant que #434 n'en dépende.

À contrôler après déploiement : `sudo iptables -S DOCKER-USER` montre les sauts vers `CF-DOCKER`, et le site répond à l'identique.