### PR TITLE
feat(ops): permettre deux piles simultanées, une par environnement

### DIFF
--- a/ArboreBackend/scripts/reconcile-guests.sh
+++ b/ArboreBackend/scripts/reconcile-guests.sh
@@ -23,7 +23,10 @@
 
 set -euo pipefail
 
-CONTAINER="${ARBORE_BACKEND_CONTAINER:-arbore-backend}"
+# Le nom porte l'environnement depuis #434 : `arbore-prod-backend`,
+# `arbore-dev-backend`. Le défaut vise la PRODUCTION, seule base que ce job
+# traite (cf. reconcile_guests.go, codé en dur sur prodDBName).
+CONTAINER="${ARBORE_BACKEND_CONTAINER:-arbore-${ARBORE_ENV:-prod}-backend}"
 APPLY=""
 
 case "${1:-}" in

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,19 @@ SNAPSHOT_RETENTION_DAYS=14
 # l'environnement — un préfixe `VAR=val sudo …` est silencieusement perdu
 # (vérifié sur le VPS). Vider ce tableau suffit si docker tourne sans sudo.
 DOCKER_PRIVILEGE=( sudo )
-DOCKER_COMPOSE=( "${DOCKER_PRIVILEGE[@]}" docker compose )
+# Un projet compose PAR ENVIRONNEMENT (#434). Sans nom de projet, compose le
+# déduit du nom du répertoire — identique pour les deux piles, qui se
+# recycleraient mutuellement : démarrer dev arrêterait la production, sans
+# qu'aucune commande n'échoue.
+ARBORE_ENV="${ARBORE_ENV:-prod}"
+COMPOSE_PROJECT="arbore-$ARBORE_ENV"
+
+# ARBORE_ENV est passée en ARGUMENT de sudo, pas exportée : sudo efface
+# l'environnement. Un simple `export` n'atteindrait jamais compose, et
+# `container_name` résoudrait toujours vers `arbore-prod-…` — déployer dev
+# recyclerait donc les conteneurs de PRODUCTION, sans qu'aucune commande
+# n'échoue. Même raison que pour GIT_COMMIT et ARBORE_IMAGE_TAG.
+DOCKER_COMPOSE=( "${DOCKER_PRIVILEGE[@]}" ARBORE_ENV="$ARBORE_ENV" docker compose -p "$COMPOSE_PROJECT" )
 
 step() { printf '%b[%s/7]%b %s\n' "$YELLOW" "$1" "$NC" "$2"; }
 ok()   { printf '%b✅ %s%b\n' "$GREEN" "$1" "$NC"; }
@@ -593,8 +605,8 @@ do_docker_images() {
 
     # ARBORE_IMAGE_TAG est consommée par docker-compose.yml. L'assignation vient
     # après DOCKER_PRIVILEGE, cf. le commentaire à sa définition.
-    if "${DOCKER_PRIVILEGE[@]}" ARBORE_IMAGE_TAG="$wanted" \
-        docker compose pull backend ai-generator web; then
+    if "${DOCKER_PRIVILEGE[@]}" ARBORE_ENV="$ARBORE_ENV" ARBORE_IMAGE_TAG="$wanted" \
+        docker compose -p "$COMPOSE_PROJECT" pull backend ai-generator web; then
         IMAGE_TAG="$wanted"
         ok "Images tirées depuis ghcr ($wanted)"
         echo
@@ -607,8 +619,8 @@ do_docker_images() {
     # alors l'image en local et ne retente pas de la tirer.
     # GIT_COMMIT est injecté dans le binaire backend puis renvoyé par GET /health :
     # c'est ce qui rend une dérive prod ↔ main détectable d'un simple curl (#341).
-    if ! "${DOCKER_PRIVILEGE[@]}" GIT_COMMIT="$git_sha" ARBORE_IMAGE_TAG="$wanted" \
-        docker compose build backend ai-generator web; then
+    if ! "${DOCKER_PRIVILEGE[@]}" ARBORE_ENV="$ARBORE_ENV" GIT_COMMIT="$git_sha" ARBORE_IMAGE_TAG="$wanted" \
+        docker compose -p "$COMPOSE_PROJECT" build backend ai-generator web; then
         fail "docker compose build a échoué"
         exit 1
     fi
@@ -620,8 +632,8 @@ do_docker_images() {
 # ───── [5/7] Docker compose up ────────────────────────────────────
 do_docker_up() {
     step 5 "Redémarrage des containers..."
-    if ! "${DOCKER_PRIVILEGE[@]}" ARBORE_IMAGE_TAG="$IMAGE_TAG" \
-        docker compose up -d backend ai-generator web; then
+    if ! "${DOCKER_PRIVILEGE[@]}" ARBORE_ENV="$ARBORE_ENV" ARBORE_IMAGE_TAG="$IMAGE_TAG" \
+        docker compose -p "$COMPOSE_PROJECT" up -d backend ai-generator web; then
         fail "docker compose up a échoué"
         exit 1
     fi
@@ -666,7 +678,7 @@ check_web() {
     if [ "$code" = "200" ]; then
         ok "Web health 200 OK"
     else
-        warn "Web: HTTP $code sur :3000 (non bloquant — voir 'sudo docker logs --tail 50 arbore-web')"
+        warn "Web: HTTP $code sur :3000 (non bloquant — voir 'sudo docker logs --tail 50 arbore-${ARBORE_ENV:-prod}-web')"
     fi
 }
 
@@ -690,7 +702,7 @@ do_health_check() {
     done
 
     fail "Health: HTTP $http_code (après ${max_attempts} essais espacés de 2s)"
-    fail "Vérifier les logs : sudo docker logs --tail 50 arbore-backend"
+    fail "Vérifier les logs : sudo docker logs --tail 50 arbore-${ARBORE_ENV:-prod}-backend"
     exit 1
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,15 @@ services:
     # n'a ni le CPU ni le disque pour trois builds (#425). Le bloc `build:`
     # reste pour le dev local et pour le repli si le tirage échoue.
     image: ${ARBORE_IMAGE_PREFIX:-ghcr.io/arboreteam/arbore}-ai:${ARBORE_IMAGE_TAG:-latest}
-    container_name: arbore-ai-generator
+    # Le nom porte l'environnement (#434). Un nom de conteneur est GLOBAL à
+    # l'hôte : figé, il empêcherait une seconde pile de démarrer, quel que
+    # soit le projet compose.
+    #
+    # Paramétré plutôt que supprimé, car des scripts hors compose résolvent
+    # le conteneur par son nom — notamment le cron de réconciliation
+    # (ArboreBackend/scripts/reconcile-guests.sh). Les laisser deviner un
+    # nom généré `<projet>-<service>-1` serait plus fragile.
+    container_name: arbore-${ARBORE_ENV:-prod}-ai-generator
     restart: unless-stopped
     # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
     # limite : les journaux d'accès contiennent des adresses IP (tronquées
@@ -42,7 +50,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
     ports:
-      - "${BIND_ADDRESS:-127.0.0.1}:8000:8000"
+      - "${BIND_ADDRESS:-127.0.0.1}:${AI_PORT:-8000}:8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=3)"]
       interval: 30s
@@ -68,7 +76,7 @@ services:
     # n'a ni le CPU ni le disque pour trois builds (#425). Le bloc `build:`
     # reste pour le dev local et pour le repli si le tirage échoue.
     image: ${ARBORE_IMAGE_PREFIX:-ghcr.io/arboreteam/arbore}-backend:${ARBORE_IMAGE_TAG:-latest}
-    container_name: arbore-backend
+    container_name: arbore-${ARBORE_ENV:-prod}-backend
     restart: unless-stopped
     # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
     # limite : les journaux d'accès contiennent des adresses IP (tronquées
@@ -182,7 +190,7 @@ services:
     # n'a ni le CPU ni le disque pour trois builds (#425). Le bloc `build:`
     # reste pour le dev local et pour le repli si le tirage échoue.
     image: ${ARBORE_IMAGE_PREFIX:-ghcr.io/arboreteam/arbore}-web:${ARBORE_IMAGE_TAG:-latest}
-    container_name: arbore-web
+    container_name: arbore-${ARBORE_ENV:-prod}-web
     restart: unless-stopped
     # Rotation des journaux (#385). Sans elle, le driver json-file croît sans
     # limite : les journaux d'accès contiennent des adresses IP (tronquées
@@ -255,7 +263,7 @@ services:
   # réelles. Les surcharger via l'environnement si besoin.
   minio:
     image: minio/minio:latest
-    container_name: arbore-minio
+    container_name: arbore-${ARBORE_ENV:-prod}-minio
     profiles: ["dev"]
     restart: unless-stopped
     command: server /data --console-address ":9001"

--- a/ops/nginx/web.conf
+++ b/ops/nginx/web.conf
@@ -1,4 +1,4 @@
-# web.arbore.app — reverse-proxy vers le conteneur Next.js (arbore-web, :3000).
+# web.arbore.app — reverse-proxy vers le conteneur Next.js (arbore-<env>-web).
 # + proxy des chemins réservés Firebase (/__/auth/, /__/firebase/) pour un
 #   authDomain custom. sub_filter recolore la page handler Firebase (boutons
 #   MDL indigo #3f51b5 / accent #ff4081 -> vert Arbore #234632).

--- a/scripts/cleanup-test-db.sh
+++ b/scripts/cleanup-test-db.sh
@@ -114,9 +114,9 @@ fi
 #
 # Le container est piloté par docker-compose ; un simple restart suffit.
 # Variable BACKEND_CONTAINER overridable si le nom change (default
-# arbore-backend, défini dans docker-compose.yml).
+# arbore-<env>-backend, défini dans docker-compose.yml — #434).
 
-BACKEND_CONTAINER="${BACKEND_CONTAINER:-arbore-backend}"
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-arbore-${ARBORE_ENV:-prod}-backend}"
 
 if command -v docker >/dev/null 2>&1 && sudo -n docker ps >/dev/null 2>&1; then
     if sudo -n docker restart "$BACKEND_CONTAINER" >/dev/null 2>&1; then


### PR DESCRIPTION
Second morceau de #434. Permet de déployer un commit sur dev **sans toucher la
production**, ce qui est l'objectif de l'issue.

## Un changement d'approche, que j'assume

L'issue prévoyait de faire passer nginx dans le réseau Docker et de router par
nom d'hôte. **J'ai sur-conçu.**

Mon objection portait sur les ports **aléatoires** : un port tiré au hasard doit
être retenu dans une table qui n'existe que sur la machine — la configuration
volatile que #401 combat. Mais des ports **déclarés par environnement**, dans le
fichier chiffré versionné, n'ont pas ce défaut. C'est de la configuration, pas
de l'état.

Le routage par nom d'hôte reste le meilleur état final, et #434 le conserve en
perspective. Il ne justifiait pas de migrer le proxy pendant que le site tourne,
avec un alias `backend` qui aurait résolu au hasard entre prod et dev, une pile
proxy séparée et un retour arrière à écrire — pour un objectif que des ports
déclarés atteignent tout de suite.

## Trois pièges rencontrés, tous silencieux

**1. `container_name` figé est global à l'hôte.** Une seconde pile refuserait de
démarrer. Paramétré (`arbore-${ARBORE_ENV}-backend`) plutôt que supprimé : des
scripts hors compose résolvent le conteneur par son nom, et leur faire deviner
un nom généré `<projet>-<service>-1` serait plus fragile.

**2. Sans nom de projet, compose le déduit du répertoire** — identique pour les
deux piles, qui se recycleraient mutuellement. **Démarrer dev aurait arrêté la
production**, sans qu'aucune commande n'échoue.

**3. `sudo` efface l'environnement.** Un `export ARBORE_ENV` n'aurait jamais
atteint compose : `container_name` aurait résolu vers `arbore-prod-…` quel que
soit l'environnement demandé, donc dev recyclant les conteneurs de production.
La variable est passée en argument de sudo, comme `GIT_COMMIT` et
`ARBORE_IMAGE_TAG` avant elle.

## Conséquence : les conteneurs de production sont renommés

`arbore-backend` → `arbore-prod-backend`. Ce qui les résout par nom devait
suivre :

| Fichier | Rôle |
|---|---|
| `ArboreBackend/scripts/reconcile-guests.sh` | **cron hebdomadaire** de suppression des données orphelines — sans ce correctif il ne trouve plus le conteneur |
| `scripts/cleanup-test-db.sh` | nettoyage de la base de test |
| `deploy.sh` × 2 | messages d'aide |

Le premier est le plus important : le job aurait échoué chaque dimanche, et
personne ne lit les journaux d'un cron qui a toujours marché.

## Vérifications

```
ARBORE_ENV=prod → arbore-prod-{backend,web,ai-generator}  :8080 :3000 :8000
ARBORE_ENV=dev  → arbore-dev-{backend,web,ai-generator}   :8081 :3001 :8001
```

- `docker compose config` produit des noms **et** des ports distincts ✅
- Les quatre invocations de compose transmettent `ARBORE_ENV` à travers sudo ✅
- `bash -n` sur les trois scripts modifiés ✅
- Le port de l'ai-generator était le seul non paramétré ; il l'est désormais

## Au déploiement

Les conteneurs de production seront **recréés** sous leur nouveau nom — même
effet qu'un déploiement ordinaire, quelques secondes d'indisponibilité.

À vérifier ensuite : `docker ps` montre bien `arbore-prod-*`, et le cron de
réconciliation trouve son conteneur (`ARBORE_BACKEND_CONTAINER` inchangé, le
défaut suit l'environnement).

## Reste de #434

- Remplir `ops/secrets/dev.enc.env` — ports, `MONGODB_URI` → `arbore_test`
- `infra/envs/dev.tfvars` pour `api-dev` / `web-dev`
- Blocs `server` nginx pour dev
- Vérifier que `ARBORE_ENV=dev ./deploy.sh` tient de bout en bout : la garde de
  branche, le snapshot pre-deploy et le health check supposent tous la prod
