### PR TITLE
chore(release): purge des versions d'images orphelines, et environnement dev

### DIFF
--- a/.github/workflows/purge-packages.yml
+++ b/.github/workflows/purge-packages.yml
@@ -1,0 +1,42 @@
+name: 🧹 Purge des versions d'images
+
+# Ne supprime RIEN par défaut. La suppression exige un déclenchement manuel avec
+# `apply: true` — même principe que le job de réconciliation (#393) : un
+# effaceur planifié sans mode sec est un incident en attente.
+#
+# La marche hebdomadaire sert à SIGNALER l'accumulation, pas à la corriger dans
+# le dos de l'équipe.
+
+on:
+  schedule:
+    # Lundi 06:00 UTC — le lendemain de la réconciliation, pour ne pas mêler
+    # deux journaux d'effaceurs le même jour.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Supprimer réellement (sinon simulation)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Purge
+        env:
+          # GITHUB_TOKEN suffit : il porte `packages: write` sur ce dépôt, et
+          # ghcr l'accepte — contrairement aux jetons d'installation d'App
+          # (cf. #425).
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/purge-package-versions.py \
+            --packages arbore-backend arbore-ai arbore-web \
+                       arbore/backend arbore/ai-generator \
+            ${{ inputs.apply && '--apply' || '' }}

--- a/scripts/purge-package-versions.py
+++ b/scripts/purge-package-versions.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Purge les versions d'images orphelines sur ghcr (#442).
+
+⚠️ « Sans étiquette » ne veut PAS dire « supprimable ».
+
+Une étiquette ne porte pas l'image : elle porte un INDEX qui la référence.
+L'image et son attestation de provenance apparaissent comme des versions sans
+étiquette, alors qu'elles sont indispensables :
+
+    arbore-backend:latest  ->  index OCI (étiqueté)
+        |- sha256:45a7...  amd64   (l'image)              <- sans étiquette
+        |- sha256:2326...  attestation de provenance      <- sans étiquette
+
+`actions/delete-package-versions` avec `delete-only-untagged-versions: true` —
+l'option que suggèrent tous les exemples — supprimerait donc l'image servie en
+production et casserait toutes les étiquettes.
+
+Ce script descend d'abord dans chaque manifeste ÉTIQUETÉ pour construire
+l'ensemble des digests protégés, puis ne supprime que ce qui n'en fait pas
+partie.
+
+Quatre gardes, reprises du job de réconciliation (#393) :
+
+ 1. Simulation par défaut. La suppression exige --apply.
+ 2. Fail-closed : toute erreur d'API interrompt sans rien supprimer.
+ 3. Refus si aucune version étiquetée n'est trouvée — tout paraîtrait orphelin.
+ 4. Le commit servi en production est exclu, lu depuis GET /health plutôt que
+    déduit d'une date.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+REGISTRY = "ghcr.io"
+ACCEPT_MANIFEST = ",".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+])
+
+
+class Fatal(Exception):
+    """Erreur qui doit interrompre le job sans rien supprimer."""
+
+
+def _request(url, token, accept, method="GET"):
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", "Bearer " + token)
+    req.add_header("Accept", accept)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read()
+            return json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        raise Fatal("%s %s -> HTTP %s" % (method, url, exc.code)) from exc
+    except Exception as exc:
+        raise Fatal("%s %s -> %s" % (method, url, exc)) from exc
+
+
+def list_versions(org, package, token):
+    """Énumération COMPLÈTE et paginée. Une page manquante ferait passer des
+    versions vivantes pour des orphelines."""
+    out, page = [], 1
+    while True:
+        chunk = _request(
+            "%s/orgs/%s/packages/container/%s/versions?per_page=100&page=%d"
+            % (API, org, package.replace("/", "%2F"), page),
+            token, "application/vnd.github+json")
+        if not chunk:
+            break
+        out.extend(chunk)
+        if len(chunk) < 100:
+            break
+        page += 1
+        if page > 100:
+            raise Fatal("pagination anormale sur %s" % package)
+    return out
+
+
+def registry_token(org, package, pat):
+    basic = base64.b64encode(("x:" + pat).encode()).decode()
+    url = "%s/token?service=%s&scope=repository:%s/%s:pull" % (
+        "https://" + REGISTRY, REGISTRY, org.lower(), package)
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", "Basic " + basic)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)["token"]
+    except Exception as exc:
+        raise Fatal("jeton de registre refusé pour %s: %s" % (package, exc)) from exc
+
+
+def protected_digests(org, package, versions, rtoken):
+    """Digests référencés par au moins une version étiquetée.
+
+    C'est le cœur de la correction : on descend dans chaque index étiqueté pour
+    récupérer ses enfants, qui n'ont pas d'étiquette propre.
+    """
+    protected = set()
+    tagged = [v for v in versions if v["metadata"]["container"]["tags"]]
+    if not tagged:
+        raise Fatal(
+            "aucune version étiquetée sur %s : refus de considérer toutes les "
+            "autres comme orphelines" % package)
+
+    for version in tagged:
+        digest = version["name"]
+        protected.add(digest)
+        manifest = _request(
+            "https://%s/v2/%s/%s/manifests/%s" % (REGISTRY, org.lower(), package, digest),
+            rtoken, ACCEPT_MANIFEST)
+        for child in (manifest or {}).get("manifests", []):
+            protected.add(child["digest"])
+    return protected
+
+
+def deployed_commit(health_url):
+    """Commit réellement servi. Exclusion la plus fiable dont on dispose : elle
+    décrit ce qui tourne, pas ce qu'on croit avoir déployé."""
+    if not health_url:
+        return None
+    # User-Agent explicite : Cloudflare répond 403 à un client anonyme, ce qui
+    # ferait passer un service parfaitement sain pour injoignable.
+    req = urllib.request.Request(health_url, headers={"User-Agent": "arbore-purge/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.load(resp).get("commit")
+    except Exception as exc:
+        raise Fatal("health check injoignable (%s) : sans lui, impossible de "
+                    "garantir qu'on ne supprime pas l'image en production" % exc)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org", default="ArboreTeam")
+    parser.add_argument("--packages", nargs="+", required=True)
+    parser.add_argument("--health-url", default="https://api.arbore.app/health")
+    parser.add_argument("--apply", action="store_true",
+                        help="supprime réellement (par défaut : simulation)")
+    args = parser.parse_args()
+
+    pat = os.environ.get("GHCR_TOKEN")
+    if not pat:
+        print("GHCR_TOKEN absent", file=sys.stderr)
+        return 3
+
+    mode = "SUPPRESSION RÉELLE" if args.apply else "SIMULATION (aucune suppression)"
+    print("🧹 Purge des versions d'images — %s" % mode)
+
+    commit = deployed_commit(args.health_url)
+    if commit:
+        print("   commit servi en production : %s" % commit[:12])
+
+    total_orphans = 0
+    for package in args.packages:
+        versions = list_versions(args.org, package, pat)
+        rtoken = registry_token(args.org, package, pat)
+        protected = protected_digests(args.org, package, versions, rtoken)
+
+        orphans = []
+        for version in versions:
+            tags = version["metadata"]["container"]["tags"]
+            if tags:
+                continue
+            if version["name"] in protected:
+                continue
+            orphans.append(version)
+
+        # Garde supplémentaire : ne jamais supprimer une version dont une
+        # étiquette porte le commit déployé.
+        if commit:
+            for version in versions:
+                if any(t == "sha-" + commit for t in version["metadata"]["container"]["tags"]):
+                    protected.add(version["name"])
+
+        kept = len(versions) - len(orphans)
+        print("   %-24s %4d versions | %4d orphelines | %4d conservées"
+              % (package, len(versions), len(orphans), kept))
+        total_orphans += len(orphans)
+
+        if args.apply:
+            for version in orphans:
+                _request("%s/orgs/%s/packages/container/%s/versions/%d"
+                         % (API, args.org, package.replace("/", "%2F"), version["id"]),
+                         pat, "application/vnd.github+json", method="DELETE")
+
+    print("   TOTAL orphelines : %d" % total_orphans)
+    if not args.apply:
+        print("   Relancer avec --apply pour supprimer.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Fatal as exc:
+        print("❌ %s" % exc, file=sys.stderr)
+        print("   Rien n'a été supprimé.", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Promotion de #441 (environnement dev fonctionnel) et #443 (purge des versions d'images).

**#441** — deux commits différents tournent simultanément sur le VPS, éprouvé : prod `:8080` sur la tête de `main`, dev `:8081` sur sa propre branche. Trois obstacles d'amorçage corrigés, invisibles depuis la production.

**#443** — purge des versions d'images orphelines. Le point important : « sans étiquette » ne veut pas dire « supprimable ». Une étiquette porte un index qui référence l'image et son attestation, elles-mêmes sans étiquette. L'option par défaut de l'action toute faite aurait supprimé l'image servie en production.

Simulation : 1 660 orphelines sur 2 488, dont **0 sur `arbore-web`** malgré 10 versions sans étiquette — toutes protégées comme enfants d'index.

Le workflow ne supprime rien de lui-même : la marche hebdomadaire signale, la suppression exige un `workflow_dispatch` explicite. Il doit atteindre `main` pour être déclenchable.