### PR TITLE
feat(ci): publier aussi les images de la branche dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,17 @@ name: 📦 Build & Publish images
 
 on:
   push:
-    branches: [ "main" ]
+    # `dev` publie aussi (#434) : sans ça, chaque déploiement de l'environnement
+    # de dev rebâtissait sur le VPS, ce qui annulait le bénéfice de #425.
+    #
+    # Le coût est borné par la rétention (#442) : dix versions `sha-` par
+    # package, les releases `v*` et les étiquettes mouvantes exclues. Sans cette
+    # borne posée d'abord, on aurait ajouté un robinet à une baignoire sans
+    # bonde.
+    #
+    # `latest` reste attaché à la branche par défaut via `is_default_branch` :
+    # une publication depuis `dev` ne la déplace pas.
+    branches: [ "main", "dev" ]
     tags: [ "v*" ]
   # Les PR sont BUILDÉES sans être publiées : une image cassée est détectée
   # avant le merge, pas après. C'est l'apport principal de l'ancien workflow, et

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -516,6 +516,47 @@ external access is blocked by the firewall above.
 
 ---
 
+## Dev environment — a second stack on the same machine
+
+Since #434 the machine runs two independent stacks. They share the kernel, the
+disk and the Firebase project; they share **neither the deployed version, nor
+the ports, nor the environment file**.
+
+| | production | dev |
+|---|---|---|
+| Checkout | `/home/fedora/Arbore` | `/home/fedora/Arbore-dev` |
+| Branch | `main` | `dev` |
+| Compose project | `arbore-prod` | `arbore-dev` |
+| Containers | `arbore-prod-*` | `arbore-dev-*` |
+| Ports | 8080 / 3000 / 8000 | 8081 / 3001 / 8001 |
+| Environment file | `.env` | `.env.dev` |
+| Mongo database | `arbore` | `arbore_test` |
+| age key | `arbore-prod.txt` | `arbore-dev.txt` |
+
+**One checkout per environment is required, not a convenience**: `deploy.sh`
+derives the image tag from `git rev-parse HEAD`. A shared checkout would deploy
+the same commit on both sides, defeating the point of having two environments.
+
+Deploying dev:
+
+```bash
+cd /home/fedora/Arbore-dev
+ARBORE_ENV=dev ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
+Checking that both serve distinct commits:
+
+```bash
+curl -s http://localhost:8080/health | jq -r .commit   # prod
+curl -s http://localhost:8081/health | jq -r .commit   # dev
+```
+
+**A non-primary environment does not touch host configuration** — crontab,
+systemd units, nginx. The crontab is rendered with the current checkout path:
+applied from `Arbore-dev` it would point production's jobs at that directory,
+the reconciliation job included. Only `ARBORE_PRIMARY_ENV` (default `prod`)
+applies them.
+
 ## Appendix — Secret rotation
 
 In case of a leak (see issue history #117, #119):

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -517,6 +517,48 @@ externe direct est bloqué par le firewall ci-dessus.
 
 ---
 
+## Environnement de dev — seconde pile sur la même machine
+
+Depuis #434, la machine porte deux piles indépendantes. Elles partagent le
+noyau, le disque et le projet Firebase ; elles ne partagent **ni la version
+déployée, ni les ports, ni le fichier d'environnement**.
+
+| | production | dev |
+|---|---|---|
+| Checkout | `/home/fedora/Arbore` | `/home/fedora/Arbore-dev` |
+| Branche | `main` | `dev` |
+| Projet compose | `arbore-prod` | `arbore-dev` |
+| Conteneurs | `arbore-prod-*` | `arbore-dev-*` |
+| Ports | 8080 / 3000 / 8000 | 8081 / 3001 / 8001 |
+| Fichier d'environnement | `.env` | `.env.dev` |
+| Base Mongo | `arbore` | `arbore_test` |
+| Clé age | `arbore-prod.txt` | `arbore-dev.txt` |
+
+**Un checkout par environnement est nécessaire, pas confortable** :
+`deploy.sh` calcule l'étiquette d'image depuis `git rev-parse HEAD`. Un checkout
+partagé ferait déployer le même commit des deux côtés, ce qui annulerait
+l'intérêt d'avoir deux environnements.
+
+Déployer dev :
+
+```bash
+cd /home/fedora/Arbore-dev
+ARBORE_ENV=dev ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
+Vérifier que les deux servent bien des commits distincts :
+
+```bash
+curl -s http://localhost:8080/health | jq -r .commit   # prod
+curl -s http://localhost:8081/health | jq -r .commit   # dev
+```
+
+**Un environnement non primaire ne touche pas à la configuration hôte** —
+crontab, unités systemd, nginx. Le crontab est rendu avec le chemin du checkout
+courant : appliqué depuis `Arbore-dev`, il ferait pointer les tâches de la
+production vers ce répertoire, job de réconciliation compris. Seul
+`ARBORE_PRIMARY_ENV` (défaut `prod`) les applique.
+
 ## Annexe — Rotation des secrets
 
 En cas de fuite (cf. historique des issues #117, #119) :


### PR DESCRIPTION
Étape 5 et dernière de la séquence de #442. **Débloque #434.**

## Pourquoi maintenant, et pas plus tôt

Sans publication pour `dev`, chaque déploiement de l'environnement de dev
retombait sur un build local :

```
⚠️  Tirage ghcr échoué pour sha-346900f… — repli sur un build local
✅ Build local réussi
```

Le repli fonctionne, bruyamment, comme conçu — mais le bénéfice de #425 était
annulé pour cet environnement : ~10 min de CPU sur le VPS à chaque déploiement.

**L'ajouter avant la rétention aurait été ajouter un robinet à une baignoire
sans bonde.** C'est maintenant borné : dix versions `sha-` par package, releases
`v*` et étiquettes mouvantes exclues.

## Ce qui ne bouge pas

`latest` reste attaché à la branche par défaut via `is_default_branch`. Une
publication depuis `dev` ne la déplace pas, et le repli manuel
`docker pull …:latest` continue de désigner la production.

## Documentation

Les deux runbooks gagnent la table des différences entre les deux piles, et les
deux points qui ne se devinent pas :

**Un checkout par environnement est nécessaire, pas confortable.** `deploy.sh`
calcule l'étiquette d'image depuis `git rev-parse HEAD` — un checkout partagé
ferait déployer le même commit des deux côtés, ce qui annulerait l'intérêt
d'avoir deux environnements. Découvert à l'essai, écrit nulle part avant.

**Un environnement non primaire ne touche pas à la configuration hôte.** Le
crontab est rendu avec le chemin du checkout courant : appliqué depuis
`Arbore-dev`, il ferait pointer les tâches de production vers ce répertoire, job
de réconciliation compris.

## Après le merge

Le checkout de dev sur le VPS suit une branche de feature ; il devra passer sur
`dev` pour profiter des images publiées :

```bash
cd /home/fedora/Arbore-dev && git checkout dev
ARBORE_ENV=dev ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
```

Le tirage devra alors réussir, et le journal ne plus mentionner de build local.

## Séquence

~~1. purger les orphelins~~ · ~~2. consolider (#429)~~ · 3. supprimer l'ancien
nommage *(interface)* · ~~4. rétention~~ · ~~**5. publier pour dev**~~
