### PR TITLE
chore(release): déploiement par release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: 🏷️ Release
+
+# Crée la release GitHub quand une étiquette `v*` est poussée.
+#
+# Ne construit ni ne publie d'image : `deploy.yml` réagit déjà aux mêmes
+# étiquettes et produit `1.2.3`, `1.2` et `sha-<commit>`. Dupliquer le build
+# ici referait l'erreur de #429.
+#
+# La release est le point de décision de la mise en production. Le déploiement
+# reste manuel :
+#   ARBORE_DEPLOY_TAG=v1.2.0 ./deploy.sh
+
+on:
+  push:
+    tags: [ "v*" ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Historique complet : les notes sont générées à partir des commits
+          # depuis l'étiquette précédente.
+          fetch-depth: 0
+
+      - name: Créer la release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Les images portent le commit, pas l'étiquette : c'est `sha-<commit>`
+          # que `deploy.sh` tire. On le rappelle dans les notes pour qu'un
+          # retour arrière ne demande pas d'aller le chercher.
+          commit="$(git rev-parse HEAD)"
+          repo_lower="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+
+          {
+            echo "## Déployer cette release"
+            echo
+            echo '```bash'
+            echo "cd /home/fedora/Arbore"
+            echo "ARBORE_DEPLOY_TAG=$TAG ./deploy.sh"
+            echo '```'
+            echo
+            echo "Vérifier ensuite :"
+            echo '```bash'
+            echo "curl -s https://api.arbore.app/health | jq -r .commit"
+            echo "# attendu : $commit"
+            echo '```'
+            echo
+            echo "## Images"
+            echo
+            for suffix in backend ai web; do
+              echo "- \`ghcr.io/${repo_lower}-${suffix}:${TAG#v}\`"
+            done
+            echo
+            echo "Également étiquetées \`sha-$commit\`."
+          } > notes.md
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file notes.md \
+            --generate-notes

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 # deploy.sh — Déploiement automatisé d'Arbore (backend + ai-generator + web) sur le VPS.
 #
 # Enchaîne :
-#   1. git pull --ff-only
+#   1. git pull --ff-only, ou checkout d'une release (ARBORE_DEPLOY_TAG)
 #   2. mongodump pre-deploy → backups/daily/arbore-predeploy-<ISO>.tar.gz
 #   3. rotation des snapshots > 14 jours
 #   4. tirage des images ghcr (repli : build local)
@@ -155,13 +155,30 @@ do_git_pull() {
     # Paramétrable plutôt que codé en dur : #401 vise plusieurs environnements,
     # et une machine de staging déploierait légitimement `dev`. La production ne
     # définit pas la variable et refuse donc tout sauf `main`.
-    local expected_branch="${ARBORE_DEPLOY_BRANCH:-main}"
-    local current_branch
-    current_branch="$(git rev-parse --abbrev-ref HEAD)"
-    if [ "$current_branch" != "$expected_branch" ]; then
-        fail "Checkout sur '$current_branch', attendu '$expected_branch' — déploiement refusé"
-        fail "Pour déployer une autre branche : ARBORE_DEPLOY_BRANCH=<branche> ./deploy.sh"
-        exit 1
+    # Deux modes de déploiement, exclusifs.
+    #
+    #   BRANCHE  (défaut)  suit la tête de `main` — le flux quotidien
+    #   RELEASE  ARBORE_DEPLOY_TAG=v1.2.0 — déploie une étiquette figée
+    #
+    # Le mode release existe parce qu'une branche est une cible MOUVANTE :
+    # « déployer main » ne désigne pas la même chose selon l'heure. Une release
+    # nomme un artefact précis, ce qui rend le retour arrière évident — on
+    # redéploie `v1.2.0`, on ne cherche pas un SHA dans un journal.
+    local deploy_tag="${ARBORE_DEPLOY_TAG:-}"
+
+    if [ -z "$deploy_tag" ]; then
+        # Garde-fou de branche (#384). `git pull --ff-only` suit la branche
+        # COURANTE du checkout : si quelqu'un en laisse une autre en place, le
+        # script la déploierait sans rien signaler.
+        local expected_branch="${ARBORE_DEPLOY_BRANCH:-main}"
+        local current_branch
+        current_branch="$(git rev-parse --abbrev-ref HEAD)"
+        if [ "$current_branch" != "$expected_branch" ]; then
+            fail "Checkout sur '$current_branch', attendu '$expected_branch' — déploiement refusé"
+            fail "Pour déployer une autre branche : ARBORE_DEPLOY_BRANCH=<branche> ./deploy.sh"
+            fail "Pour déployer une release       : ARBORE_DEPLOY_TAG=v1.2.0 ./deploy.sh"
+            exit 1
+        fi
     fi
 
     # Trois catégories, traitées différemment :
@@ -208,7 +225,25 @@ do_git_pull() {
         warn "$untracked fichier(s) non suivis présents — ignorés (sans effet sur un fast-forward)"
     fi
 
-    if ! git pull --ff-only; then
+    if [ -n "$deploy_tag" ]; then
+        # Mode release : on récupère les étiquettes puis on se place dessus en
+        # HEAD détachée. Pas de `git pull` — il n'a pas de sens hors d'une
+        # branche, et une release ne doit surtout pas bouger.
+        if ! git fetch --tags --force --quiet origin; then
+            fail "Impossible de récupérer les étiquettes"
+            exit 1
+        fi
+        if ! git rev-parse -q --verify "refs/tags/$deploy_tag" > /dev/null; then
+            fail "Release '$deploy_tag' introuvable"
+            fail "Étiquettes disponibles : $(git tag --list 'v*' --sort=-version:refname | head -5 | tr '\n' ' ')"
+            exit 1
+        fi
+        if ! git checkout --quiet --detach "refs/tags/$deploy_tag"; then
+            fail "Impossible de se placer sur '$deploy_tag'"
+            exit 1
+        fi
+        ok "Release $deploy_tag ($(git rev-parse --short HEAD))"
+    elif ! git pull --ff-only; then
         fail "Erreur lors du git pull"
         if [ "$out_of_band" -gt 0 ]; then
             fail "Si un commit entrant touche ${OUT_OF_BAND_PATHS[*]}, git refuse d'écraser les"
@@ -216,7 +251,9 @@ do_git_pull() {
         fi
         exit 1
     fi
-    ok "Git pull réussi"
+    if [ -z "$deploy_tag" ]; then
+        ok "Git pull réussi"
+    fi
 
     # Le script vient peut-être de se remplacer lui-même. bash lit le fichier
     # au fil de l'exécution : sans ré-exécution, on continuerait avec l'ANCIENNE

--- a/docs/en/operations/vps-bootstrap.md
+++ b/docs/en/operations/vps-bootstrap.md
@@ -516,6 +516,51 @@ external access is blocked by the firewall above.
 
 ---
 
+## Releases — deploying a fixed target rather than a branch
+
+`main` is a **moving** target: "deploy main" does not mean the same thing at
+different times. A release names a precise artefact, which makes rollback
+obvious — you redeploy `v1.2.0`, you do not hunt for a SHA in a log.
+
+### Cutting a release
+
+```bash
+git checkout main && git pull
+git tag -a v1.2.0 -m "Guest access, image pulling"
+git push origin v1.2.0
+```
+
+Two workflows react: `deploy.yml` publishes images tagged `1.2.0`, `1.2` and
+`sha-<commit>`; `release.yml` creates the GitHub release with its notes.
+
+### Deploying a release
+
+```bash
+cd /home/fedora/Arbore
+ARBORE_DEPLOY_TAG=v1.2.0 ./deploy.sh
+```
+
+The checkout moves to a detached HEAD on the tag. No `git pull`: it is
+meaningless outside a branch, and a release must not move.
+
+### Rolling back
+
+```bash
+ARBORE_DEPLOY_TAG=v1.1.0 ./deploy.sh
+```
+
+That is all. The `v1.1.0` image still exists: retention keeps versions carrying
+a `v*` tag **indefinitely**, and only purges branch `sha-` versions beyond the
+ten most recent (#442).
+
+### Returning to branch tracking
+
+```bash
+git checkout main && ./deploy.sh
+```
+
+Branch mode is the default; simply leave `ARBORE_DEPLOY_TAG` unset.
+
 ## Dev environment — a second stack on the same machine
 
 Since #434 the machine runs two independent stacks. They share the kernel, the

--- a/docs/fr/operations/vps-bootstrap.md
+++ b/docs/fr/operations/vps-bootstrap.md
@@ -517,6 +517,52 @@ externe direct est bloqué par le firewall ci-dessus.
 
 ---
 
+## Releases — déployer une cible figée plutôt qu'une branche
+
+`main` est une cible **mouvante** : « déployer main » ne désigne pas la même
+chose selon l'heure. Une release nomme un artefact précis, ce qui rend le retour
+arrière évident — on redéploie `v1.2.0`, on ne cherche pas un SHA dans un
+journal.
+
+### Publier une release
+
+```bash
+git checkout main && git pull
+git tag -a v1.2.0 -m "Accès invité, tirage d'images"
+git push origin v1.2.0
+```
+
+Deux workflows réagissent : `deploy.yml` publie les images étiquetées `1.2.0`,
+`1.2` et `sha-<commit>` ; `release.yml` crée la release GitHub avec ses notes.
+
+### Déployer une release
+
+```bash
+cd /home/fedora/Arbore
+ARBORE_DEPLOY_TAG=v1.2.0 ./deploy.sh
+```
+
+Le checkout passe en HEAD détachée sur l'étiquette. Pas de `git pull` : il n'a
+pas de sens hors d'une branche, et une release ne doit pas bouger.
+
+### Revenir en arrière
+
+```bash
+ARBORE_DEPLOY_TAG=v1.1.0 ./deploy.sh
+```
+
+C'est tout. L'image de `v1.1.0` existe encore : la rétention conserve
+**indéfiniment** les versions portant une étiquette `v*`, et ne purge que les
+`sha-` de branche au-delà des dix plus récentes (#442).
+
+### Revenir au suivi de branche
+
+```bash
+git checkout main && ./deploy.sh
+```
+
+Le mode branche est le défaut ; il suffit de ne pas définir `ARBORE_DEPLOY_TAG`.
+
 ## Environnement de dev — seconde pile sur la même machine
 
 Depuis #434, la machine porte deux piles indépendantes. Elles partagent le


### PR DESCRIPTION
Promotion de #450.

`deploy.sh` gagne un mode release (`ARBORE_DEPLOY_TAG=v1.2.0`) qui se place en HEAD détachée sur une étiquette, sans `git pull` — une release ne doit pas bouger.

`release.yml` crée la release GitHub sur poussée d'une étiquette `v*`, sans construire d'image : `deploy.yml` réagit déjà aux mêmes étiquettes.

Donne enfin son sens à la rétention de #442, qui conserve indéfiniment les versions `v*`.