### PR TITLE
docs(architecture): vue de déploiement — infrastructure et exploitation

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -16,6 +16,7 @@ The documentation is split into complementary views. Depending on what you are l
 | Internal modules — Go backend | [`architecture/03-components-backend.md`](architecture/03-components-backend.md) |
 | Internal modules — Next.js web | [`architecture/03-components-web.md`](architecture/03-components-web.md) |
 | MongoDB data model | [`architecture/04-data-model.md`](architecture/04-data-model.md) |
+| **Infrastructure and operations** (layers, pipeline, environments, secrets) | [`architecture/05-infrastructure.md`](architecture/05-infrastructure.md) |
 | 3D model LOD architecture | [`3d-lod-architecture.md`](3d-lod-architecture.md) |
 | Signup flow with Firebase rollback | [`flows/auth-signup.md`](flows/auth-signup.md) |
 | Garden creation flow (wizard) | [`flows/garden-creation.md`](flows/garden-creation.md) |

--- a/docs/en/architecture/05-infrastructure.md
+++ b/docs/en/architecture/05-infrastructure.md
@@ -1,0 +1,283 @@
+# C4 — Deployment view: infrastructure and operations
+
+This view describes **how code becomes a running service**, and what guarantees
+we know which one is running.
+
+For the containers themselves, see [`02-containers.md`](02-containers.md).
+
+## The principle
+
+> **The repository is the complete definition of a deployment.**
+>
+> `git clone`, supply the secrets, run the deployment with an environment type —
+> everything comes up, with no command typed by hand afterwards.
+
+This principle has one consequence that governs everything else: **no
+configuration may exist only on a machine**. What lives only there drifts with
+nothing to signal it, and the documentation describing it drifts along.
+
+The historical proof: `vps-bootstrap.md` documented *one* cron when the VPS had
+*two*. The drift survived for months, discovered by accident while running
+`crontab -l` to install a third.
+
+---
+
+## The three layers
+
+They differ by **the channel they use**, and that distinction is why they cannot
+be merged.
+
+```mermaid
+flowchart TB
+    subgraph tf["1 · Provisioning — Terraform"]
+        direction LR
+        tf1["Talks to APIs<br/>Cloudflare, R2"]
+        tf2["Creates what does not exist yet<br/>DNS, buckets"]
+    end
+
+    subgraph ops["2 · Configuration — ops/ + deploy.sh"]
+        direction LR
+        ops1["Talks over SSH<br/>to an existing machine"]
+        ops2["Lays down crontab, systemd,<br/>nginx, secrets"]
+    end
+
+    subgraph run["3 · Runtime — Docker Compose"]
+        direction LR
+        run1["Orchestrates containers"]
+        run2["Pulls images<br/>already built"]
+    end
+
+    tf --> ops --> run
+```
+
+| Layer | Channel | Creates / changes |
+|---|---|---|
+| **Terraform** | provider API | the machine, DNS, the bucket |
+| **`ops/` + `deploy.sh`** | SSH to a machine that exists | packages, crontab, systemd, nginx, secrets |
+| **Docker Compose** | local Docker daemon | application containers |
+
+> **Terraform never connects to a machine.** It clicks the dashboard buttons for
+> you, through the same API. SSH access is of no use to it — it is the wrong
+> kind of access.
+
+Wiring one into the other through a `provisioner "remote-exec"` is an
+anti-pattern: a provisioner only runs at creation, never replays, and detects no
+drift.
+
+---
+
+## A commit's journey to production
+
+```mermaid
+sequenceDiagram
+    participant dev as Developer
+    participant gh as GitHub
+    participant ci as CI (Actions)
+    participant reg as ghcr.io
+    participant vps as VPS
+
+    dev->>gh: merge to main
+    gh->>ci: triggers Build & Publish
+    ci->>ci: build backend / ai / web
+    ci->>reg: push sha-<commit>, latest
+    Note over reg: immutable tag per commit
+
+    dev->>vps: ssh + ./deploy.sh
+    vps->>gh: git pull --ff-only
+    vps->>vps: apply ops/ (crontab, systemd, nginx)
+    vps->>vps: decrypt secrets (SOPS)
+    vps->>vps: pre-deploy Mongo snapshot
+    vps->>reg: docker compose pull sha-<commit>
+    reg-->>vps: images
+    vps->>vps: compose up -d
+    vps->>vps: health check
+```
+
+**The VPS no longer compiles anything.** It previously ran three builds on every
+deployment — ten minutes of CPU and several GB of intermediate layers on an
+already tight disk — to redo what CI had just produced.
+
+### The fallback is deliberate, and loud
+
+If ghcr is unreachable or the image missing, `deploy.sh` **builds locally** and
+says so. A deployment must not depend on a registry's availability; but it must
+never drift in silence.
+
+---
+
+## Image tagging
+
+| Tag | Scope | Lifetime |
+|---|---|---|
+| `sha-<full commit>` | every push to `main` or `dev` | last 10 per package |
+| `1.2.3`, `1.2` | git tag `v*` | **indefinite** |
+| `latest` | default branch only | moving |
+| `main`, `dev`, `pr-42` | branch or PR | moving |
+
+The **full SHA** is required: `deploy.sh` pulls `sha-$(git rev-parse HEAD)`. A
+short SHA would match nothing and the deployment would silently fall back to a
+local build.
+
+`latest` is restricted to the default branch. Without that guard, publishing
+from `dev` would move the tag and the manual fallback `docker pull …:latest`
+would serve something other than production.
+
+### Purge and retention
+
+One trap is worth knowing, because it costs production:
+
+> **"Untagged" does not mean "deletable".**
+>
+> A tag does not carry the image: it carries an **index** that references the
+> image and its provenance attestation, **both untagged**.
+
+```mermaid
+flowchart LR
+    tag["sha-231f197<br/>(tagged)"] --> idx["OCI index"]
+    idx --> img["amd64 image<br/>UNTAGGED"]
+    idx --> att["attestation<br/>UNTAGGED"]
+```
+
+The `delete-only-untagged-versions: true` option — the one every example
+suggests — would delete the image serving production and leave an index pointing
+at nothing.
+
+`scripts/purge-package-versions.py` therefore walks into every **tagged**
+manifest to build the protected set. Four guards, taken from the reconciliation
+job: dry-run by default, fail-closed, refusal if no tagged version is found, and
+exclusion of the commit read from `GET /health`.
+
+---
+
+## Environments
+
+Two independent stacks on one machine. They share the kernel, the disk and the
+Firebase project; they share **neither the version, nor the ports, nor the
+environment file**.
+
+```mermaid
+flowchart TB
+    subgraph host["VPS"]
+        subgraph prod["arbore-prod · /home/fedora/Arbore · main"]
+            p1["backend :8080"]
+            p2["web :3000"]
+            p3["ai :8000"]
+        end
+        subgraph devenv["arbore-dev · /home/fedora/Arbore-dev · dev"]
+            d1["backend :8081"]
+            d2["web :3001"]
+            d3["ai :8001"]
+        end
+        nginx["nginx (host)<br/>:80 / :443"]
+    end
+    nginx --> p1
+    nginx --> p2
+    prod -.->|arbore| mongo[("MongoDB Atlas")]
+    devenv -.->|arbore_test| mongo
+```
+
+**One git checkout per environment is required, not a convenience.**
+`deploy.sh` derives the image tag from `git rev-parse HEAD`: a shared checkout
+would deploy the same commit on both sides, defeating the point of having two
+environments.
+
+**A non-primary environment does not touch host configuration.** The crontab is
+rendered with the current checkout path: applied from `Arbore-dev`, it would
+point production's jobs at that directory, the reconciliation job included.
+
+Operational detail in [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md).
+
+---
+
+## Secrets
+
+Encrypted in the repository with **SOPS + age**. SOPS encrypts **values** and
+leaves **keys** readable: the inventory is versioned and reviewable in a PR, the
+values are not.
+
+```
+GHCR_TOKEN=ENC[AES256_GCM,data:rcfZ…]
+```
+
+One age key per environment. `apply_secrets` decrypts at deployment time into
+the environment file and `arbore-data/secrets/`.
+
+**Without a private key the deployment continues** with the configuration in
+place. A machine without a key must deploy as before, not fail.
+
+### Secret zero
+
+One secret cannot live in the repository: **the age key**, since it is what
+decrypts the others.
+
+> Automation does not create trust, it propagates it. The manual step never
+> disappears: it moves up one level and amortises.
+
+| | Manual steps |
+|---|---|
+| Machine without identity, N machines | **N** — one key placement per machine |
+| Cloud with instance identity | **1, once** — the account credentials |
+
+On a cloud the instance reads its secrets through its identity, and SOPS accepts
+**AWS KMS** as an additional recipient — `.sops.yaml` gains one line, nothing is
+rewritten.
+
+⚠️ **Terraform must never carry the age key.** The value would land in the state
+in plaintext. It declares *"this instance may read this secret"*, never the
+secret.
+
+---
+
+## Network and origin firewall
+
+The origin accepts `:80` and `:443` only from Cloudflare ranges. That lock
+covers **two distinct paths**, and this is the easiest point to miss:
+
+```mermaid
+flowchart LR
+    net["Internet"] --> input["INPUT<br/>CF-HTTP chain"] --> hnginx["nginx on the host"]
+    net --> docker["FORWARD / DOCKER-USER<br/>CF-DOCKER chain"] --> cont["container publishing a port"]
+```
+
+> Traffic destined for a **container** does not traverse `INPUT`. Protecting
+> only `INPUT` would leave the origin open as soon as a service moved into a
+> container — with no error, the site continuing to work.
+
+In `DOCKER-USER` you need **`RETURN`**, not `ACCEPT`: an `ACCEPT` is terminal
+for the whole `FORWARD` hook and would short-circuit Docker's own rules.
+
+---
+
+## What is guaranteed, and how to verify it
+
+| Guarantee | Verification |
+|---|---|
+| Production serves the expected commit | `curl -s https://api.arbore.app/health \| jq -r .commit` |
+| DNS and the R2 bucket match the declaration | `terraform plan` — exit code 0 |
+| The origin stays closed to direct access | TCP connection to the IP on `:443` from outside |
+| The two environments are independent | `/health` on `:8080` and `:8081` — distinct commits |
+| Nothing was built on the VPS | "Images tirées depuis ghcr" in the log |
+
+---
+
+## What is deliberately not automated
+
+| | Why |
+|---|---|
+| **The deployment itself** | it remains a decided act. Making it automatic is tracked in #430, and requires alerting first |
+| **Placing the age key** | secret zero — irreducible without machine identity |
+| **Creating Firebase projects** | the §1 criterion targets deployment, not the initial creation of a provider account |
+| **Deleting an entire package** | a one-off, irreversible operation; giving a weekly script that capability would be a bad trade |
+
+---
+
+## References
+
+- [#401](https://github.com/ArboreTeam/Arbore/issues/401) — parent issue: make the repository deployable to N environments
+- [#341](https://github.com/ArboreTeam/Arbore/issues/341) — the undetected drift that started this
+- [#425](https://github.com/ArboreTeam/Arbore/issues/425) — image pulling
+- [#427](https://github.com/ArboreTeam/Arbore/pull/427) — Terraform declaration
+- [#434](https://github.com/ArboreTeam/Arbore/issues/434) — second stack
+- [#442](https://github.com/ArboreTeam/Arbore/issues/442) — purge and retention
+- [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md) — procedures
+- [`../operations/asset-storage.md`](../operations/asset-storage.md) — R2 and MinIO

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -16,6 +16,7 @@ La documentation est découpée en vues complémentaires. Selon l'information re
 | Modules internes côté backend Go | [`architecture/03-components-backend.md`](architecture/03-components-backend.md) |
 | Modules internes côté web Next.js | [`architecture/03-components-web.md`](architecture/03-components-web.md) |
 | Schéma de données MongoDB | [`architecture/04-data-model.md`](architecture/04-data-model.md) |
+| **Infrastructure et exploitation** (couches, pipeline, environnements, secrets) | [`architecture/05-infrastructure.md`](architecture/05-infrastructure.md) |
 | Architecture LOD des modèles 3D | [`3d-lod-architecture.md`](3d-lod-architecture.md) |
 | Flow de signup avec rollback Firebase | [`flows/auth-signup.md`](flows/auth-signup.md) |
 | Flow de création de jardin (wizard) | [`flows/garden-creation.md`](flows/garden-creation.md) |
@@ -49,7 +50,7 @@ docs/
 ├── appstore-listing.md        # listing App Store (multilingue, neutre)
 ├── fr/                        # documentation française (référence)
 │   ├── README.md              # ce document
-│   ├── architecture/          # vue STATIQUE (modèle C4 : context, containers, components, data)
+│   ├── architecture/          # vue STATIQUE (C4 : context, containers, components, data, déploiement)
 │   ├── flows/                 # vue DYNAMIQUE (séquences, flowcharts)
 │   ├── state-machines/        # vue COMPORTEMENTALE
 │   ├── screens/               # per-screen specs (hero screens)

--- a/docs/fr/architecture/05-infrastructure.md
+++ b/docs/fr/architecture/05-infrastructure.md
@@ -1,0 +1,287 @@
+# C4 — Vue de déploiement : infrastructure et exploitation
+
+Cette vue décrit **comment le code devient un service qui tourne**, et ce qui
+garantit qu'on sait lequel tourne.
+
+Pour les containers eux-mêmes, voir [`02-containers.md`](02-containers.md).
+
+## Le principe
+
+> **Le dépôt est la définition complète d'un déploiement.**
+>
+> `git clone`, fournir les secrets, lancer le déploiement avec un type
+> d'environnement — tout est actif, sans commande tapée à la main ensuite.
+
+Ce principe a une conséquence qui gouverne tout le reste : **aucune
+configuration ne doit exister uniquement sur une machine**. Ce qui n'existe que
+là dérive sans que rien ne le signale, et la documentation qui la décrit dérive
+avec elle.
+
+La preuve historique : `vps-bootstrap.md` documentait *un* cron quand le VPS en
+avait *deux*. La dérive a survécu des mois, découverte par hasard en tapant
+`crontab -l` pour en installer un troisième.
+
+---
+
+## Les trois couches
+
+Elles se distinguent par **le canal qu'elles empruntent**, et cette distinction
+explique pourquoi on ne peut pas les fusionner.
+
+```mermaid
+flowchart TB
+    subgraph tf["1 · Provisionnement — Terraform"]
+        direction LR
+        tf1["Parle à des API<br/>Cloudflare, R2"]
+        tf2["Crée ce qui n'existe pas encore<br/>DNS, buckets"]
+    end
+
+    subgraph ops["2 · Configuration — ops/ + deploy.sh"]
+        direction LR
+        ops1["Parle en SSH<br/>à une machine existante"]
+        ops2["Pose crontab, systemd,<br/>nginx, secrets"]
+    end
+
+    subgraph run["3 · Exécution — Docker Compose"]
+        direction LR
+        run1["Orchestre les conteneurs"]
+        run2["Tire des images<br/>déjà construites"]
+    end
+
+    tf --> ops --> run
+```
+
+| Couche | Canal | Crée / modifie |
+|---|---|---|
+| **Terraform** | API du fournisseur | la machine, le DNS, le bucket |
+| **`ops/` + `deploy.sh`** | SSH sur une machine qui existe | paquets, crontab, systemd, nginx, secrets |
+| **Docker Compose** | démon Docker local | les conteneurs applicatifs |
+
+> **Terraform ne se connecte jamais à une machine.** Il clique les boutons du
+> tableau de bord à votre place, par la même API. Un accès SSH ne lui sert à
+> rien — c'est le mauvais type d'accès.
+
+Les brancher l'une sur l'autre par un `provisioner "remote-exec"` est un
+anti-patron : un provisioner ne tourne qu'à la création, ne rejoue jamais, et ne
+détecte aucune dérive.
+
+---
+
+## Le trajet d'un commit jusqu'à la production
+
+```mermaid
+sequenceDiagram
+    participant dev as Développeur
+    participant gh as GitHub
+    participant ci as CI (Actions)
+    participant reg as ghcr.io
+    participant vps as VPS
+
+    dev->>gh: merge sur main
+    gh->>ci: déclenche Build & Publish
+    ci->>ci: build backend / ai / web
+    ci->>reg: pousse sha-<commit>, latest
+    Note over reg: étiquette immuable par commit
+
+    dev->>vps: ssh + ./deploy.sh
+    vps->>gh: git pull --ff-only
+    vps->>vps: applique ops/ (crontab, systemd, nginx)
+    vps->>vps: déchiffre les secrets (SOPS)
+    vps->>vps: snapshot Mongo pre-deploy
+    vps->>reg: docker compose pull sha-<commit>
+    reg-->>vps: images
+    vps->>vps: compose up -d
+    vps->>vps: health check
+```
+
+**Le VPS ne compile plus rien.** Il tirait auparavant trois builds à chaque
+déploiement — dix minutes de CPU et plusieurs Go de couches intermédiaires sur
+un disque déjà tendu — pour refaire ce que la CI venait de produire.
+
+### Le repli est délibéré, et bruyant
+
+Si ghcr est injoignable ou l'image absente, `deploy.sh` **construit en local**
+et le signale. Un déploiement ne doit pas dépendre de la disponibilité d'un
+registre ; mais il ne doit jamais dériver en silence.
+
+---
+
+## Étiquetage des images
+
+| Étiquette | Portée | Durée de vie |
+|---|---|---|
+| `sha-<commit complet>` | tout push sur `main` ou `dev` | 10 dernières par package |
+| `1.2.3`, `1.2` | étiquette git `v*` | **indéfinie** |
+| `latest` | branche par défaut uniquement | mouvante |
+| `main`, `dev`, `pr-42` | branche ou PR | mouvante |
+
+Le **SHA complet** est requis : `deploy.sh` tire `sha-$(git rev-parse HEAD)`.
+Un SHA court ne correspondrait à rien et le déploiement retomberait
+silencieusement sur un build local.
+
+`latest` est restreinte à la branche par défaut. Sans cette garde, une
+publication depuis `dev` déplacerait l'étiquette et le repli manuel
+`docker pull …:latest` servirait autre chose que la production.
+
+### Purge et rétention
+
+Un piège mérite d'être connu, parce qu'il coûte la production :
+
+> **« Sans étiquette » ne veut pas dire « supprimable ».**
+>
+> Une étiquette ne porte pas l'image : elle porte un **index** qui référence
+> l'image et son attestation de provenance, **elles-mêmes sans étiquette**.
+
+```mermaid
+flowchart LR
+    tag["sha-231f197<br/>(étiqueté)"] --> idx["index OCI"]
+    idx --> img["image amd64<br/>SANS étiquette"]
+    idx --> att["attestation<br/>SANS étiquette"]
+```
+
+L'option `delete-only-untagged-versions: true` — celle que suggèrent tous les
+exemples — supprimerait l'image servie en production et laisserait un index
+pointant dans le vide.
+
+`scripts/purge-package-versions.py` descend donc dans chaque manifeste
+**étiqueté** pour construire l'ensemble protégé. Quatre gardes, reprises du job
+de réconciliation : simulation par défaut, fail-closed, refus si aucune
+étiquette n'est trouvée, et exclusion du commit lu depuis `GET /health`.
+
+---
+
+## Les environnements
+
+Deux piles indépendantes sur une machine. Elles partagent le noyau, le disque et
+le projet Firebase ; elles ne partagent **ni la version, ni les ports, ni le
+fichier d'environnement**.
+
+```mermaid
+flowchart TB
+    subgraph host["VPS"]
+        subgraph prod["arbore-prod · /home/fedora/Arbore · main"]
+            p1["backend :8080"]
+            p2["web :3000"]
+            p3["ai :8000"]
+        end
+        subgraph devenv["arbore-dev · /home/fedora/Arbore-dev · dev"]
+            d1["backend :8081"]
+            d2["web :3001"]
+            d3["ai :8001"]
+        end
+        nginx["nginx (hôte)<br/>:80 / :443"]
+    end
+    nginx --> p1
+    nginx --> p2
+    prod -.->|arbore| mongo[("MongoDB Atlas")]
+    devenv -.->|arbore_test| mongo
+```
+
+**Un checkout git par environnement est nécessaire, pas confortable.**
+`deploy.sh` calcule l'étiquette d'image depuis `git rev-parse HEAD` : un
+checkout partagé ferait déployer le même commit des deux côtés, ce qui
+annulerait l'intérêt d'avoir deux environnements.
+
+**Un environnement non primaire ne touche pas à la configuration hôte.** Le
+crontab est rendu avec le chemin du checkout courant : appliqué depuis
+`Arbore-dev`, il ferait pointer les tâches de production vers ce répertoire, job
+de réconciliation compris.
+
+Détail opérationnel dans [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md).
+
+---
+
+## Secrets
+
+Chiffrés dans le dépôt par **SOPS + age**. SOPS chiffre les **valeurs** et
+laisse les **clés** lisibles : l'inventaire est versionné et relisible en revue
+de PR, les valeurs ne le sont pas.
+
+```
+GHCR_TOKEN=ENC[AES256_GCM,data:rcfZ…]
+```
+
+Une clé age par environnement. `apply_secrets` déchiffre au déploiement vers le
+fichier d'environnement et `arbore-data/secrets/`.
+
+**Sans clé privée, le déploiement continue** avec la configuration en place. Une
+machine sans clé doit se déployer comme avant, pas échouer.
+
+### Le secret zéro
+
+Il reste un secret qui ne peut pas vivre dans le dépôt : **la clé age**, puisque
+c'est elle qui déchiffre les autres.
+
+> L'automatisation ne crée pas de confiance, elle la propage. Le geste manuel ne
+> disparaît jamais : il remonte d'un niveau et s'amortit.
+
+| | Gestes manuels |
+|---|---|
+| Machine sans identité, N machines | **N** — une pose de clé par machine |
+| Cloud avec identité d'instance | **1, une fois** — les identifiants du compte |
+
+Sur un cloud, l'instance lit ses secrets par son identité et SOPS accepte
+**AWS KMS** comme destinataire supplémentaire — le `.sops.yaml` gagne une ligne,
+rien n'est à réécrire.
+
+⚠️ **Terraform ne doit jamais porter la clé age.** La valeur atterrirait en clair
+dans le state. Il déclare *« cette instance a le droit de lire ce secret »*,
+jamais le secret.
+
+---
+
+## Réseau et pare-feu d'origine
+
+L'origine n'accepte `:80` et `:443` que depuis les plages Cloudflare. Ce
+verrouillage couvre **deux chemins distincts**, et c'est le point le plus facile
+à manquer :
+
+```mermaid
+flowchart LR
+    net["Internet"] --> input["INPUT<br/>chaîne CF-HTTP"] --> hnginx["nginx sur l'hôte"]
+    net --> docker["FORWARD / DOCKER-USER<br/>chaîne CF-DOCKER"] --> cont["conteneur publiant un port"]
+```
+
+> Le trafic destiné à un **conteneur** ne traverse pas `INPUT`. Ne protéger que
+> `INPUT` laisserait l'origine ouverte dès qu'un service passerait en conteneur
+> — sans erreur, le site continuant de fonctionner.
+
+Dans `DOCKER-USER` il faut **`RETURN`** et non `ACCEPT` : un `ACCEPT` est
+terminal pour tout le hook `FORWARD` et court-circuiterait les règles propres de
+Docker.
+
+---
+
+## Ce qui est garanti, et comment le vérifier
+
+| Garantie | Vérification |
+|---|---|
+| La production sert le commit attendu | `curl -s https://api.arbore.app/health \| jq -r .commit` |
+| Le DNS et le bucket R2 sont conformes | `terraform plan` — code de sortie 0 |
+| L'origine reste fermée en direct | connexion TCP à l'IP sur `:443` depuis l'extérieur |
+| Les deux environnements sont indépendants | `/health` sur `:8080` et `:8081` — commits distincts |
+| Rien n'a été construit sur le VPS | « Images tirées depuis ghcr » dans le journal |
+
+---
+
+## Ce qui n'est délibérément pas automatisé
+
+| | Pourquoi |
+|---|---|
+| **Le déploiement lui-même** | il reste un geste décidé. Le rendre automatique est traité en #430, et suppose d'abord une remontée d'alerte |
+| **La pose de la clé age** | secret zéro — irréductible sans identité de machine |
+| **La création des projets Firebase** | le critère du §1 vise le déploiement, pas la création initiale d'un compte fournisseur |
+| **La suppression d'un package entier** | opération unique et irréversible ; doter un script hebdomadaire d'une telle capacité serait un mauvais échange |
+
+---
+
+## Références
+
+- [#401](https://github.com/ArboreTeam/Arbore/issues/401) — issue parente : rendre le dépôt déployable sur N environnements
+- [#341](https://github.com/ArboreTeam/Arbore/issues/341) — la dérive non détectée à l'origine du chantier
+- [#425](https://github.com/ArboreTeam/Arbore/issues/425) — tirage d'images
+- [#427](https://github.com/ArboreTeam/Arbore/pull/427) — déclaration Terraform
+- [#434](https://github.com/ArboreTeam/Arbore/issues/434) — seconde pile
+- [#442](https://github.com/ArboreTeam/Arbore/issues/442) — purge et rétention
+- [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md) — procédures
+- [`../operations/stockage-assets.md`](../operations/stockage-assets.md) — R2 et MinIO


### PR DESCRIPTION
Documente le chantier mené depuis le 2026-09-04 : **37 commits d'infrastructure**,
de la déclaration de `ops/` jusqu'aux releases.

## Où ça se place

La **vue de déploiement est le quatrième diagramme de C4**. Elle prend donc sa
place dans la numérotation existante — `05-infrastructure.md` après
`04-data-model.md` — plutôt que dans un dossier à part.

## Ce que le document contient

Cinq diagrammes Mermaid : les trois couches, le trajet d'un commit jusqu'à la
production, la structure d'un index d'images, la topologie des deux
environnements, et les deux chemins du pare-feu.

Il est organisé autour de **ce qui ne se devine pas en lisant le code** :

**Les trois couches se distinguent par leur canal** — API pour Terraform, SSH
pour `ops/`, démon Docker pour compose. C'est ce qui explique qu'on ne peut pas
les fusionner, et pourquoi un `provisioner "remote-exec"` est un anti-patron.

**« Sans étiquette » ne veut pas dire « supprimable ».** Une étiquette porte un
index qui référence l'image et son attestation, elles-mêmes sans étiquette.
L'option que suggèrent tous les exemples supprimerait l'image de production.

**Le pare-feu couvre deux chemins.** Le trafic vers un conteneur ne traverse pas
`INPUT` ; ne protéger que lui laisserait l'origine ouverte sans aucune erreur.
Et dans `DOCKER-USER` il faut `RETURN`, pas `ACCEPT`.

**Un checkout par environnement est nécessaire, pas confortable** : `deploy.sh`
calcule l'étiquette d'image depuis `git rev-parse HEAD`.

**Le secret zéro est irréductible** sans identité de machine, et Terraform ne
doit jamais le porter — la valeur atterrirait en clair dans le state.

## Deux sections qui manquaient

**Ce qui est garanti, et la commande qui le vérifie.** Sans elle, un lecteur ne
peut pas contrôler l'état réel — il doit croire la documentation, ce qui est
exactement ce que ce chantier cherche à éviter.

**Ce qui n'est délibérément pas automatisé, avec la raison.** Sans elle, on ne
distingue pas un manque d'un choix, et quelqu'un « corrigera » un jour une
décision volontaire.

## Vérifications

- Parité `fr`/`en` : mêmes fichiers des deux côtés ✅
- Délimiteurs de blocs équilibrés, 5 blocs Mermaid par langue ✅
- `docs-drift-check.sh` : 504 références vérifiées, aucune dérive ✅
- Entrées ajoutées aux deux index
- La syntaxe Mermaid et les liens internes sont validés par la CI
