### PR TITLE
perf(ci): supprimer les exécutions redondantes, 81 % du coût étant sur macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,15 @@ name: 🌱 Arbore CI/CD
 # `dev` est la branche d'intégration : les PR de feature la ciblent, donc la CI
 # doit y tourner (sinon une feature entre dans dev sans build/test/lint).
 on:
+  # `push` UNIQUEMENT sur main : un événement `pull_request` teste déjà le
+  # commit de MERGE (fusion de la tête dans la base), donc rejouer la CI après
+  # le merge dans `dev` retestait exactement le même code.
+  #
+  # Une modification iOS déclenchait ainsi quatre exécutions macOS pour un seul
+  # changement — PR vers dev, push dev, PR de promotion, push main. À ×10 sur le
+  # palier Actions, c'était 81 % de la consommation du dépôt.
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main", "dev" ]
   workflow_dispatch:
@@ -247,7 +254,11 @@ jobs:
   # iOS UI - Build (nécessite macOS)
   ios_ui:
     needs: changes
-    if: needs.changes.outputs.ios_ui == 'true' || github.event_name == 'workflow_dispatch'
+    # La promotion `dev` -> `main` porte un code déjà validé par la PR de
+    # feature : rejouer les tests macOS n'apporte rien et coûte ×10.
+    if: >-
+      (needs.changes.outputs.ios_ui == 'true' && (github.base_ref != 'main' || github.head_ref != 'dev'))
+      || github.event_name == 'workflow_dispatch'
     # macos-15 pour disposer d'Xcode 26 (SDK iOS 26, Liquid Glass).
     runs-on: macos-15
     # 55 min : marge pour build (~7 min) + Run Unit Tests (jusqu'à 35 min) sous Xcode 26.
@@ -537,7 +548,11 @@ jobs:
   # iOS AR Module - Build
   ios_ar:
     needs: changes
-    if: needs.changes.outputs.ios_ar == 'true' || github.event_name == 'workflow_dispatch'
+    # La promotion `dev` -> `main` porte un code déjà validé par la PR de
+    # feature : rejouer les tests macOS n'apporte rien et coûte ×10.
+    if: >-
+      (needs.changes.outputs.ios_ar == 'true' && (github.base_ref != 'main' || github.head_ref != 'dev'))
+      || github.event_name == 'workflow_dispatch'
     runs-on: macos-14
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
## Le constat

Consommation Actions de septembre, mesurée par l'API de facturation :

| | Minutes | Multiplicateur | Équivalent facturable |
|---|---|---|---|
| Linux | 2 062 | ×1 | 2 062 |
| **macOS** | **858** | **×10** | **8 580** |
| **Total** | | | **10 642** |

Palier d'une organisation gratuite : **2 000 par mois**. **81 % du coût vient
des 858 minutes macOS.**

## La cause

Une seule modification iOS déclenchait **quatre exécutions macOS** pour tester
exactement le même code :

1. PR vers `dev`
2. push sur `dev` après merge
3. PR de promotion vers `main`
4. push sur `main`

## Les deux correctifs

**`push` sur `dev` retirée.** Un événement `pull_request` teste déjà le commit
de **merge** — la fusion de la tête dans la base — donc rejouer la CI après le
merge ne couvre rien de nouveau.

`push` sur `main` est **conservée** : c'est la branche déployée, et un filet sur
la production vaut ses minutes.

**Les jobs macOS sont sautés sur la promotion `dev` → `main`.** Ce code a déjà
été validé par la PR de feature ; le rejouer coûte ×10 pour zéro information.

## L'effet

De quatre exécutions macOS par modification iOS à **deux** — la PR de feature,
et le push sur `main`. Environ **4 300 minutes équivalentes économisées par
mois** au rythme actuel.

Les jobs Linux ne sont touchés que par le retrait de `push: dev` : ils coûtent
dix fois moins et servent de garde à chaque étape.
