### PR TITLE
chore(release): API de dev exposée, pare-feu en liste blanche

### DIFF
--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -28,3 +28,29 @@ resource "cloudflare_dns_record" "web" {
   proxied = true
   ttl     = 1
 }
+
+# ── Environnements secondaires ────────────────────────────────────────────
+#
+# Déclarés dans CE state, pas dans un state par environnement.
+#
+# #401 prévoyait l'inverse. Pour deux enregistrements dans la MÊME zone, la
+# séparation coûterait plus qu'elle ne protège : un `init -reconfigure` oublié
+# ferait appliquer les variables de dev contre le state de prod, et Terraform
+# proposerait de détruire les dix ressources de production. Le mode d'échec est
+# sans commune mesure avec le bénéfice.
+#
+# Le raisonnement de fond : un enregistrement DNS appartient à la ZONE, qui est
+# partagée, pas à un environnement. C'est la même logique que
+# `manage_zone_records`.
+#
+# Ce qui appartient VRAIMENT à un environnement — son bucket, son cluster —
+# justifiera un state séparé le jour où il existera.
+resource "cloudflare_dns_record" "api_dev" {
+  count   = var.enable_dev_hostnames ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+  name    = "api-dev.${var.domain}"
+  type    = "A"
+  content = var.origin_ip
+  proxied = true
+  ttl     = 1
+}

--- a/infra/envs/prod.tfvars.example
+++ b/infra/envs/prod.tfvars.example
@@ -21,3 +21,6 @@ cloudflare_zone_id    = ""
 
 r2_bucket_name  = "arbore-assets"
 r2_jurisdiction = "eu"
+
+# Noms d'hôte de l'environnement de dev, sur la même machine (#434).
+enable_dev_hostnames = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -71,3 +71,13 @@ variable "manage_zone_records" {
   type        = bool
   default     = false
 }
+
+variable "enable_dev_hostnames" {
+  description = <<-EOT
+    Créer les noms d'hôte de l'environnement de dev (`api-dev`).
+    Ils pointent la MÊME machine que la production : les deux piles cohabitent
+    sur le VPS, nginx les distingue par `server_name`.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/ops/nginx/arbore-dev.conf
+++ b/ops/nginx/arbore-dev.conf
@@ -1,0 +1,48 @@
+# api-dev.arbore.app — API de l'environnement de développement (#434, #456).
+#
+# Fichier SÉPARÉ de arbore.conf plutôt que paramétrage de celui-ci : la
+# configuration de production n'est pas touchée, donc ce changement ne peut pas
+# la casser. `apply_nginx` installe tous les `*.conf` du répertoire, valide par
+# `nginx -t` APRÈS installation et AVANT rechargement, et restaure la sauvegarde
+# si la validation échoue.
+#
+# Proxifie vers 127.0.0.1:8081 — le backend de la pile `arbore-dev`. Ce port
+# n'est lié qu'à la loopback : nginx est le seul chemin depuis l'extérieur, et
+# l'origine reste fermée aux IP non-Cloudflare par la chaîne CF-HTTP.
+#
+# Pas de vhost pour le web de dev : il exigerait son propre
+# NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN, donc une image distincte, et l'ajout de
+# web-dev.arbore.app aux domaines autorisés de Firebase. À faire seulement si le
+# besoin devient réel.
+
+server {
+    listen 80;
+    server_name api-dev.arbore.app;
+
+    location / {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api-dev.arbore.app;
+
+    # Même certificat d'origine que la production : il couvre la zone, et c'est
+    # Cloudflare qui présente le certificat public au client.
+    ssl_certificate     /etc/ssl/cloudflare/origin.pem;
+    ssl_certificate_key /etc/ssl/cloudflare/origin.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}

--- a/ops/sbin/cf-http-firewall.sh
+++ b/ops/sbin/cf-http-firewall.sh
@@ -7,8 +7,14 @@
 #    FORWARD/DOCKER-USER). Ne proteger que INPUT laisserait donc l'origine
 #    ouverte des que nginx passerait en conteneur -- sans aucune erreur, le
 #    site continuant de fonctionner (#434).
-#  - :8080 (API Go) et :8000 (AI generator) -> pas d'acces externe direct
-#    (DOCKER-USER v4+v6, scope -i eth0 ; loopback + inter-conteneurs preserves)
+#  - AUCUN port de conteneur joignable depuis eth0, hors :80/:443 Cloudflare.
+#    Liste blanche et non enumeration : enumerer les ports se perime a chaque
+#    environnement ajoute. Constate le 2026-09-08 -- les ports de dev (8081,
+#    3001, 8001) et le web de prod (3000) n'avaient AUCUNE regle. Ce qui les
+#    protegeait n'etait pas le pare-feu mais une valeur par defaut dans
+#    docker-compose.yml (BIND_ADDRESS=127.0.0.1). Un `.env` posant 0.0.0.0 pour
+#    « acceder a dev depuis son poste » aurait expose six services a Internet,
+#    sans erreur ni avertissement (#456).
 set -euo pipefail
 
 EXT_IF="eth0"
@@ -41,40 +47,54 @@ iptables -C INPUT -p tcp --dport 80 -j CF-HTTP 2>/dev/null || \
 iptables -C INPUT -p tcp --dport 443 -j CF-HTTP 2>/dev/null || \
   iptables -A INPUT -p tcp --dport 443 -j CF-HTTP
 
-# --- :80 / :443 vers un CONTENEUR : Cloudflare uniquement ---
+# --- Trafic EXTERNE vers un CONTENEUR : liste blanche ---
 #
-# Chaine distincte de CF-HTTP, et ce n'est pas une duplication : dans
-# DOCKER-USER il faut RETURN et non ACCEPT. Un ACCEPT serait terminal pour tout
-# le hook FORWARD et court-circuiterait les propres regles de Docker (suivi de
-# connexion, isolation inter-reseaux). RETURN rend la main a DOCKER-USER, qui
-# poursuit normalement.
+# Un seul saut depuis DOCKER-USER vers une chaine qu'on maitrise entierement,
+# videe et reconstruite a chaque passage. C'est ce qui rend l'ordre des regles
+# DETERMINISTE : avec des `-I` successifs, l'ordre depend de ce qui existait
+# deja, donc d'un historique qu'on ne controle pas.
 #
-# Inerte tant que nginx ecoute sur l'hote : aucun trafic :80/:443 n'est alors
-# forwarde vers un conteneur. La regle devient active le jour ou nginx bascule.
-iptables -N CF-DOCKER 2>/dev/null || true
-iptables -F CF-DOCKER
-for cidr in "${CF_RANGES[@]}"; do iptables -A CF-DOCKER -s "$cidr" -j RETURN; done
-iptables -A CF-DOCKER -j DROP
-for port in 80 443; do
-  iptables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER 2>/dev/null || \
-    iptables -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER
+# RETURN et non ACCEPT : un ACCEPT est terminal pour tout le hook FORWARD et
+# court-circuiterait les regles propres de Docker (suivi de connexion,
+# isolation inter-reseaux). RETURN rend la main a DOCKER-USER, qui poursuit.
+#
+# Portee `-i eth0` : le trafic inter-conteneurs passe par le bridge, pas par
+# eth0, et le trafic sortant porte `-o eth0`. Ni l'un ni l'autre n'est touche.
+iptables -N ARBORE-EXT 2>/dev/null || true
+iptables -F ARBORE-EXT
+for cidr in "${CF_RANGES[@]}"; do
+  iptables -A ARBORE-EXT -p tcp -m multiport --dports 80,443 -s "$cidr" -j RETURN
 done
+iptables -A ARBORE-EXT -j DROP
 
-# IPv6 vers un conteneur sur :80/:443 : DROP sec. Les enregistrements DNS de
-# l'origine sont des A (IPv4) -- Cloudflare joint donc l'origine en v4, et il
-# n'existe aucun chemin v6 legitime. Fail-closed, coherent avec le traitement
-# de :8080 et :8000 ci-dessous.
+iptables -C DOCKER-USER -i "$EXT_IF" -j ARBORE-EXT 2>/dev/null || \
+  iptables -I DOCKER-USER -i "$EXT_IF" -j ARBORE-EXT
+
+# Les regles par port de la version precedente deviennent redondantes : la
+# liste blanche les couvre toutes. On les retire pour qu'il ne reste qu'une
+# seule source de verite -- deux mecanismes concurrents finissent par diverger.
 for port in 80 443; do
-  ip6tables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null || \
-    ip6tables -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
+  while iptables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER 2>/dev/null; do
+    iptables -D DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j CF-DOCKER
+  done
 done
+for port in 8080 8000; do
+  while iptables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null; do
+    iptables -D DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
+  done
+done
+iptables -F CF-DOCKER 2>/dev/null || true
+iptables -X CF-DOCKER 2>/dev/null || true
 
-# --- :8080 / :8000 : pas d'acces externe direct (v4 + v6) ---
-for fw in iptables ip6tables; do
-  for port in 8080 8000; do
-    $fw -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null || \
-      $fw -I DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
+# IPv6 : DROP sec sur tout trafic externe vers un conteneur. Les enregistrements
+# de l'origine sont des A (IPv4), Cloudflare joint donc l'origine en v4 et aucun
+# chemin v6 legitime n'existe.
+ip6tables -C DOCKER-USER -i "$EXT_IF" -j DROP 2>/dev/null || \
+  ip6tables -I DOCKER-USER -i "$EXT_IF" -j DROP
+for port in 80 443 8080 8000; do
+  while ip6tables -C DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP 2>/dev/null; do
+    ip6tables -D DOCKER-USER -i "$EXT_IF" -p tcp --dport "$port" -j DROP
   done
 done
 
-echo "cf-http-firewall applied OK (${#CF_RANGES[@]} CF ranges, INPUT + DOCKER-USER)"
+echo "cf-http-firewall applied OK (${#CF_RANGES[@]} plages CF ; INPUT + liste blanche DOCKER-USER)"


### PR DESCRIPTION
Promotion de #464.

**Pare-feu** — aucun port de conteneur joignable depuis eth0, hors 80/443 Cloudflare. Remplace une énumération de ports qui ne couvrait ni les ports de dev ni le web de prod : leur seule protection était une valeur par défaut dans docker-compose.yml.

**nginx** — vhost `api-dev.arbore.app` vers 127.0.0.1:8081, dans un fichier séparé pour ne pas toucher la configuration de production.

**DNS** — déjà appliqué par Terraform (1 to add, 0 to change).

À vérifier après déploiement : la chaîne ARBORE-EXT en place, les deux `/health` distincts, l'origine toujours fermée en direct.