### PR TITLE
docs: expliquer comment viser l'environnement de dev depuis l'app iOS

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -36,6 +36,7 @@ The documentation is split into complementary views. Depending on what you are l
 | Observability (Sentry iOS + web) | [`operations/observability.md`](operations/observability.md) |
 | Botanical data audit | [`operations/botanical-data-audit.md`](operations/botanical-data-audit.md) |
 | TestFlight deployment (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
+| Prod/dev environments (targeting dev from Xcode) | [`operations/environments.md`](operations/environments.md) |
 | VPS provisioning (Docker · nginx · Mongo) | [`operations/vps-bootstrap.md`](operations/vps-bootstrap.md) |
 | 3D asset storage (R2 · S3 · MinIO) | [`operations/asset-storage.md`](operations/asset-storage.md) |
 | Architecture Decision Records (ADR) index | [`decisions/_index.md`](decisions/_index.md) |

--- a/docs/en/architecture/05-infrastructure.md
+++ b/docs/en/architecture/05-infrastructure.md
@@ -170,10 +170,11 @@ flowchart TB
         end
         nginx["nginx (host)<br/>:80 / :443"]
     end
-    nginx --> p1
-    nginx --> p2
+    nginx -->|api.arbore.app| p1
+    nginx -->|web.arbore.app| p2
+    nginx -->|api-dev.arbore.app| d1
     prod -.->|arbore| mongo[("MongoDB Atlas")]
-    devenv -.->|arbore_test| mongo
+    devenv -.->|arbore_dev| mongo
 ```
 
 **One git checkout per environment is required, not a convenience.**
@@ -186,6 +187,8 @@ rendered with the current checkout path: applied from `Arbore-dev`, it would
 point production's jobs at that directory, the reconciliation job included.
 
 Operational detail in [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md).
+To target dev from the iOS app, see
+[`../operations/environments.md`](../operations/environments.md).
 
 ---
 

--- a/docs/en/operations/environments.md
+++ b/docs/en/operations/environments.md
@@ -1,0 +1,121 @@
+# Environments: prod, dev, and how to target either
+
+This document is for **whoever develops the iOS app** and wants to work against
+the development backend rather than production.
+
+For the server-side mechanics (two Docker stacks, nginx, deployment), see
+[`../architecture/05-infrastructure.md`](../architecture/05-infrastructure.md).
+For provisioning, [`vps-bootstrap.md`](vps-bootstrap.md).
+
+---
+
+## The two environments
+
+|          | branch | address              | database     | deployed  |
+|----------|--------|----------------------|--------------|-----------|
+| **prod** | `main` | `api.arbore.app`     | `arbore`     | manually  |
+| **dev**  | `dev`  | `api-dev.arbore.app` | `arbore_dev` | manually  |
+
+Both run **at the same time** on the same VPS, on separate ports, from two
+distinct git checkouts. They share neither version, secrets, nor data.
+
+Breaking dev has no effect on beta testers. That is its purpose.
+
+---
+
+## The three iOS build configurations
+
+| configuration | backend called | use                                         |
+|---------------|----------------|---------------------------------------------|
+| `Debug`       | **production** | everyday debugging, against real data       |
+| `Dev`         | **dev**        | test a backend feature not yet promoted     |
+| `Release`     | production     | TestFlight build                            |
+
+**`Debug` targets production, deliberately.** That is what you want most of the
+time: reproducing a bug reported by a beta tester requires their data. Pointing
+`Debug` at dev would have made that common case impossible without
+reconfiguration.
+
+Hence a third configuration rather than two: choosing an environment becomes
+explicit, instead of a side effect of "am I debugging or shipping".
+
+### Where it is wired
+
+```
+ArboreUi/Dev.xcconfig            Dev configuration — host, protocol
+  └── #include? Secrets.dev.xcconfig    API key (gitignored, absent from the repo)
+
+ArboreUi/Debug.xcconfig          Debug and Release configurations
+ArboreUi/Release.xcconfig
+  └── #include? Secrets.xcconfig        same, for production
+```
+
+The `#include?` with a question mark is an **optional include**: if the secrets
+file is missing, the build still succeeds, with an empty key. That is what lets
+CI compile without secrets — but it is also why a forgotten file shows up as a
+runtime `401`, not as a compile error.
+
+---
+
+## Switching to dev
+
+**1. Obtain `ArboreUi/Secrets.dev.xcconfig`.**
+
+It carries the dev backend's API key, so it is not in the repository
+(`.gitignore`). Two ways to get it:
+
+- ask a maintainer;
+- or, if you hold the `dev` age key, generate it:
+
+  ```sh
+  cp ArboreUi/Secrets.dev.xcconfig.example ArboreUi/Secrets.dev.xcconfig
+  SOPS_AGE_KEY_FILE=~/.config/sops/age/arbore-dev.txt \
+    sops --decrypt ops/secrets/dev.enc.env | grep '^ARBORE_API_KEY='
+  ```
+
+  then copy the value into `ARBORE_API_KEY`.
+
+**2. Place the file in `ArboreUi/`.**
+
+**3. In Xcode, select the "ArboreUi Dev" scheme.**
+
+**4. Run.** To go back to production, switch back to the "ArboreUi" scheme.
+
+### Check which backend you are hitting
+
+```sh
+curl https://api.arbore.app/health
+curl https://api-dev.arbore.app/health
+```
+
+Each returns the commit it is running. Two different commits means dev is ahead
+of prod, which is the normal state while a feature is in flight.
+
+---
+
+## What differs on dev
+
+**Sentry is off.** Without a DSN the SDK does not start, so test crashes do not
+pollute production reports. `Secrets.dev.xcconfig` therefore leaves the three
+`SENTRY_DSN_*` variables empty — that is intended, do not fill them in.
+
+**3D models are read from disk**, not from R2. Dev has no bucket credentials:
+giving it any would have meant a dev age key opens write access to production
+storage.
+
+**The Firebase project is shared with production.** This is a decision, not a
+missing step: one project per environment would mean duplicating accounts,
+security rules and Apple certificates for every environment, for little benefit
+at our scale.
+
+> ⚠️ **Consequence worth remembering.** An account created on dev also exists on
+> production, and deleting an account on dev deletes the Firebase identity for
+> good. Give notice before testing deletion flows.
+
+---
+
+## References
+
+- Umbrella issue: [#401](https://github.com/ArboreTeam/Arbore/issues/401)
+- Dev environment: [#434](https://github.com/ArboreTeam/Arbore/issues/434)
+- Remaining hardcoded constants: [#456](https://github.com/ArboreTeam/Arbore/issues/456)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -36,6 +36,7 @@ La documentation est découpée en vues complémentaires. Selon l'information re
 | Observabilité (Sentry iOS + web) | [`operations/observability.md`](operations/observability.md) |
 | Audit des données botaniques | [`operations/botanical-data-audit.md`](operations/botanical-data-audit.md) |
 | Déploiement TestFlight (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
+| Environnements prod/dev (viser le dev depuis Xcode) | [`operations/environnements.md`](operations/environnements.md) |
 | Provisionnement VPS (Docker · nginx · Mongo) | [`operations/vps-bootstrap.md`](operations/vps-bootstrap.md) |
 | Stockage des assets 3D (R2 · S3 · MinIO) | [`operations/stockage-assets.md`](operations/stockage-assets.md) |
 | Index des décisions d'architecture (ADR) | [`decisions/_index.md`](decisions/_index.md) |

--- a/docs/fr/architecture/05-infrastructure.md
+++ b/docs/fr/architecture/05-infrastructure.md
@@ -171,10 +171,11 @@ flowchart TB
         end
         nginx["nginx (hôte)<br/>:80 / :443"]
     end
-    nginx --> p1
-    nginx --> p2
+    nginx -->|api.arbore.app| p1
+    nginx -->|web.arbore.app| p2
+    nginx -->|api-dev.arbore.app| d1
     prod -.->|arbore| mongo[("MongoDB Atlas")]
-    devenv -.->|arbore_test| mongo
+    devenv -.->|arbore_dev| mongo
 ```
 
 **Un checkout git par environnement est nécessaire, pas confortable.**
@@ -188,6 +189,8 @@ crontab est rendu avec le chemin du checkout courant : appliqué depuis
 de réconciliation compris.
 
 Détail opérationnel dans [`../operations/vps-bootstrap.md`](../operations/vps-bootstrap.md).
+Pour viser le dev depuis l'app iOS, voir
+[`../operations/environnements.md`](../operations/environnements.md).
 
 ---
 

--- a/docs/fr/operations/environnements.md
+++ b/docs/fr/operations/environnements.md
@@ -1,0 +1,125 @@
+# Environnements : prod, dev, et comment viser l'un ou l'autre
+
+Ce document s'adresse à **qui développe l'app iOS** et veut travailler contre le
+backend de développement plutôt que contre la production.
+
+Pour la mécanique serveur (deux piles Docker, nginx, déploiement), voir
+[`../architecture/05-infrastructure.md`](../architecture/05-infrastructure.md).
+Pour le provisionnement, [`vps-bootstrap.md`](vps-bootstrap.md).
+
+---
+
+## Les deux environnements
+
+|          | branche | adresse              | base de données | déployé            |
+|----------|---------|----------------------|-----------------|--------------------|
+| **prod** | `main`  | `api.arbore.app`     | `arbore`        | manuellement       |
+| **dev**  | `dev`   | `api-dev.arbore.app` | `arbore_dev`    | manuellement       |
+
+Les deux tournent **en même temps** sur le même VPS, sur des ports distincts,
+depuis deux checkouts git séparés. Ils ne partagent ni la version, ni les
+secrets, ni les données.
+
+Casser le dev n'a aucun effet sur les bêta-testeurs. C'est sa raison d'être.
+
+---
+
+## Les trois configurations de build iOS
+
+| configuration | backend appelé | usage                                        |
+|---------------|----------------|----------------------------------------------|
+| `Debug`       | **production** | débogage courant, contre les données réelles |
+| `Dev`         | **dev**        | tester une feature backend pas encore promue |
+| `Release`     | production     | build TestFlight                             |
+
+**`Debug` vise la production, et c'est délibéré.** C'est ce qu'on veut la
+plupart du temps : reproduire un bug remonté par un bêta-testeur suppose ses
+données. Faire basculer `Debug` sur le dev aurait rendu ce cas courant
+impossible sans reconfiguration.
+
+D'où une troisième configuration plutôt que deux : le choix de l'environnement
+devient explicite, au lieu d'être un effet de bord de « je débogue ou je livre ».
+
+### Où c'est câblé
+
+```
+ArboreUi/Dev.xcconfig            configuration Dev — hôte, protocole
+  └── #include? Secrets.dev.xcconfig    clé d'API (gitignoré, absent du dépôt)
+
+ArboreUi/Debug.xcconfig          configurations Debug et Release
+ArboreUi/Release.xcconfig
+  └── #include? Secrets.xcconfig        idem, pour la production
+```
+
+Le `#include?` avec point d'interrogation est un **include optionnel** : si le
+fichier de secrets manque, le build passe quand même, avec une clé vide. C'est
+ce qui permet à la CI de compiler sans secret — mais c'est aussi pourquoi un
+fichier oublié se manifeste par un `401` à l'exécution, pas par une erreur de
+compilation.
+
+---
+
+## Basculer sur le dev
+
+**1. Récupérez `ArboreUi/Secrets.dev.xcconfig`.**
+
+Il porte la clé d'API du backend de dev, donc il n'est pas dans le dépôt
+(`.gitignore`). Deux façons de l'obtenir :
+
+- demandez-le à un mainteneur ;
+- ou, si vous avez la clé age `dev`, générez-le :
+
+  ```sh
+  cp ArboreUi/Secrets.dev.xcconfig.example ArboreUi/Secrets.dev.xcconfig
+  SOPS_AGE_KEY_FILE=~/.config/sops/age/arbore-dev.txt \
+    sops --decrypt ops/secrets/dev.enc.env | grep '^ARBORE_API_KEY='
+  ```
+
+  puis reportez la valeur dans `ARBORE_API_KEY`.
+
+**2. Posez le fichier dans `ArboreUi/`.**
+
+**3. Dans Xcode, sélectionnez le schéma « ArboreUi Dev ».**
+
+**4. Lancez.** Pour revenir en production, reprenez le schéma « ArboreUi ».
+
+### Vérifier contre quoi vous tapez
+
+```sh
+curl https://api.arbore.app/health
+curl https://api-dev.arbore.app/health
+```
+
+Chacun renvoie le commit qu'il fait tourner. Deux commits différents = le dev
+est en avance sur la prod, ce qui est l'état normal quand une feature est en
+cours.
+
+---
+
+## Ce qui diffère en dev
+
+**Sentry est éteint.** Sans DSN, le SDK ne démarre pas : les plantages de test
+ne viennent pas polluer les rapports de production. `Secrets.dev.xcconfig`
+laisse donc les trois variables `SENTRY_DSN_*` vides — c'est voulu, ne les
+remplissez pas.
+
+**Les modèles 3D sont lus sur le disque**, pas sur R2. Le dev n'a pas les
+identifiants du bucket : les lui donner aurait signifié qu'une clé age de dev
+ouvre l'écriture sur le stockage de production.
+
+**Le projet Firebase est partagé avec la production.** C'est une décision, pas
+une étape manquante : un projet par environnement obligerait à dupliquer les
+comptes, les règles de sécurité et les certificats Apple à chaque environnement,
+pour un bénéfice faible à notre échelle.
+
+> ⚠️ **Conséquence à retenir.** Un compte créé en dev existe aussi côté
+> production, et une suppression de compte en dev supprime l'identité Firebase
+> pour de bon. Prévenez avant de tester les parcours de suppression.
+
+---
+
+## Références
+
+- Chantier d'ensemble : [#401](https://github.com/ArboreTeam/Arbore/issues/401)
+- Environnement de dev : [#434](https://github.com/ArboreTeam/Arbore/issues/434)
+- Constantes en dur restantes : [#456](https://github.com/ArboreTeam/Arbore/issues/456)


### PR DESCRIPTION
## Le problème

L'environnement de dev tourne depuis #434 et `api-dev.arbore.app` est en service.
Mais il n'était décrit que dans `operations/vps-bootstrap.md` — un runbook
d'infrastructure, là où personne développant en Swift n'ira chercher.

Un environnement que l'équipe ne sait pas viser ne sert à rien.

## Ce que ça ajoute

`operations/environnements.md` (FR) et `operations/environments.md` (EN) :

- les deux environnements, leurs branches, adresses et **bases distinctes**
  (`arbore` / `arbore_dev`) ;
- les **trois configurations de build** iOS et laquelle utiliser quand ;
- la marche à suivre pour basculer sur le dev — obtenir `Secrets.dev.xcconfig`,
  ou le générer soi-même avec la clé age `dev` ;
- comment **vérifier contre quel backend on tape** (les deux `/health` affichent
  leur commit).

## Trois choix qui, non écrits, se lisent comme des oublis

**`Debug` vise la production, délibérément.** Reproduire un bug remonté par un
bêta-testeur suppose ses données. D'où trois configurations plutôt que deux : le
choix de l'environnement devient explicite, au lieu d'être un effet de bord de
« je débogue ou je livre ».

**Sentry est éteint en dev** et doit le rester — sinon les plantages de test
polluent les rapports de production.

**Firebase est partagé** par décision, pas par étape manquante. Avec la
conséquence pratique mise en avertissement : un compte créé en dev existe aussi
en production, et une suppression y est définitive.

## Correction au passage

Le schéma de déploiement de `05-infrastructure.md` était périmé sur deux points :

- il annonçait la base `arbore_test` alors que le dev utilise `arbore_dev`
  depuis #434 — c'est précisément la confusion qui avait fait ouvrir la base de
  production au dev ;
- il ne montrait pas nginx desservant le dev, alors qu'`api-dev.arbore.app` est
  en service.

## Vérifications

- `docs-drift-check.sh` : 508 références de chemins vérifiées, aucune dérive
- 325 liens relatifs vérifiés dans `docs/`, aucun cassé
- parité FR/EN respectée, les deux hubs `README.md` mis à jour
- noms de schémas et de configurations vérifiés contre `xcodebuild -list`
  (`ArboreUi`, `ArboreUi Dev` · `Debug`, `Release`, `Dev`)

Refs #401, #434
