### PR TITLE
fix(web): donner au healthcheck sa propre route, pour que Sentry cesse de le compter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,11 @@ services:
       # 127.0.0.1 (et pas localhost) : dans le conteneur, localhost résout
       # d'abord en IPv6 [::1] où Next.js n'écoute pas (bind 0.0.0.0 IPv4) →
       # faux "unhealthy". Forcer l'IPv4 rend le check fiable.
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
+      # `/health` et non `/` (#469) : la racine est aussi la vraie page
+      # d'accueil, et la sonde y représentait 99,2 % du volume tracé par
+      # Sentry. Une route distincte permet de filtrer la sonde sans rendre
+      # invisible le trafic réel de la page d'accueil.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/web/app/health/route.ts
+++ b/web/app/health/route.ts
@@ -1,0 +1,27 @@
+// Route de santé dédiée au healthcheck Docker (#469).
+//
+// Avant, le healthcheck visait `/`. Mesuré côté Sentry sur 7 jours : `GET /`
+// représentait 21 880 spans sur 22 060 — 99,2 % du volume tracé — quand toutes
+// les vraies pages réunies en totalisaient 180. Le tracing ne décrivait donc
+// pas l'usage du site, mais la sonde qui le surveille.
+//
+// Le coût n'était PAS celui du rendu : `/` est prérendu statique, le
+// healthcheck ne faisait que servir un fichier. C'est le bruit dans Sentry qui
+// pose problème, pas le calcul.
+//
+// Pourquoi une route dédiée plutôt qu'un simple filtre : `/` est aussi la vraie
+// page d'accueil. Filtrer `GET /` aurait rendu invisible le trafic qu'on veut
+// justement voir. Séparer les deux chemins est ce qui permet de taire l'un sans
+// taire l'autre.
+//
+// `force-dynamic` est nécessaire : sans lui, Next.js prérendrait cette réponse
+// au build et la servirait en statique. Le healthcheck ne prouverait alors plus
+// que le processus répond — il ne testerait que la capacité à servir un
+// fichier, ce qui est précisément ce qu'un healthcheck ne doit pas faire.
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok', service: 'arbore-web' });
+}

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -10,4 +10,11 @@ Sentry.init({
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.NODE_ENV,
   tracesSampleRate: 0.1,
   sendDefaultPii: false,
+
+  // Le healthcheck Docker interroge `/health` toutes les 30 s dans chaque
+  // conteneur. Sans ce filtre il représenterait l'essentiel du tracing — le
+  // relevé avant correction donnait 99,2 % du volume pour l'ancienne cible `/`
+  // (#469). Un healthcheck qui réussit n'apprend rien ; s'il échoue, Docker
+  // le signale déjà en marquant le conteneur `unhealthy`.
+  ignoreTransactions: ['GET /health'],
 });


### PR DESCRIPTION
## Le constat, mesuré

Relevé dans Sentry sur 7 jours, projet `frontend-web-arbore` :

| transaction | spans | part |
|---|---|---|
| `GET /` | 21 880 | **99,2 %** |
| toutes les autres pages réunies | ~180 | 0,8 % |

`/profile`, `/signup`, `/login`, `/welcome`, `/pricing`, `/garden`, `/features`,
`/about` totalisent **180 spans en une semaine**.

La source est le healthcheck Docker, qui interroge `/` toutes les 30 secondes
dans chaque conteneur. Le tracing ne décrivait donc pas l'usage du site, mais la
sonde qui le surveille.

## Ce que ce n'était pas

**Le coût n'était pas celui du rendu.** J'avais d'abord écrit que le healthcheck
« faisait rendre la page d'accueil complète » — c'est faux : `/` est prérendu
statique, la sonde ne faisait que servir un fichier de 40 Ko. Le problème est le
bruit dans Sentry, pas le calcul. La correction reste la même, sa justification
non.

## Pourquoi une route dédiée plutôt qu'un filtre

`ignoreTransactions: ['GET /']` aurait suffi à faire taire la sonde — et aurait
rendu invisible le trafic de la vraie page d'accueil, qui partage le même
chemin. Séparer les deux permet de taire l'une sans taire l'autre.

## Les trois modifications

- `web/app/health/route.ts` — route de santé, réponse JSON minimale
- `docker-compose.yml` — le healthcheck vise `/health`
- `web/sentry.server.config.ts` — `ignoreTransactions: ['GET /health']`

## Vérifications

Deux points où le raisonnement seul aurait pu se tromper, donc testés :

**`force-dynamic` est nécessaire.** Sans lui Next.js prérendrait la réponse au
build ; le healthcheck ne testerait alors plus que la capacité à servir un
fichier statique, ce qu'un healthcheck ne doit précisément pas faire. Le build
confirme `λ /health` (Server) et non `○` (Static).

**HEAD répond 200.** `wget --spider` envoie une requête HEAD. Un handler qui ne
l'accepterait pas ferait passer le conteneur `unhealthy` — donc `web` ne
démarrerait plus. Testé sur le build réel : `curl -I /health` → 200.

```
build     λ /health                     ← dynamique, pas statique
GET  /health  → 200  {"status":"ok","service":"arbore-web"}
HEAD /health  → 200
GET  /        → 200  (page d'accueil intacte)
typecheck     ✅
```

## Ce que ça ne corrige pas

Les deux environnements web remontent toujours dans le même projet Sentry
étiquetés `production` — c'est l'autre volet de #469, qui demande un `ARG` de
build et ne peut pas se régler côté déploiement.

Refs #469, #388
