### PR TITLE
fix(web): promouvoir la route de santé dédiée vers la production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,11 @@ services:
       # 127.0.0.1 (et pas localhost) : dans le conteneur, localhost résout
       # d'abord en IPv6 [::1] où Next.js n'écoute pas (bind 0.0.0.0 IPv4) →
       # faux "unhealthy". Forcer l'IPv4 rend le check fiable.
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
+      # `/health` et non `/` (#469) : la racine est aussi la vraie page
+      # d'accueil, et la sonde y représentait 99,2 % du volume tracé par
+      # Sentry. Une route distincte permet de filtrer la sonde sans rendre
+      # invisible le trafic réel de la page d'accueil.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/web/app/health/route.ts
+++ b/web/app/health/route.ts
@@ -1,0 +1,27 @@
+// Route de santé dédiée au healthcheck Docker (#469).
+//
+// Avant, le healthcheck visait `/`. Mesuré côté Sentry sur 7 jours : `GET /`
+// représentait 21 880 spans sur 22 060 — 99,2 % du volume tracé — quand toutes
+// les vraies pages réunies en totalisaient 180. Le tracing ne décrivait donc
+// pas l'usage du site, mais la sonde qui le surveille.
+//
+// Le coût n'était PAS celui du rendu : `/` est prérendu statique, le
+// healthcheck ne faisait que servir un fichier. C'est le bruit dans Sentry qui
+// pose problème, pas le calcul.
+//
+// Pourquoi une route dédiée plutôt qu'un simple filtre : `/` est aussi la vraie
+// page d'accueil. Filtrer `GET /` aurait rendu invisible le trafic qu'on veut
+// justement voir. Séparer les deux chemins est ce qui permet de taire l'un sans
+// taire l'autre.
+//
+// `force-dynamic` est nécessaire : sans lui, Next.js prérendrait cette réponse
+// au build et la servirait en statique. Le healthcheck ne prouverait alors plus
+// que le processus répond — il ne testerait que la capacité à servir un
+// fichier, ce qui est précisément ce qu'un healthcheck ne doit pas faire.
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok', service: 'arbore-web' });
+}

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -10,4 +10,11 @@ Sentry.init({
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.NODE_ENV,
   tracesSampleRate: 0.1,
   sendDefaultPii: false,
+
+  // Le healthcheck Docker interroge `/health` toutes les 30 s dans chaque
+  // conteneur. Sans ce filtre il représenterait l'essentiel du tracing — le
+  // relevé avant correction donnait 99,2 % du volume pour l'ancienne cible `/`
+  // (#469). Un healthcheck qui réussit n'apprend rien ; s'il échoue, Docker
+  // le signale déjà en marquant le conteneur `unhealthy`.
+  ignoreTransactions: ['GET /health'],
 });


### PR DESCRIPTION
Promotion `dev` → `main` de #470.

## Ce que ça change

Le healthcheck Docker du conteneur web vise `/health` au lieu de `/`, et cette
transaction est filtrée du tracing Sentry. Mesuré avant correction : `GET /`
représentait **21 880 spans sur 22 060 en 7 jours — 99,2 %** du volume tracé,
quand toutes les vraies pages réunies en totalisaient 180.

## Vérifié sur dev avant promotion

C'est un changement de healthcheck : s'il est faux, le conteneur ne démarre pas.
Déployé sur `dev` et contrôlé sur le conteneur réel plutôt que raisonné :

```
Healthcheck.Test : ["CMD","wget","--tries=1","--spider","http://127.0.0.1:3000/health"]
State.Health     : healthy
dernier check    : exit=0  "remote file exists"
GET  /health     : {"status":"ok","service":"arbore-web"}
wget --spider    : remote file exists       ← HEAD, pas GET
```

Le point qui pouvait casser la production est `wget --spider`, qui envoie une
requête **HEAD** : un handler qui ne l'accepterait pas ferait passer le conteneur
`unhealthy` et `web` ne démarrerait plus. Next.js implémente HEAD
automatiquement pour un handler GET — vérifié en local puis sur le conteneur.

## Note sur le diff

`ops/sbin/cf-http-firewall.sh` apparaît dans la comparaison des deux branches
parce que `main` porte le correctif conntrack (#466) que `dev` n'a pas. `dev`
n'a pas touché ce fichier : la fusion conserve la version de `main`.

Refs #469
