### PR TITLE
docs: promouvoir la documentation Sentry et déploiement vers main

### DIFF
--- a/docs/en/operations/environments.md
+++ b/docs/en/operations/environments.md
@@ -93,6 +93,45 @@ of prod, which is the normal state while a feature is in flight.
 
 ---
 
+## Deploying an environment
+
+Deployment is **manual**, by choice: nobody ships to production without knowing
+it. On the VPS, one checkout per environment.
+
+```sh
+# production
+cd /home/fedora/Arbore && ./deploy.sh
+
+# development
+cd /home/fedora/Arbore-dev && ARBORE_ENV=dev ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
+Three traps, all hit for real:
+
+**`ARBORE_DEPLOY_BRANCH=dev` is mandatory for dev.** Without it the script
+refuses: `Checkout sur 'dev', attendu 'main' — déploiement refusé`. This guard
+(#384) exists because a checkout left on a working branch would deploy that
+branch silently. The default is `main`, so production does not set the variable.
+
+**Do not run `deploy.sh` under `sudo`.** The script handles Docker elevation
+itself. Under `sudo`, git switches to root's keys and `git pull` fails with a
+misleading `Permission denied (publickey)`.
+
+**Wait for images to be published.** `deploy.sh` pulls the image tagged
+`sha-<commit>`; if the publish workflow has not finished, the pull fails and the
+script falls back to a local build — slow, and the running image is then no
+longer the one CI produced. Check before deploying:
+
+```sh
+gh api "repos/ArboreTeam/Arbore/actions/runs?head_sha=$(git rev-parse origin/main)" \
+  --jq '.workflow_runs[] | select(.name|test("Build")) | .conclusion'
+```
+
+`gh run list --commit <sha>` sometimes returns stale results, including deleted
+workflows. The direct API call above is reliable.
+
+---
+
 ## What differs on dev
 
 **Sentry is off.** Without a DSN the SDK does not start, so test crashes do not

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -6,7 +6,26 @@ Crash and performance reporting for Arbore. **iOS** and **web** are wired up; th
 - iOS SDK: [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa) via Swift Package Manager
 - Web SDK: [`@sentry/nextjs`](https://github.com/getsentry/sentry-javascript)
 - Org: `epi-apps` (sentry.io, **EU** data residency)
-- Projects: `arbore-frontend` (iOS), `arbore-backend` (Gin — Phase 2)
+- Projects: `arbore-frontend` (iOS), `frontend-web-arbore` (web), `arbore-backend` (Gin — Phase 2)
+
+---
+
+## Measured state — 2026-09-08
+
+Read from the Sentry organization, not inferred from configuration. Re-measure
+rather than trust: these figures age.
+
+| project | SDK | traffic over 90 days |
+|---|---|---|
+| `arbore-frontend` (iOS) | ✅ | **nothing at all** |
+| `frontend-web-arbore` | ✅ | 192,800 spans, 0 errors |
+| `arbore-backend` | ❌ absent from `go.mod` | empty |
+
+**Zero errors across all three projects.** That is not a sign of health, it is
+the measurement of what is not wired up — see the two sections below.
+
+A Sentry organization `arbore` also exists, **empty**. It must not be used as a
+destination by mistake: everything lives in `epi-apps`.
 
 ## iOS
 
@@ -22,6 +41,13 @@ Crash and performance reporting for Arbore. **iOS** and **web** are wired up; th
 `SentryManager` is **disabled until a DSN is configured _and_ the user has explicitly opted in** to diagnostics sharing (the `privacy_shareData` toggle in the privacy settings, **off by default** — GDPR opt-in, #226). Without secrets or consent, the app builds and runs identically (handy for contributors and CI). `start()` is a no-op until consent is given; toggling consent starts/stops the SDK at runtime via `updateConsent(granted:uid:)`. The user context is the **Firebase UID only** (no email or name) and tracks auth state through a single `addStateDidChangeListener` in `AppDelegate`.
 
 Options set: `environment` (`debug`/`beta`), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus a `beforeSend` hook that strips IP / email / name / request body from every event (keeping only the UID pseudonym).
+
+> ⚠️ **Consequence worth knowing: iOS reports nothing.** Zero events in 90 days
+> (measured 2026-09-08). The mechanism works — it is consent that is never
+> given, because it is never offered. The whole chain, DSN and dSYM upload
+> included, is in place and has no effect. A launch crash on a tester's device
+> is today indistinguishable from a tester who does not open the app. Open
+> decision in #469.
 
 ### iOS setup (one-shot)
 
@@ -64,6 +90,36 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 | `web/sentry.edge.config.ts` | edge | same as server |
 
 `web/instrumentation.ts` loads the server/edge configs based on `NEXT_RUNTIME`. `tracesSampleRate = 0.1`. The error boundaries `web/app/error.tsx` and `web/app/global-error.tsx` call `Sentry.captureException`. Source map upload is opt-in via `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` (uncommitted); when absent, the build does not fail.
+
+### Healthcheck noise
+
+The Docker healthcheck hits `web/app/health/route.ts` — a dedicated route, not
+`/`. That transaction is excluded from tracing by `ignoreTransactions:
+['GET /health']` in `sentry.server.config.ts`.
+
+Before this separation (#469), the probe targeted `/` and accounted for
+**21,880 spans out of 22,060 over 7 days — 99.2%** of traced volume, while every
+real page combined totalled 180. Tracing described not the site's usage but the
+probe watching it — #388's pattern on the backend, transposed to the web.
+
+A dedicated route rather than a filter on `GET /`: the root is also the real
+homepage, and filtering it would have hidden the traffic we actually want.
+
+`force-dynamic` on the route is required — without it Next.js would prerender
+it, and the probe would only test the ability to serve a static file.
+
+### ⚠️ Environments are not distinguished
+
+`NEXT_PUBLIC_SENTRY_ENV` is **empty** in `web/.env`, so environment falls back to
+`NODE_ENV` — which is `production` in any Next build. **Both prod and dev report
+as `production`**, into the same project.
+
+`docker-compose.yml` does set this variable at runtime. It has no effect: Next.js
+replaces `NEXT_PUBLIC_*` with their values **at build time**, on the server as
+well as the client. The compiled code no longer reads `process.env`.
+
+**Corollary: this cannot be fixed at deploy time.** It needs a build `ARG`, hence
+one image per environment. Tracked in #469.
 
 ## Backend (Go)
 

--- a/docs/fr/operations/environnements.md
+++ b/docs/fr/operations/environnements.md
@@ -96,6 +96,46 @@ cours.
 
 ---
 
+## Déployer un environnement
+
+Le déploiement est **manuel**, par choix : personne ne pousse en production sans
+le savoir. Sur le VPS, un checkout par environnement.
+
+```sh
+# production
+cd /home/fedora/Arbore && ./deploy.sh
+
+# développement
+cd /home/fedora/Arbore-dev && ARBORE_ENV=dev ARBORE_DEPLOY_BRANCH=dev ./deploy.sh
+```
+
+Trois pièges, tous rencontrés en vrai :
+
+**`ARBORE_DEPLOY_BRANCH=dev` est obligatoire pour le dev.** Sans lui le script
+refuse : `Checkout sur 'dev', attendu 'main' — déploiement refusé`. Ce garde-fou
+(#384) existe parce qu'un checkout laissé sur une branche de travail ferait
+déployer cette branche sans rien signaler. Le défaut est `main`, et la
+production ne définit donc pas la variable.
+
+**Ne pas lancer `deploy.sh` avec `sudo`.** Le script gère lui-même l'élévation
+pour Docker. Sous `sudo`, git bascule sur les clés de root et le `git pull`
+échoue sur un `Permission denied (publickey)` trompeur.
+
+**Attendre la publication des images.** `deploy.sh` tire l'image étiquetée
+`sha-<commit>` ; si le workflow de publication n'a pas fini, le tirage échoue et
+le script se replie sur un build local — lent, et l'image qui tourne n'est alors
+plus celle que la CI a produite. Vérifier avant de déployer :
+
+```sh
+gh api "repos/ArboreTeam/Arbore/actions/runs?head_sha=$(git rev-parse origin/main)" \
+  --jq '.workflow_runs[] | select(.name|test("Build")) | .conclusion'
+```
+
+`gh run list --commit <sha>` renvoie parfois des résultats périmés, y compris des
+workflows supprimés. L'appel direct à l'API ci-dessus est fiable.
+
+---
+
 ## Ce qui diffère en dev
 
 **Sentry est éteint.** Sans DSN, le SDK ne démarre pas : les plantages de test

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -6,7 +6,26 @@ Reporting de crashs et de performance pour Arbore. **iOS** et **web** sont câbl
 - SDK iOS : [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa) via Swift Package Manager
 - SDK web : [`@sentry/nextjs`](https://github.com/getsentry/sentry-javascript)
 - Org : `epi-apps` (sentry.io, résidence des données **UE**)
-- Projets : `arbore-frontend` (iOS), `arbore-backend` (Gin — Phase 2)
+- Projets : `arbore-frontend` (iOS), `frontend-web-arbore` (web), `arbore-backend` (Gin — Phase 2)
+
+---
+
+## État mesuré — 2026-09-08
+
+Relevé dans l'organisation Sentry, pas déduit de la configuration. À refaire
+plutôt qu'à croire : ces chiffres vieillissent.
+
+| projet | SDK | trafic sur 90 jours |
+|---|---|---|
+| `arbore-frontend` (iOS) | ✅ | **rien** |
+| `frontend-web-arbore` | ✅ | 192 800 spans, 0 erreur |
+| `arbore-backend` | ❌ absent de `go.mod` | vide |
+
+**Zéro erreur pour les trois projets.** Ce n'est pas un signe de bonne santé,
+c'est la mesure de ce qui n'est pas branché — voir les deux sections suivantes.
+
+Une organisation Sentry `arbore` existe aussi, **vide**. Elle ne doit pas servir
+de destination par erreur : tout vit dans `epi-apps`.
 
 ## iOS
 
@@ -22,6 +41,13 @@ Reporting de crashs et de performance pour Arbore. **iOS** et **web** sont câbl
 `SentryManager` est **désactivé tant qu'un DSN n'est pas configuré _et_ que l'utilisateur n'a pas explicitement opté** pour le partage de diagnostics (toggle `privacy_shareData` dans les réglages de confidentialité, **off par défaut** — opt-in RGPD, #226). Sans secrets ni consentement, l'app se build et tourne à l'identique (pratique pour les contributeurs et la CI). `start()` est un no-op jusqu'au consentement ; basculer le consentement démarre/arrête le SDK à chaud via `updateConsent(granted:uid:)`. Le contexte utilisateur est l'**UID Firebase uniquement** (ni email ni nom) et suit l'état d'auth via un unique `addStateDidChangeListener` dans `AppDelegate`.
 
 Options posées : `environment` (`debug`/`beta`), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (vie privée), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus un hook `beforeSend` qui retire IP / email / nom / corps de requête de chaque événement (ne conserve que le pseudonyme UID).
+
+> ⚠️ **Conséquence à connaître : l'iOS ne remonte rien.** Zéro événement en
+> 90 jours (mesuré le 2026-09-08). Le mécanisme fonctionne — c'est le
+> consentement qui n'est jamais donné, faute d'être proposé. Toute la chaîne,
+> DSN et upload dSYM compris, est en place et sans effet. Un crash au lancement
+> chez un testeur est aujourd'hui indiscernable d'un testeur qui n'ouvre pas
+> l'app. Arbitrage ouvert dans #469.
 
 ### Setup iOS (one-shot)
 
@@ -64,6 +90,36 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 | `web/sentry.edge.config.ts` | edge | idem serveur |
 
 `web/instrumentation.ts` charge les configs serveur/edge selon `NEXT_RUNTIME`. `tracesSampleRate = 0.1`. Les frontières d'erreur `web/app/error.tsx` et `web/app/global-error.tsx` appellent `Sentry.captureException`. L'upload des source maps est opt-in via `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` (non committés) ; absent, le build n'échoue pas.
+
+### Bruit du healthcheck
+
+Le healthcheck Docker interroge `web/app/health/route.ts` — une route dédiée,
+et non `/`. Cette transaction est exclue du tracing par `ignoreTransactions:
+['GET /health']` dans `sentry.server.config.ts`.
+
+Avant cette séparation (#469), la sonde visait `/` et représentait **21 880
+spans sur 22 060 en 7 jours — 99,2 %** du volume tracé, quand toutes les vraies
+pages réunies en totalisaient 180. Le tracing ne décrivait pas l'usage du site
+mais la sonde qui le surveille — le motif de #388 côté backend, transposé au web.
+
+Une route dédiée plutôt qu'un filtre sur `GET /` : la racine est aussi la vraie
+page d'accueil, la filtrer aurait masqué le trafic qu'on cherche à voir.
+
+`force-dynamic` sur la route est nécessaire — sans lui Next.js la prérendrait,
+et la sonde ne testerait plus que la capacité à servir un fichier statique.
+
+### ⚠️ Les environnements ne sont pas distingués
+
+`NEXT_PUBLIC_SENTRY_ENV` est **vide** dans `web/.env`, et l'environnement tombe
+donc sur le repli `NODE_ENV` — qui vaut `production` dans tout build Next.
+**Prod et dev remontent tous deux comme `production`**, dans le même projet.
+
+`docker-compose.yml` définit pourtant cette variable au runtime. Ça ne sert à
+rien : Next.js remplace les `NEXT_PUBLIC_*` par leur valeur **à la compilation**,
+côté serveur comme côté client. Le code compilé ne lit plus `process.env`.
+
+**Corollaire : ce réglage ne peut pas se corriger côté déploiement.** Il faut un
+`ARG` de build, donc une image par environnement. Suivi dans #469.
 
 ## Backend (Go)
 


### PR DESCRIPTION
Promotion `dev` → `main` de #473. **Documentation uniquement.**

Deux trous constatés en travaillant sur #469 :

**`observability.md` décrivait la mécanique, jamais son effet.** Elle expliquait
comment Sentry est câblé sans dire ce qu'il remonte — c'est-à-dire presque rien.
Notamment : l'opt-in RGPD de l'iOS était documenté, mais pas sa conséquence,
**aucun événement en 90 jours**. Ajoute aussi l'état mesuré et daté des trois
projets, la confusion des environnements web, et le bruit du healthcheck avec sa
correction (#470).

**`environnements.md` ne disait pas comment déployer.** Le document ajouté ce
matin explique comment viser le dev depuis Xcode, mais pas comment déployer un
environnement — j'ai buté dessus moi-même quelques heures plus tard. Les trois
pièges y figurent : `ARBORE_DEPLOY_BRANCH=dev`, l'interdiction du `sudo`, et
l'attente de la publication des images.

```
docs-drift-check.sh   518 références, aucune dérive
liens relatifs        325 vérifiés, 0 cassé
parité FR/EN          41 fichiers de chaque côté
```

Refs #401, #469
