### PR TITLE
fix(web): figer jsx sur preserve, la valeur que Next.js impose

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Constat

`web/tsconfig.json` déclarait `"jsx": "react-jsx"`. Next.js impose `"preserve"`
et réécrivait le fichier **à chaque build**. La valeur versionnée n'était donc
jamais celle utilisée.

## Pourquoi ça mérite un correctif

Quiconque construit le web se retrouvait avec un arbre sale sans avoir rien
modifié :

- un `git add -A` réflexe embarque la modification dans une PR sans rapport —
  c'est arrivé sur #470, où il a fallu l'exclure à la main ;
- un `git checkout` la fait disparaître silencieusement ;
- elle brouille `git status` pendant tout travail sur le web.

Rien de grave isolément. Mais un `git status` qu'on cesse de lire ne prévient
plus de rien.

## Vérifications

```
tsc --noEmit      ✅
npm run build     ✅
git status après build : tsconfig.json intact
```

Closes #471
