### PR TITLE
fix(web): Next.js 16.3.4 — CVE-2026-75604, RCE non authentifiée (CRITICAL)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,7 +47,7 @@
         "framer-motion": "^12.23.24",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.446.0",
-        "next": "16.2.11",
+        "next": "^16.3.4",
         "next-themes": "^0.3.0",
         "postcss": "8.5.22",
         "react": "18.3.1",
@@ -2263,9 +2263,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
-      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
+      "integrity": "sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2309,9 +2309,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
-      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.4.tgz",
+      "integrity": "sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==",
       "cpu": [
         "arm64"
       ],
@@ -2325,9 +2325,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
-      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.4.tgz",
+      "integrity": "sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==",
       "cpu": [
         "x64"
       ],
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
-      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.4.tgz",
+      "integrity": "sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==",
       "cpu": [
         "arm64"
       ],
@@ -2360,9 +2360,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
-      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.4.tgz",
+      "integrity": "sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==",
       "cpu": [
         "arm64"
       ],
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
-      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.4.tgz",
+      "integrity": "sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==",
       "cpu": [
         "x64"
       ],
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
-      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.4.tgz",
+      "integrity": "sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==",
       "cpu": [
         "x64"
       ],
@@ -2417,9 +2417,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
-      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.4.tgz",
+      "integrity": "sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==",
       "cpu": [
         "arm64"
       ],
@@ -2433,9 +2433,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
-      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.4.tgz",
+      "integrity": "sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==",
       "cpu": [
         "x64"
       ],
@@ -6627,9 +6627,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -12496,16 +12496,16 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
-      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.4.tgz",
+      "integrity": "sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.11",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.4",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -12515,15 +12515,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.11",
-        "@next/swc-darwin-x64": "16.2.11",
-        "@next/swc-linux-arm64-gnu": "16.2.11",
-        "@next/swc-linux-arm64-musl": "16.2.11",
-        "@next/swc-linux-x64-gnu": "16.2.11",
-        "@next/swc-linux-x64-musl": "16.2.11",
-        "@next/swc-win32-arm64-msvc": "16.2.11",
-        "@next/swc-win32-x64-msvc": "16.2.11",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.4",
+        "@next/swc-darwin-x64": "16.3.4",
+        "@next/swc-linux-arm64-gnu": "16.3.4",
+        "@next/swc-linux-arm64-musl": "16.3.4",
+        "@next/swc-linux-x64-gnu": "16.3.4",
+        "@next/swc-linux-x64-musl": "16.3.4",
+        "@next/swc-win32-arm64-msvc": "16.3.4",
+        "@next/swc-win32-x64-msvc": "16.3.4",
+        "sharp": "^0.35.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,7 @@
     "framer-motion": "^12.23.24",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.446.0",
-    "next": "16.2.11",
+    "next": "^16.3.4",
     "next-themes": "^0.3.0",
     "postcss": "8.5.22",
     "react": "18.3.1",
@@ -85,7 +85,7 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-	"postcss": "8.5.22",
-	"sharp": "0.35.3"
+    "postcss": "8.5.22",
+    "sharp": "0.35.3"
   }
 }


### PR DESCRIPTION
## Ce que c'est

```
CVE-2026-75604   CRITICAL
next 16.2.11  →  corrigé en 16.3.3
Next.js: Unauthenticated Remote Code Execution
API d'optimisation d'images, fichiers AVIF
GHSA-2xp9-vwfh-vxw4
```

Une **exécution de code à distance sans authentification**, dans le framework
qui sert `web.arbore.app` en production aujourd'hui.

## Comment on l'a su

Trivy a bloqué la CI de la PR #478, qui n'a aucun rapport. L'avis a été publié
depuis le dernier build ; cette PR est simplement la première à passer après.

**Ce n'est pas un effet de bord malheureux, c'est le gate qui fait son travail.**
Aucune PR ne peut plus être fusionnée tant que la production reste exposée. Le
gate ne signale que les failles corrigeables (`ignore-unfixed: true`) : il y
avait donc une action possible immédiatement.

## Le choix de version

Monté en **16.3.4**, la dernière publiée de la ligne, plutôt qu'en 16.3.3, le
minimum correctif. Pas de raison de s'arrêter à la version qui corrige tout
juste quand la suivante est disponible.

## Vérifications

```
tsc --noEmit     ✅
npm run build    ✅
npm test         8 tests, 2 fichiers, tous verts
```

## À faire après fusion

Déployer **sans attendre** la promotion habituelle : la production tourne
actuellement une version vulnérable. La PR #478 sera rebasée ensuite.

Refs #401
