### PR TITLE
fix(web): promouvoir l'étiquetage runtime de l'environnement Sentry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,13 @@ services:
       - ARBORE_API_KEY=${ARBORE_API_KEY}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN:-}
+      # Lue au RUNTIME par sentry.{server,edge}.config.ts (#469) : c'est elle qui
+      # étiquette réellement les événements, et elle permet à une seule image de
+      # servir les deux environnements.
+      - SENTRY_ENVIRONMENT=${ARBORE_ENV:-prod}
+      # ⚠️ Sans effet, conservée pour mémoire. Next.js inline les `NEXT_PUBLIC_*`
+      # à la COMPILATION : le code compilé ne lit plus process.env, donc la poser
+      # ici ne change rien. C'est précisément le piège de #469.
       - NEXT_PUBLIC_SENTRY_ENV=${NEXT_PUBLIC_SENTRY_ENV:-production}
       - NEXT_PUBLIC_APP_VERSION=${NEXT_PUBLIC_APP_VERSION:-1.0.0}
       - PORT=3000

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -109,18 +109,22 @@ homepage, and filtering it would have hidden the traffic we actually want.
 `force-dynamic` on the route is required — without it Next.js would prerender
 it, and the probe would only test the ability to serve a static file.
 
-### ⚠️ Environments are not distinguished
+### Environment tagging
 
-`NEXT_PUBLIC_SENTRY_ENV` is **empty** in `web/.env`, so environment falls back to
-`NODE_ENV` — which is `production` in any Next build. **Both prod and dev report
-as `production`**, into the same project.
+`SENTRY_ENVIRONMENT` (`prod` / `dev`, derived from `ARBORE_ENV`) is read **at
+runtime** by `sentry.server.config.ts` and `sentry.edge.config.ts`. One image
+therefore serves both environments, each tagging itself.
 
-`docker-compose.yml` does set this variable at runtime. It has no effect: Next.js
-replaces `NEXT_PUBLIC_*` with their values **at build time**, on the server as
-well as the client. The compiled code no longer reads `process.env`.
+The trap fixed by #469: `NEXT_PUBLIC_SENTRY_ENV` is inlined **at build time**.
+Setting it on the container had no effect, `web/.env` left it empty, and the
+`NODE_ENV` fallback yielded `production` everywhere — prod and dev
+indistinguishable.
 
-**Corollary: this cannot be fixed at deploy time.** It needs a build `ARG`, hence
-one image per environment. Tracked in #469.
+> ⚠️ **Remaining limit, browser side only.** `sentry.client.config.ts` runs in
+> the browser and cannot read a runtime variable: its tag stays frozen at build
+> time. No effect today — over 90 days the project received **no** browser
+> transactions at all, every span comes from the server. Fixing it would require
+> one image per environment.
 
 ## Backend (Go)
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -109,18 +109,22 @@ page d'accueil, la filtrer aurait masqué le trafic qu'on cherche à voir.
 `force-dynamic` sur la route est nécessaire — sans lui Next.js la prérendrait,
 et la sonde ne testerait plus que la capacité à servir un fichier statique.
 
-### ⚠️ Les environnements ne sont pas distingués
+### Étiquetage des environnements
 
-`NEXT_PUBLIC_SENTRY_ENV` est **vide** dans `web/.env`, et l'environnement tombe
-donc sur le repli `NODE_ENV` — qui vaut `production` dans tout build Next.
-**Prod et dev remontent tous deux comme `production`**, dans le même projet.
+`SENTRY_ENVIRONMENT` (`prod` / `dev`, dérivée d'`ARBORE_ENV`) est lue **au
+runtime** par `sentry.server.config.ts` et `sentry.edge.config.ts`. Une seule
+image sert donc les deux environnements, chacun s'étiquetant lui-même.
 
-`docker-compose.yml` définit pourtant cette variable au runtime. Ça ne sert à
-rien : Next.js remplace les `NEXT_PUBLIC_*` par leur valeur **à la compilation**,
-côté serveur comme côté client. Le code compilé ne lit plus `process.env`.
+Le piège corrigé par #469 : `NEXT_PUBLIC_SENTRY_ENV` est inlinée **à la
+compilation**. La poser sur le conteneur n'avait aucun effet, `web/.env` la
+laissait vide, et le repli `NODE_ENV` donnait `production` partout — prod et dev
+indistinguables.
 
-**Corollaire : ce réglage ne peut pas se corriger côté déploiement.** Il faut un
-`ARG` de build, donc une image par environnement. Suivi dans #469.
+> ⚠️ **Limite restante, côté navigateur uniquement.** `sentry.client.config.ts`
+> s'exécute dans le navigateur et ne peut pas lire une variable au runtime : son
+> étiquette reste figée à la compilation. Sans effet aujourd'hui — sur 90 jours
+> le projet n'a reçu **aucune** transaction de navigateur, tout le volume vient
+> du serveur. Y remédier exigerait une image par environnement.
 
 ## Backend (Go)
 

--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -9,6 +9,21 @@ const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 Sentry.init({
   dsn,
   enabled: !!dsn,
+  // ⚠️ Limite connue et assumée (#469). Contrairement aux configs serveur et
+  // edge, ce fichier est exécuté par le NAVIGATEUR : il ne peut pas lire une
+  // variable d'environnement au runtime. Next.js inline les `NEXT_PUBLIC_*` à la
+  // compilation, donc l'étiquette est figée dans l'image — et comme `web/.env`
+  // laisse la valeur vide, le repli `NODE_ENV` donne `production` partout.
+  //
+  // Conséquence : les erreurs NAVIGATEUR d'un web de dev seraient étiquetées
+  // `production`. C'est sans effet aujourd'hui — sur 90 jours, le projet n'a
+  // reçu aucune transaction de navigateur (`pageload`, `navigation`) : tout le
+  // volume vient du serveur, et le serveur s'étiquette correctement depuis ce
+  // correctif.
+  //
+  // Y remédier exigerait une image par environnement, ou l'injection de la
+  // valeur dans le document par le serveur. Ni l'un ni l'autre ne se justifie
+  // tant que le web de dev n'a pas d'utilisateurs.
   environment: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.NODE_ENV,
   tracesSampleRate: 0.1,
   sendDefaultPii: false,

--- a/web/sentry.edge.config.ts
+++ b/web/sentry.edge.config.ts
@@ -7,7 +7,21 @@ const dsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 Sentry.init({
   dsn,
   enabled: !!dsn,
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.NODE_ENV,
+  // `SENTRY_ENVIRONMENT` D'ABORD, et c'est tout l'objet du correctif (#469).
+  //
+  // `NEXT_PUBLIC_SENTRY_ENV` est inliné À LA COMPILATION par Next.js : la valeur
+  // posée sur le conteneur n'a aucun effet, le code compilé ne lit plus
+  // `process.env`. `web/.env` la laissant vide, le repli tombait sur `NODE_ENV`
+  // — `production` dans tout build Next. Prod et dev remontaient donc sous la
+  // même étiquette, indistinguables.
+  //
+  // Ce fichier tourne côté serveur, au runtime : une variable NON préfixée
+  // `NEXT_PUBLIC_` y est lue à l'exécution. Une seule image sert donc les deux
+  // environnements, chacun s'étiquetant lui-même.
+  environment:
+    process.env.SENTRY_ENVIRONMENT ||
+    process.env.NEXT_PUBLIC_SENTRY_ENV ||
+    process.env.NODE_ENV,
   tracesSampleRate: 0.1,
   sendDefaultPii: false,
 });

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -7,7 +7,21 @@ const dsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 Sentry.init({
   dsn,
   enabled: !!dsn,
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENV || process.env.NODE_ENV,
+  // `SENTRY_ENVIRONMENT` D'ABORD, et c'est tout l'objet du correctif (#469).
+  //
+  // `NEXT_PUBLIC_SENTRY_ENV` est inliné À LA COMPILATION par Next.js : la valeur
+  // posée sur le conteneur n'a aucun effet, le code compilé ne lit plus
+  // `process.env`. `web/.env` la laissant vide, le repli tombait sur `NODE_ENV`
+  // — `production` dans tout build Next. Prod et dev remontaient donc sous la
+  // même étiquette, indistinguables.
+  //
+  // Ce fichier tourne côté serveur, au runtime : une variable NON préfixée
+  // `NEXT_PUBLIC_` y est lue à l'exécution. Une seule image sert donc les deux
+  // environnements, chacun s'étiquetant lui-même.
+  environment:
+    process.env.SENTRY_ENVIRONMENT ||
+    process.env.NEXT_PUBLIC_SENTRY_ENV ||
+    process.env.NODE_ENV,
   tracesSampleRate: 0.1,
   sendDefaultPii: false,
 


### PR DESCRIPTION
Promotion de #478. Ferme le problème 1 de #469.

## Vérifié sur dev avant promotion

```
conteneur arbore-dev-web    SENTRY_ENVIRONMENT = dev
                            NEXT_PUBLIC_SENTRY_ENV = production  (inerte)
```

Puis 40 requêtes sur le web de dev, et le relevé Sentry :

```
environment: dev          GET /          30    ← échantillonné à 10 %… et large
environment: production   GET /signup    80
                          GET /login     50
                          GET /          50
```

**Les deux environnements sont désormais distingués**, dans le même projet et
avec la même image. C'était l'objet du correctif.

## Rappel de ce qui a changé dans l'approche

#469 préconisait un `ARG` de build, donc une image par environnement. La mesure
a montré que tout le volume vient du serveur — aucune transaction de navigateur
en 90 jours — et les configs serveur et edge s'exécutent au runtime. Une
variable non préfixée `NEXT_PUBLIC_` suffit donc, sans doubler la publication.

La limite navigateur subsiste et est documentée dans le fichier concerné.

## Observation

La production reçoit du **vrai trafic** : 80 vues sur `/signup`, 50 sur
`/login`, autant sur l'accueil, en une heure. Le healthcheck étant filtré depuis
#470, ce sont des visites réelles — auparavant invisibles sous 99,2 % de bruit.

Refs #469, #401
