### PR TITLE
fix(ios,backend): le filtre par difficulté vidait le catalogue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
         - correspondant
         - continuent
         - infiniment
+        - existantes
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -237,10 +237,23 @@ type LifeCycleInfo struct {
 }
 
 type CareInfo struct {
-	Weekly    []string `json:"weekly" bson:"weekly"`
-	Monthly   []string `json:"monthly" bson:"monthly"`
-	Yearly    []string `json:"yearly" bson:"yearly"`
-	ExtraTips []string `json:"extraTips" bson:"extraTips"`
+	// Difficulty : niveau d'entretien affiché et filtrable (« Facile »,
+	// « Intermédiaire », « Exigeant »). `omitempty` : la fiche reste valide sans.
+	//
+	// Le modèle iOS déclarait ce champ depuis l'origine, mais il était absent
+	// ICI — donc jamais sérialisé, donc toujours nil côté app. Les deux filtres
+	// qui le lisaient s'en trouvaient neutralisés, et celui du catalogue vidait
+	// même la liste : un critère absent n'excluait pas « rien », il excluait
+	// TOUT (#485).
+	//
+	// Ajouter le champ ne le peuple pas : les 124 fiches existantes le laissent
+	// vide. C'est le repli sur `flags.easyCare` côté client qui fait tenir le
+	// filtre en attendant.
+	Difficulty string   `json:"difficulty,omitempty" bson:"difficulty,omitempty"`
+	Weekly     []string `json:"weekly" bson:"weekly"`
+	Monthly    []string `json:"monthly" bson:"monthly"`
+	Yearly     []string `json:"yearly" bson:"yearly"`
+	ExtraTips  []string `json:"extraTips" bson:"extraTips"`
 }
 
 type LanguageData struct {

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -355,3 +355,50 @@ fileprivate struct PlantFallback {
             ])))
     }
 }
+
+// MARK: - Niveau d'entretien (#485)
+
+extension Plant {
+
+    /// Niveau d'entretien d'une plante, tel qu'un filtre peut l'exploiter.
+    enum CareDifficulty {
+        case easy
+        case moderate
+        case demanding
+    }
+
+    /// Résout le niveau d'entretien, ou `nil` si la donnée est absente.
+    ///
+    /// Deux sources, dans cet ordre :
+    ///
+    /// 1. `care.difficulty`, qui porte les trois niveaux. Le backend ne le
+    ///    sérialisait pas jusqu'à #485 et aucune fiche ne le renseigne encore.
+    /// 2. `flags.easyCare`, présent sur 98 des 124 fiches. Binaire, donc
+    ///    incapable de distinguer « intermédiaire » — d'où le repli, pas le
+    ///    remplacement.
+    ///
+    /// **`nil` signifie « inconnu », pas « ne correspond pas ».** La distinction
+    /// est tout l'objet de #485 : le filtre du catalogue traitait l'absence de
+    /// donnée comme un échec de correspondance et excluait donc la totalité du
+    /// catalogue. Un filtre ne doit jamais cacher ce qu'il ne sait pas juger.
+    func careDifficulty(locale: String = "fr") -> CareDifficulty? {
+        if let raw = translations[locale]?.care?.difficulty?.lowercased(),
+           !raw.isEmpty {
+            // Mots-clés des quatre langues servies par le catalogue.
+            let easy = ["facile", "easy", "simple", "einfach", "leicht", "fácil", "facil", "débutant"]
+            let moderate = ["intermé", "medium", "modér", "mittel", "moderat", "intermedio"]
+            let demanding = ["exigeant", "difficile", "hard", "expert", "anspruchsvoll", "schwer", "dificil", "difícil"]
+
+            // « Exigeant » d'abord : « pas facile » contient « facile ».
+            if demanding.contains(where: raw.contains) { return .demanding }
+            if moderate.contains(where: raw.contains) { return .moderate }
+            if easy.contains(where: raw.contains) { return .easy }
+        }
+
+        if let flags = flags {
+            return flags.easyCare ? .easy : .demanding
+        }
+
+        return nil
+    }
+}

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -382,8 +382,21 @@ extension Plant {
     /// donnée comme un échec de correspondance et excluait donc la totalité du
     /// catalogue. Un filtre ne doit jamais cacher ce qu'il ne sait pas juger.
     func careDifficulty(locale: String = "fr") -> CareDifficulty? {
-        if let raw = translations[locale]?.care?.difficulty?.lowercased(),
-           !raw.isEmpty {
+        // La langue demandée d'abord, puis n'importe quelle autre.
+        //
+        // La difficulté est une CATÉGORIE, pas de la prose : la lire dans une
+        // autre langue reste juste, puisque la reconnaissance est multilingue.
+        // Sans ce repli, une fiche traduite en français seulement perdrait sa
+        // difficulté pour un utilisateur anglophone — la donnée existe, elle
+        // serait simplement ignorée.
+        let candidates = [translations[locale]] + translations
+            .filter { $0.key != locale }
+            .sorted { $0.key < $1.key }        // ordre stable, pas au hasard du dictionnaire
+            .map { $0.value }
+
+        if let raw = candidates
+            .compactMap({ $0?.care?.difficulty?.lowercased() })
+            .first(where: { !$0.isEmpty }) {
             // Mots-clés des quatre langues servies par le catalogue.
             let easy = ["facile", "easy", "simple", "einfach", "leicht", "fácil", "facil", "débutant"]
             let moderate = ["intermé", "medium", "modér", "mittel", "moderat", "intermedio"]

--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -21,8 +21,8 @@ struct WizardPlantFilter {
         // 2. Exposure → flags.shade/fullSun (fallback: sun.lightType)
         if !matchesExposure(plant: plant, translation: translation) { return false }
 
-        // 3. Maintenance → flags.easyCare (fallback: care.difficulty + water.frequency)
-        if !matchesMaintenance(plant: plant, translation: translation) { return false }
+        // 3. Maintenance → Plant.careDifficulty (care.difficulty, repli flags.easyCare)
+        if !matchesMaintenance(plant: plant, locale: locale) { return false }
 
         // 4. Safety → flags.toxicToPets/Children (fallback: toxic keywords)
         if !matchesSafety(plant: plant, translation: translation) { return false }
@@ -175,50 +175,27 @@ struct WizardPlantFilter {
 
     // MARK: - Maintenance Matching
 
-    private func matchesMaintenance(plant: Plant, translation: PlantTranslation) -> Bool {
+    private func matchesMaintenance(plant: Plant, locale: String) -> Bool {
         guard let maintenance = wizard.maintenance, !maintenance.isEmpty else { return true }
         let maintL = maintenance.lowercased()
 
-        // Prefer structured flags when available.
-        if let flags = plant.flags {
-            if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
-                return flags.easyCare
-            }
-            // "Exigeant" / unknown → accept all.
-            return true
+        // Résolution partagée avec le filtre du catalogue (#485) : `care.difficulty`
+        // quand il existe, repli sur `flags.easyCare` sinon.
+        //
+        // `nil` = entretien inconnu. On n'exclut pas : 26 des 124 fiches n'ont
+        // ni difficulté ni flags, et les masquer sur une donnée manquante
+        // reviendrait à affirmer qu'elles ne conviennent pas.
+        guard let actual = plant.careDifficulty(locale: locale) else { return true }
+
+        // ⚠️ « Très facile » et « Facile » donnent le même résultat tant que la
+        // source est `flags.easyCare`, qui est binaire. La distinction
+        // n'apparaîtra qu'une fois `care.difficulty` peuplé (#485).
+        if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
+            return actual == .easy
         }
 
-        let plantDifficulty = (translation.care?.difficulty ?? "").lowercased()
-        let plantWater = (translation.water?.frequency ?? "").lowercased()
-        let combined = plantDifficulty + " " + plantWater
-
-        let maint = maintenance.lowercased()
-
-        // "Très facile" → veryEasy
-        if maint.contains("très facile") || maint == "veryeasy" {
-            // Only accept very easy / easy plants
-            let isEasy = combined.contains("facile") || combined.contains("simple")
-                || combined.contains("easy") || combined.contains("débutant")
-                || combined.contains("minimal") || combined.contains("peu")
-                || combined.contains("résistant")
-            let isHard = combined.contains("exigeant") || combined.contains("difficile")
-                || combined.contains("expert") || combined.contains("hard")
-            return isEasy || !isHard
-        }
-
-        // "Facile" → easy
-        if maint.contains("facile") || maint == "easy" {
-            // Accept easy + moderate plants
-            let isHard = combined.contains("exigeant") || combined.contains("difficile")
-                || combined.contains("expert") || combined.contains("hard")
-            return !isHard
-        }
-
-        // "Exigeant" → demanding - show ALL plants, including demanding ones
-        if maint.contains("exigeant") || maint == "demanding" {
-            return true
-        }
-
+        // « Exigeant » n'exclut rien : quelqu'un prêt à s'investir accepte aussi
+        // les plantes faciles. Le critère est une capacité, pas une exigence.
         return true
     }
 

--- a/ArboreUi/ArboreUi/Views/CatalogueView.swift
+++ b/ArboreUi/ArboreUi/Views/CatalogueView.swift
@@ -39,7 +39,7 @@ struct CatalogueView: View {
             }
             .navigationBarHidden(true) // On cache la nav bar native pour utiliser la nôtre
             .sheet(isPresented: $showFilters) {
-                FilterView(filters: $filters)
+                FilterView(filters: $filters, plants: plants)
                     .environmentObject(themeManager)
             }
             .onAppear {

--- a/ArboreUi/ArboreUi/Views/FilterView.swift
+++ b/ArboreUi/ArboreUi/Views/FilterView.swift
@@ -98,10 +98,15 @@ struct FilterView: View {
     @Binding var filters: PlantFilters
     
     @State private var tempFilters: PlantFilters
-    
-    init(filters: Binding<PlantFilters>) {
+
+    /// Catalogue affiché, pour n'offrir que les niveaux d'entretien auxquels les
+    /// données peuvent répondre (#485).
+    private let plants: [Plant]
+
+    init(filters: Binding<PlantFilters>, plants: [Plant] = []) {
         self._filters = filters
         self._tempFilters = State(initialValue: filters.wrappedValue)
+        self.plants = plants
     }
     
     let lightOptions = [
@@ -116,11 +121,31 @@ struct FilterView: View {
         L10n.t("FILTER_WATER_HIGH")
     ]
     
-    let difficultyOptions = [
-        L10n.t("FILTER_DIFFICULTY_EASY"),
-        L10n.t("FILTER_DIFFICULTY_MEDIUM"),
-        L10n.t("FILTER_DIFFICULTY_HARD")
-    ]
+    /// Niveaux d'entretien réellement proposables, mesurés sur le catalogue (#485).
+    ///
+    /// Proposer un choix auquel aucune donnée ne peut répondre est pire que ne
+    /// pas le proposer : « Intermédiaire » ne renverrait ni les faciles ni les
+    /// exigeantes, mais exactement les fiches SANS donnée — un sous-ensemble
+    /// arbitraire présenté comme une réponse.
+    ///
+    /// Aujourd'hui la seule source est `flags.easyCare`, qui est binaire : le
+    /// niveau intermédiaire disparaît donc de lui-même. Il réapparaîtra sans
+    /// changement de code le jour où des fiches porteront `care.difficulty`.
+    var difficultyOptions: [String] {
+        let niveaux = Set(plants.compactMap { $0.careDifficulty(locale: locale) })
+
+        var options = [L10n.t("FILTER_DIFFICULTY_EASY")]
+        if niveaux.contains(.moderate) {
+            options.append(L10n.t("FILTER_DIFFICULTY_MEDIUM"))
+        }
+        options.append(L10n.t("FILTER_DIFFICULTY_HARD"))
+        return options
+    }
+
+    /// Langue courante, pour lire la bonne traduction des fiches.
+    private var locale: String {
+        Locale.current.language.languageCode?.identifier ?? "fr"
+    }
 
     var body: some View {
         NavigationStack {

--- a/ArboreUi/ArboreUi/Views/FilterView.swift
+++ b/ArboreUi/ArboreUi/Views/FilterView.swift
@@ -54,26 +54,39 @@ struct PlantFilters: Equatable {
             }
         }
         
-        // Filtre difficulté
+        // Filtre difficulté (#485)
+        //
+        // Ce bloc excluait AUTREFOIS toutes les plantes : il lisait
+        // `care.difficulty`, un champ que le backend ne sérialisait pas, donc
+        // toujours vide. Aucun mot-clé ne correspondait jamais, et chaque plante
+        // tombait dans un `return false`. Sélectionner une difficulté vidait la
+        // liste.
+        //
+        // La résolution est désormais partagée avec le wizard
+        // (`Plant.careDifficulty`), et surtout elle distingue « inconnu » de
+        // « ne correspond pas » : une plante dont on ignore l'entretien n'est
+        // PAS masquée. Un filtre qui cache ce qu'il ne sait pas juger ment à
+        // l'utilisateur.
         if let selectedDiff = difficulty {
-            let plantCare = translation.care?.difficulty?.lowercased() ?? ""
             let normalizedSelected = selectedDiff.lowercased()
-            
-            if normalizedSelected.contains("facile") || normalizedSelected.contains("easy") || normalizedSelected.contains("einfach") || normalizedSelected.contains("fácil") || normalizedSelected.contains("facil") {
-                if !plantCare.contains("facile") && !plantCare.contains("easy") && !plantCare.contains("simple") && !plantCare.contains("einfach") && !plantCare.contains("leicht") && !plantCare.contains("fácil") && !plantCare.contains("facil") {
-                    return false
-                }
-            } else if normalizedSelected.contains("intermé") || normalizedSelected.contains("medium") || normalizedSelected.contains("mittel") || normalizedSelected.contains("intermedio") {
-                if !plantCare.contains("intermé") && !plantCare.contains("medium") && !plantCare.contains("modér") && !plantCare.contains("mittel") && !plantCare.contains("moderat") && !plantCare.contains("intermedio") {
-                    return false
-                }
-            } else if normalizedSelected.contains("exigeant") || normalizedSelected.contains("hard") || normalizedSelected.contains("anspruchsvoll") || normalizedSelected.contains("dificil") || normalizedSelected.contains("difícil") {
-                if !plantCare.contains("exigeant") && !plantCare.contains("difficile") && !plantCare.contains("hard") && !plantCare.contains("expert") && !plantCare.contains("anspruchsvoll") && !plantCare.contains("schwer") && !plantCare.contains("dificil") && !plantCare.contains("difícil") {
-                    return false
-                }
+
+            let wanted: Plant.CareDifficulty?
+            if ["facile", "easy", "einfach", "fácil", "facil"].contains(where: normalizedSelected.contains) {
+                wanted = .easy
+            } else if ["intermé", "medium", "mittel", "intermedio"].contains(where: normalizedSelected.contains) {
+                wanted = .moderate
+            } else if ["exigeant", "hard", "anspruchsvoll", "dificil", "difícil"].contains(where: normalizedSelected.contains) {
+                wanted = .demanding
+            } else {
+                wanted = nil
             }
+
+            if let wanted = wanted, let actual = plant.careDifficulty(locale: locale) {
+                if actual != wanted { return false }
+            }
+            // `actual == nil` → donnée absente, on n'exclut pas.
         }
-        
+
         return true
     }
 }

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -139,6 +139,44 @@ final class PlantCareDifficultyTests: XCTestCase {
         XCTAssertTrue(filters.matches(plant: facile, locale: "fr"))
     }
 
+    // MARK: - Les options proposées suivent les données
+
+    /// Avec les seules données d'aujourd'hui — `flags.easyCare`, binaire —
+    /// « Intermédiaire » ne doit pas être proposé.
+    ///
+    /// Ce n'est pas cosmétique : ce choix ne renverrait ni les faciles ni les
+    /// exigeantes, mais exactement les fiches SANS donnée. Un sous-ensemble
+    /// arbitraire présenté comme une réponse.
+    func testIntermediaireNEstPasProposeSansDonneeDeDifficulte() throws {
+        let catalogue = [
+            try makePlant(easyCare: true),
+            try makePlant(easyCare: false),
+            try makePlant()                     // inconnue
+        ]
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: catalogue)
+
+        XCTAssertEqual(vue.difficultyOptions.count, 2,
+                       "Sans care.difficulty, seuls deux niveaux sont proposables")
+    }
+
+    /// Dès qu'une fiche porte un niveau intermédiaire, l'option réapparaît —
+    /// sans changement de code.
+    func testIntermediaireReapparaitQuandLaDonneeExiste() throws {
+        let catalogue = [
+            try makePlant(easyCare: true),
+            try makePlant(careDifficulty: "Intermédiaire")
+        ]
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: catalogue)
+
+        XCTAssertEqual(vue.difficultyOptions.count, 3)
+    }
+
+    /// Un catalogue vide ne doit pas faire disparaître le filtre entier.
+    func testCatalogueVideProposeQuandMemeLesNiveauxDeBase() {
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: [])
+        XCTAssertEqual(vue.difficultyOptions.count, 2)
+    }
+
     /// Sans critère sélectionné, le filtre laisse tout passer.
     func testAucunCritereNExcluRien() throws {
         let plant = try makePlant(careDifficulty: "Exigeant")

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import ArboreUi
+
+// PlantCareDifficultyTests.swift — issue #485.
+//
+// Le bug couvert ici était invisible et total : le filtre par difficulté du
+// catalogue lisait `care.difficulty`, un champ que le backend ne sérialisait
+// pas. La valeur étant toujours vide, aucun mot-clé ne correspondait jamais, et
+// CHAQUE plante tombait dans un `return false`. Sélectionner une difficulté
+// vidait la liste — mesuré sur les 124 fiches de production, dont 0 possédait
+// ce champ.
+//
+// La leçon qui structure ces tests : un filtre doit distinguer « je ne sais
+// pas » de « ne correspond pas ». Confondre les deux ne masque pas quelques
+// résultats, ça masque tout. C'est cet invariant qui est vérifié en premier.
+//
+// Les plantes sont construites par décodage JSON plutôt que par init direct :
+// c'est le chemin réel, et il couvre au passage la tolérance du modèle aux
+// champs absents.
+
+final class PlantCareDifficultyTests: XCTestCase {
+
+    // MARK: - Fabrique
+
+    /// Construit une plante depuis un fragment JSON, en complétant le minimum requis.
+    private func makePlant(careDifficulty: String? = nil,
+                           easyCare: Bool? = nil) throws -> Plant {
+        let care: String
+        if let d = careDifficulty {
+            care = #"{"difficulty": "\#(d)", "weekly": [], "monthly": [], "yearly": [], "extraTips": []}"#
+        } else {
+            care = #"{"weekly": [], "monthly": [], "yearly": [], "extraTips": []}"#
+        }
+
+        var flags = ""
+        if let easy = easyCare {
+            flags = #""flags": {"toxicToPets": false, "toxicToChildren": false, "easyCare": \#(easy), "shadeTolerant": false, "fullSunTolerant": false, "droughtTolerant": false, "humidityLoving": false, "flowering": false, "climbing": false, "trailing": false, "compact": false, "airPurifying": false},"#
+        }
+
+        let json = #"""
+        {
+            "id": "test-plant",
+            "name": "Plante de test",
+            "type": "interieur",
+            "imageURLs": [],
+            "description": "",
+            "modelURL": null,
+            \#(flags)
+            "translations": {
+                "fr": {
+                    "description": "",
+                    "plantType": "",
+                    "care": \#(care)
+                }
+            }
+        }
+        """#
+
+        return try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+    }
+
+    // MARK: - L'invariant central
+
+    /// Sans difficulté ni flags, le niveau est INCONNU — et surtout pas « exigeant ».
+    ///
+    /// C'est la régression de #485. 26 des 124 fiches sont dans ce cas ; les
+    /// traiter comme non conformes revenait à les faire disparaître.
+    func testDonneeAbsenteDonneInconnuEtNonUnNiveauParDefaut() throws {
+        let plant = try makePlant()
+        XCTAssertNil(plant.careDifficulty(),
+                     "Une plante sans donnée d'entretien doit rester inconnue, jamais classée par défaut")
+    }
+
+    /// Le filtre du catalogue ne masque pas ce qu'il ne sait pas juger.
+    func testFiltreNExclutPasUnePlanteDeDifficulteInconnue() throws {
+        let plant = try makePlant()
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertTrue(filters.matches(plant: plant, locale: "fr"),
+                      "Une difficulté inconnue ne doit pas exclure la plante — c'est le bug de #485")
+    }
+
+    // MARK: - Résolution depuis care.difficulty
+
+    func testDifficulteExpliciteEstPrioritaireSurLesFlags() throws {
+        // `easyCare: true` dit « facile », le texte dit « exigeant ».
+        // Le texte, plus précis, doit l'emporter.
+        let plant = try makePlant(careDifficulty: "Exigeant", easyCare: true)
+        XCTAssertEqual(plant.careDifficulty(), .demanding)
+    }
+
+    func testTroisNiveauxReconnusEnFrancais() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Facile").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Intermédiaire").careDifficulty(), .moderate)
+        XCTAssertEqual(try makePlant(careDifficulty: "Exigeant").careDifficulty(), .demanding)
+    }
+
+    func testNiveauxReconnusDansLesQuatreLangues() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Easy").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Einfach").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Fácil").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Anspruchsvoll").careDifficulty(), .demanding)
+    }
+
+    /// « Pas facile » contient « facile » : l'ordre d'évaluation doit protéger
+    /// contre cette lecture naïve.
+    func testExigeantEstTesteAvantFacile() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Plutôt difficile").careDifficulty(), .demanding)
+    }
+
+    // MARK: - Repli sur les flags
+
+    func testReplieSurEasyCareQuandLaDifficulteManque() throws {
+        XCTAssertEqual(try makePlant(easyCare: true).careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(easyCare: false).careDifficulty(), .demanding)
+    }
+
+    /// Le repli est binaire : il ne peut pas produire « intermédiaire ».
+    /// Ce test documente la limite plutôt que de la laisser surprendre.
+    func testLeRepliNeProduitJamaisIntermediaire() throws {
+        XCTAssertNotEqual(try makePlant(easyCare: true).careDifficulty(), .moderate)
+        XCTAssertNotEqual(try makePlant(easyCare: false).careDifficulty(), .moderate)
+    }
+
+    // MARK: - Le filtre discrimine bien quand la donnée existe
+
+    func testFiltreExclutUnNiveauQuiNeCorrespondPas() throws {
+        let exigeante = try makePlant(careDifficulty: "Exigeant")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertFalse(filters.matches(plant: exigeante, locale: "fr"),
+                       "Une plante exigeante doit être exclue d'un filtre « Facile »")
+    }
+
+    func testFiltreConserveUnNiveauQuiCorrespond() throws {
+        let facile = try makePlant(careDifficulty: "Facile")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertTrue(filters.matches(plant: facile, locale: "fr"))
+    }
+
+    /// Sans critère sélectionné, le filtre laisse tout passer.
+    func testAucunCritereNExcluRien() throws {
+        let plant = try makePlant(careDifficulty: "Exigeant")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: nil)
+
+        XCTAssertTrue(filters.matches(plant: plant, locale: "fr"))
+    }
+}


### PR DESCRIPTION
Corrige le symptôme rapporté dans #485.

## Le bug

Sélectionner une difficulté dans le catalogue ne renvoyait **aucune plante**.

`care.difficulty` n'existait pas dans le modèle Go — donc jamais sérialisé, donc
toujours `nil` côté app. Mesuré sur les données de production : **0 fiche sur
124** possédait ce champ.

`FilterView` le lisait quand même, et traitait l'absence comme une
non-conformité :

```swift
let plantCare = translation.care?.difficulty?.lowercased() ?? ""   // toujours ""
if !plantCare.contains("facile") && … { return false }             // exclut
```

Aucun mot-clé ne correspondant jamais, **chaque plante tombait dans le
`return false`**. Le filtre ne ratait pas quelques plantes : il les éliminait
toutes.

## Correction

| | |
|---|---|
| `ArboreBackend` | `CareInfo.Difficulty`, pour que la donnée puisse circuler |
| `Plant.swift` | `careDifficulty(locale:)` — `care.difficulty`, repli `flags.easyCare`, **`nil` si inconnu** |
| `FilterView` | utilise la résolution partagée, et **n'exclut pas sur donnée absente** |
| `WizardPlantFilter` | même résolution, comportement inchangé mais exprimé une seule fois |

**La distinction entre « inconnu » et « ne correspond pas » est tout le
correctif.** Confondre les deux ne masque pas quelques résultats, ça masque
tout — un filtre ne doit jamais cacher ce qu'il ne sait pas juger.

## Ce que ça ne fait pas

Ajouter le champ ne le peuple pas. Les 124 fiches le laissent vide et le filtre
s'appuie donc encore sur `flags.easyCare`, avec deux limites **documentées dans
le code** plutôt que laissées à découvrir :

- 26 fiches sans flags restent de difficulté inconnue, donc jamais exclues ;
- « Très facile » et « Facile » donnent le même résultat, le repli étant binaire.

Le peuplement des fiches reste le travail identifié par #485, et c'est lui qui
rendra le niveau « intermédiaire » utilisable.

## Tests

**Aucun test ne couvrait ces filtres** — c'est pourquoi un bug aussi total est
passé. `PlantCareDifficultyTests` en ajoute onze, dont le premier garde
l'invariant qui a lâché : une donnée absente ne doit pas exclure.

```
11 tests               passés sur simulateur
build iOS              SUCCEEDED
go vet + go test       2 paquets, verts
```

Refs #485


---

## Suite : les données ne permettent pas trois niveaux

Mesure sur les 124 fiches de production, faite après l'ouverture de cette PR :

```
easyCare=true    76 fiches   tâches d'entretien  6 / 7.9 / 9
easyCare=false   22 fiches   tâches d'entretien  6 / 8.4 / 10
sans flags       26 fiches
```

**Le nombre de tâches ne discrimine rien** — les plages se recouvrent presque
entièrement. Et `water.frequency` est de la prose libre, 124 chaînes distinctes.
Seul `flags.easyCare` porte un signal, et il est **binaire**.

Or l'UI proposait trois niveaux. Sélectionner « Intermédiaire » ne renvoyait ni
les faciles ni les exigeantes : **exactement les 26 fiches sans donnée**.

### Correction ajoutée

`difficultyOptions` est désormais dérivé du catalogue affiché. Le niveau
intermédiaire n'apparaît que si une fiche le porte réellement — il disparaît
donc aujourd'hui, et réapparaîtra **sans changement de code** quand
`care.difficulty` sera peuplé.

### Un défaut trouvé par les tests

`careDifficulty` ne lisait que la langue demandée : une fiche traduite en
français seulement perdait sa difficulté pour un utilisateur anglophone. La
difficulté étant une catégorie et non de la prose, un repli inter-langues a été
ajouté.

```
14 tests   tous verts
build iOS  SUCCEEDED
```
