### PR TITLE
chore(ios): figer la forme qu'Xcode réécrit à chaque ouverture

### DIFF
--- a/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
+++ b/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
@@ -79,8 +79,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		774C3B512ED1FFB100324E07 /* scanRoom */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = scanRoom;
 			sourceTree = "<group>";
 		};
@@ -94,15 +92,11 @@
 		};
 		77DD7AF02D84270800A6F6F1 /* ArboreUiTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ArboreUiTests;
 			sourceTree = "<group>";
 		};
 		77DD7AFA2D84270800A6F6F1 /* ArboreUiUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ArboreUiUITests;
 			sourceTree = "<group>";
 		};

--- a/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi Dev.xcscheme
+++ b/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi Dev.xcscheme
@@ -41,8 +41,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "77DD7AF62D84270800A6F6F1"

--- a/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
+++ b/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
@@ -41,8 +41,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "77DD7AF62D84270800A6F6F1"


### PR DESCRIPTION
## Le bruit

Ouvrir le projet dans Xcode salissait l'arbre de travail à chaque fois :

```
project.pbxproj        3 blocs `exceptions = ()` vides retirés
ArboreUi.xcscheme      `parallelizable = "NO"` retiré
ArboreUi Dev.xcscheme  idem
```

## Pourquoi c'est sans portée

Les blocs `exceptions` sont **vides**. Et `parallelizable = "NO"` est la valeur
**par défaut** d'un `TestableReference` — Xcode omet les attributs à leur
défaut, donc `ArboreUiUITests` reste exécuté séquentiellement. Vérifié : ce sont
les dix seules lignes du diff.

Committer la forme normalisée retire simplement à Xcode ce qu'il avait à
réécrire.

## Pourquoi pas un `.gitignore`

La question s'est posée en revue, et ce serait une erreur. `project.pbxproj` et
les schémas partagés **sont** le projet : les ignorer casserait le build pour
tout le monde et ferait disparaître les schémas `ArboreUi` et `ArboreUi Dev`.

Ce sont des fichiers essentiels qui subissent du bruit, pas des fichiers de
bruit. La distinction décide du remède.

## Pourquoi ça mérite une PR

Un `git status` qui affiche en permanence des modifications qu'on n'a pas faites
est un `git status` qu'on cesse de lire. C'est arrivé deux fois cette semaine :
la modification a failli partir dans une PR sans rapport (#470), puis a bloqué
un rebase (#478).

Même motif que #471 pour `web/tsconfig.json`.
