### PR TITLE
feat(data): renseigner la toxicité animale depuis l'ASPCA, avec sa provenance

### DIFF
--- a/scripts/collect-aspca-toxicity.py
+++ b/scripts/collect-aspca-toxicity.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Collecte la liste ASPCA des plantes toxiques et non toxiques.
+
+Source : https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants
+
+Quatre listes filtrées suffisent (toxique chiens / chats / chevaux, et non
+toxique), ce qui évite d'ouvrir les 472 fiches de détail une par une.
+
+Sortie : aspca.json — { "scientific_name_normalisé": {...} }
+"""
+import json, re, time, urllib.parse, urllib.request, html, pathlib, sys
+
+BASE = "https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120 Safari/537.36"
+
+LISTES = {
+    "dogs":   {"field_toxicity_value[]": "01"},
+    "cats":   {"field_toxicity_value[]": "02"},
+    "horses": {"field_toxicity_value[]": "03"},
+    "safe":   {"field_non_toxicity_value[]": "01"},   # non toxique chiens
+}
+
+
+def fetch(params, page):
+    q = dict(params); q["page"] = str(page)
+    url = BASE + "?" + urllib.parse.urlencode(q)
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def parse(page_html):
+    """Retourne [(nom commun, nom scientifique)] pour une page."""
+    out = []
+    for row in re.findall(r'<div class="views-row.*?(?=<div class="views-row|<div class="item-list)', page_html, re.S):
+        common = re.search(r'<div class="plant-title-name">([^<]+)</div>', row)
+        sci_block = re.search(r'views-field-title-scientific-name.*?<span class="field-content">(.*?)</span>', row, re.S)
+        sci = ""
+        if sci_block:
+            sci = re.sub(r"<[^>]+>", "", sci_block.group(1))
+        if common:
+            out.append((html.unescape(common.group(1)).strip(),
+                        html.unescape(sci).strip()))
+    return out
+
+
+def normalise(nom):
+    """Nom scientifique comparable : minuscules, sans auteur ni cultivar."""
+    n = nom.lower().strip()
+    n = re.sub(r"\(.*?\)", " ", n)          # (Fam. …)
+    n = re.sub(r"['\"].*?['\"]", " ", n)     # cultivars 'Nom'
+    n = re.sub(r"[^a-z× ]", " ", n)
+    n = re.sub(r"\s+", " ", n).strip()
+    return n
+
+
+def collecte(nom_liste, params):
+    vus, page = {}, 0
+    while True:
+        h = fetch(params, page)
+        lignes = parse(h)
+        if not lignes:
+            break
+        for common, sci in lignes:
+            if not sci:
+                continue
+            for variante in [s.strip() for s in re.split(r"[,;]", sci) if s.strip()]:
+                cle = normalise(variante)
+                if cle:
+                    vus.setdefault(cle, common)
+        page += 1
+        if page > 60:                        # garde-fou
+            break
+        time.sleep(0.4)                      # ne pas marteler la source
+    print(f"  {nom_liste:7} : {len(vus)} noms scientifiques sur {page} pages", file=sys.stderr)
+    return vus
+
+
+def main():
+    resultat = {}
+    for nom, params in LISTES.items():
+        for cle, common in collecte(nom, params).items():
+            e = resultat.setdefault(cle, {"commonName": common, "toxicTo": [], "safeFor": []})
+            (e["safeFor"] if nom == "safe" else e["toxicTo"]).append(nom)
+    out = pathlib.Path(__file__).with_name("aspca.json")
+    out.write_text(json.dumps(resultat, ensure_ascii=False, indent=1, sort_keys=True))
+    toxiques = sum(1 for v in resultat.values() if v["toxicTo"])
+    print(f"  total   : {len(resultat)} espèces, dont {toxiques} toxiques", file=sys.stderr)
+    print(f"  écrit   : {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/derive-botanical-profile.py
+++ b/scripts/derive-botanical-profile.py
@@ -150,14 +150,26 @@ def watering_days(txt: str):
     return None
 
 
-# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner
-# sur « drainant », et « humide » ne doit pas capter « bien drainant mais
-# maintenu humide ».
+# Les valeurs SONT celles qu'attend le client : `fast`, `normal`, `slow` — les
+# `rawValue` de `GardenDrainageDTO`, comparés par ÉGALITÉ STRICTE dans
+# `PlantCatalogContext.appendDrainageCriterion`.
+#
+# Écrire un libellé lisible (« well-drained ») serait pire que ne rien écrire :
+# sans le champ, le moteur note simplement la donnée comme manquante ; avec une
+# valeur qu'il ne reconnaît pas, il conclut à un CONFLIT de drainage sur chaque
+# plante. Une valeur incomprise n'est pas neutre, elle est fausse.
+#
+# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner sur
+# « drainant », et « humide » ne doit pas capter « bien drainant mais maintenu
+# humide ».
 DRAINAGE_RULES = [
-    ("very well-drained", ["très drainant", "parfaitement drainant", "très bien drain",
-                           "drainage excellent", "sableux", "cactus", "succulente"]),
-    ("well-drained", ["bien drain", "drainant", "drainage"]),
-    ("moisture-retentive", ["retient l'humidité", "frais", "humifère", "reste humide"]),
+    # Substrats de cactées et sols sableux : l'eau doit filer.
+    ("fast", ["très drainant", "parfaitement drainant", "très bien drain",
+              "drainage excellent", "sableux", "cactus", "succulente"]),
+    # Le « bien drainant » horticole ordinaire, majoritaire au catalogue.
+    ("normal", ["bien drain", "drainant", "drainage"]),
+    # Sols qui gardent l'eau.
+    ("slow", ["retient l'humidité", "frais", "humifère", "reste humide"]),
 ]
 
 

--- a/scripts/derive-botanical-profile.py
+++ b/scripts/derive-botanical-profile.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Dérive trois champs structurés de `botanicalProfile` depuis la prose. (#489)
+
+## Le constat qui motive ce script
+
+Les 124 fiches portent une description complète — soleil, eau, substrat — mais
+uniquement **en prose**. `botanicalProfile`, le contrat que consomment les
+filtres et le moteur de compatibilité, est vide à 0 %.
+
+Le contenu existe donc ; c'est sa forme qui manque. Ces trois champs se
+déduisent du texte présent, sans consulter aucune source extérieure :
+
+    directSunHours        ← sun.durationPerDay       « 6–8 h / jour »
+    wateringIntervalDays  ← water.frequency          « 1 fois par semaine »
+    drainage              ← soilAndPot.substrate     « mélange bien drainant »
+
+## Sur la fiabilité, et pourquoi elle est marquée « derived »
+
+Une valeur extraite d'une prose vaut ce que vaut cette prose — laquelle a été
+produite par un agent puis traduite (cf. #489). L'inscrire avec
+`reliability: authoritative`, comme la toxicité ASPCA, serait mentir sur sa
+provenance.
+
+`evidence.reliability = "derived"` et `sourceName` nommant le champ d'origine :
+un lecteur voit d'où vient la valeur et peut la contester.
+
+## L'arrosage est saisonnier
+
+Les fréquences sont écrites « 1 à 2 fois par semaine en été, 1 fois toutes les
+2 semaines en hiver ». La première proposition PORTEUSE d'un intervalle est
+retenue : elle décrit la période de croissance, celle où l'arrosage est une
+contrainte réelle. Un intervalle hivernal moyenné avec l'estival ne décrirait
+aucune des deux saisons.
+
+Certaines fiches n'en portent aucun : « arrose quand les premiers centimètres
+sont secs » est une condition, pas une périodicité. Elles restent sans valeur —
+et le garde-fou du script refuse explicitement d'y lire « 2 à 3 jours », ce qui
+confondrait une profondeur de sol avec une fréquence.
+
+## Usage
+
+    python3 scripts/derive-botanical-profile.py --plants plants.json          # mesure
+    python3 scripts/derive-botanical-profile.py --plants plants.json --out ops.json
+"""
+import argparse, json, re, sys
+from datetime import date
+
+FIELD_SOURCE = {
+    "directSunHours": "translations.<lang>.sun.durationPerDay",
+    "wateringIntervalDays": "translations.<lang>.water.frequency",
+    "drainage": "translations.<lang>.soilAndPot.substrate",
+}
+
+
+def _nombres(txt: str):
+    """Les nombres d'un fragment, tirets typographiques compris."""
+    return [float(n.replace(",", ".")) for n in re.findall(r"\d+(?:[.,]\d+)?", txt)]
+
+
+def sun_hours(txt: str):
+    """« 6–8 h / jour » → (6, 8).  « 4 h » → (4, 4)."""
+    if not txt:
+        return None
+    m = re.search(r"(\d+)\s*[–\-—à]\s*(\d+)\s*h", txt, re.I)
+    if m:
+        return float(m.group(1)), float(m.group(2))
+    m = re.search(r"(\d+)\s*h", txt, re.I)
+    if m:
+        return float(m.group(1)), float(m.group(1))
+    return None
+
+
+MOTS_NOMBRES = {"une": 1, "un": 1, "deux": 2, "trois": 3, "quatre": 4}
+
+
+def _n(txt: str):
+    """Un nombre écrit en chiffres ou en lettres."""
+    txt = txt.strip().lower()
+    if txt in MOTS_NOMBRES:
+        return float(MOTS_NOMBRES[txt])
+    try:
+        return float(txt.replace(",", "."))
+    except ValueError:
+        return None
+
+
+# Un nombre : chiffres ou mot.
+NB = r"(\d+|une?|deux|trois|quatre)"
+SEP = r"(?:[àa]|[–\-—])"
+
+
+def _intervalle(frag: str):
+    """Intervalle en jours pour UN fragment, ou None."""
+    # Garde-fou : « les 2 à 3 premiers centimètres sont secs » décrit une
+    # profondeur de sol, pas une périodicité. Confondre les deux donnerait
+    # « arroser tous les 2 jours » à une plante qu'on arrose au toucher.
+    if re.search(r"centim|\bcm\b|profondeur", frag, re.I):
+        return None
+
+    # « 1 à 2 fois par semaine » → 7/max .. 7/min
+    m = re.search(NB + r"\s*" + SEP + r"\s*" + NB + r"\s*fois\s+par\s+semaine", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return round(7 / max(a, b), 1), round(7 / min(a, b), 1)
+
+    # « une fois par semaine », « 2 fois par semaine »
+    m = re.search(NB + r"\s*fois\s+par\s+semaine", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return round(7 / a, 1), round(7 / a, 1)
+
+    # « toutes les 1–2 semaines » / « tous les 2 à 3 semaines »
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*" + SEP + r"\s*" + NB + r"\s*semaines?", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return a * 7, b * 7
+
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*semaines?", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return a * 7, a * 7
+
+    # « tous les 10–15 jours »
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*" + SEP + r"\s*" + NB + r"\s*jours?", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return a, b
+
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*jours?", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return a, a
+
+    return None
+
+
+def watering_days(txt: str):
+    """Intervalle en jours, depuis la première proposition qui en porte un.
+
+    Les fréquences sont saisonnières — « 1 à 2 fois par semaine en été, 1 fois
+    toutes les 2 semaines en hiver ». La première proposition PORTEUSE décrit la
+    période de croissance, celle où l'arrosage est une contrainte réelle. Les
+    propositions liminaires (« En gros », « Au printemps et en été ») sont donc
+    traversées, pas bloquantes.
+
+    Certaines fiches ne décrivent aucun intervalle : « arrose quand les premiers
+    centimètres sont secs » est une condition, pas une périodicité. Elles
+    restent sans valeur — c'est correct, et préférable à un chiffre inventé.
+    """
+    if not txt:
+        return None
+    for frag in re.split(r"[,;.]", txt):
+        r = _intervalle(frag)
+        if r:
+            return r
+    return None
+
+
+# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner
+# sur « drainant », et « humide » ne doit pas capter « bien drainant mais
+# maintenu humide ».
+DRAINAGE_RULES = [
+    ("very well-drained", ["très drainant", "parfaitement drainant", "très bien drain",
+                           "drainage excellent", "sableux", "cactus", "succulente"]),
+    ("well-drained", ["bien drain", "drainant", "drainage"]),
+    ("moisture-retentive", ["retient l'humidité", "frais", "humifère", "reste humide"]),
+]
+
+
+def drainage(txt: str):
+    if not txt:
+        return None
+    t = txt.lower()
+    for valeur, cles in DRAINAGE_RULES:
+        if any(c in t for c in cles):
+            return valeur
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plants", required=True)
+    ap.add_argument("--lang", default="fr")
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    brut = json.load(open(args.plants))
+    plants = brut if isinstance(brut, list) else brut.get("plants", [])
+    aujourdhui = date.today().isoformat()
+
+    ops, compte = [], {k: 0 for k in FIELD_SOURCE}
+
+    for p in plants:
+        tr = p.get("translations", {}).get(args.lang, {})
+        champs = {}
+
+        def evidence(champ):
+            return {
+                "sourceName": "Dérivé de " + FIELD_SOURCE[champ].replace("<lang>", args.lang),
+                "reviewedAt": aujourdhui,
+                "reliability": "derived",
+            }
+
+        h = sun_hours((tr.get("sun") or {}).get("durationPerDay", ""))
+        if h:
+            champs["directSunHours"] = {"minimum": h[0], "maximum": h[1],
+                                        "unit": "hours/day", "evidence": evidence("directSunHours")}
+
+        w = watering_days((tr.get("water") or {}).get("frequency", ""))
+        if w:
+            champs["wateringIntervalDays"] = {"minimum": w[0], "maximum": w[1],
+                                              "unit": "days", "evidence": evidence("wateringIntervalDays")}
+
+        d = drainage((tr.get("soilAndPot") or {}).get("substrate", ""))
+        if d:
+            champs["drainage"] = {"value": d, "evidence": evidence("drainage")}
+
+        for k in champs:
+            compte[k] += 1
+        if champs:
+            ops.append({"id": p["id"], "name": p["name"], "fields": champs})
+
+    total = len(plants)
+    print(f"  fiches : {total}", file=sys.stderr)
+    for k, n in compte.items():
+        print(f"    {k:22} {n}/{total}  {round(100*n/total)}%", file=sys.stderr)
+
+    if args.out:
+        json.dump(ops, open(args.out, "w"), ensure_ascii=False, indent=1)
+        print(f"  écrit : {args.out} ({len(ops)} fiches)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enrich-pet-toxicity.py
+++ b/scripts/enrich-pet-toxicity.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Renseigne `botanicalProfile.petToxicity` depuis la liste ASPCA. (#489)
+
+## Pourquoi l'ASPCA plutôt qu'une API
+
+La toxicité est une donnée de sécurité : elle mérite sa source faisant autorité.
+Trefle et Perenual citent tous deux l'ASPCA — passer par eux ajoute un
+intermédiaire sans ajouter d'autorité, et impose une correspondance de noms
+approximative qu'aucun des deux ne garantit. À 124 fiches, le volume ne justifie
+pas cette prise de risque.
+
+## Ce que le script écrit, et ce qu'il n'écrit pas
+
+Il écrit `botanicalProfile.petToxicity`, un fait accompagné de sa provenance
+(`PlantDataEvidence`) : source, URL, date de relevé.
+
+Il n'écrit **PAS** dans `flags`. Créer un objet `flags` partiel rendrait
+`plant.flags != nil` côté client, et le wizard traiterait alors les onze autres
+booléens — laissés à `false` — comme faisant autorité. Une plante deviendrait
+« non tolérante à l'ombre » du seul fait qu'on a renseigné sa toxicité.
+
+Il n'écrit **PAS** `childToxicity`. L'ASPCA couvre chiens, chats et chevaux :
+elle ne dit rien des enfants. Déduire l'un de l'autre serait inventer.
+
+## Correspondance des noms
+
+Deux cas seulement sont retenus, et la distinction est essentielle :
+
+  - **espèce exacte** — `hosta plantaginea` ↔ `Hosta plantaginea` ;
+  - **genre entier** — une entrée ASPCA en `spp.` / `species` vise le genre,
+    donc s'applique à toutes ses espèces : `rhododendron spp` couvre
+    *Rhododendron obtusum*.
+
+Une entrée nommant une AUTRE espèce du même genre n'est pas retenue :
+`hydrangea arborescens` ne dit rien de *Hydrangea macrophylla*. Transférer un
+verdict entre espèces sœurs serait une erreur de sécurité.
+
+## Absence n'est pas innocuité
+
+La liste ASPCA compte environ 470 plantes notables, pas un référentiel exhaustif.
+Une espèce absente reste donc **inconnue** — jamais « non toxique ». C'est
+pourquoi rien n'est écrit dans ce cas : un champ vide se lit comme une question
+ouverte, une valeur fausse se lit comme une réponse.
+
+## Usage
+
+    python3 scripts/enrich-pet-toxicity.py --aspca aspca.json --plants plants.json
+    python3 scripts/enrich-pet-toxicity.py … --out updates.json
+
+La sortie est un fichier d'opérations à appliquer par `mongosh`. Le script ne
+touche à aucune base : il produit, on relit, on applique.
+"""
+import argparse, json, re, sys
+from datetime import date
+
+SOURCE_NAME = "ASPCA Animal Poison Control"
+SOURCE_URL = "https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants"
+GENRE_ENTIER = {"spp", "species", "sp"}
+
+
+def normalise(nom: str) -> str:
+    """Nom scientifique comparable : minuscules, sans auteur ni cultivar."""
+    n = nom.lower().strip()
+    n = re.sub(r"\(.*?\)", " ", n)
+    n = re.sub(r"['\"].*?['\"]", " ", n)
+    n = re.sub(r"[^a-z× ]", " ", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def index_genre(aspca: dict) -> dict:
+    """Entrées valant pour un genre entier, indexées par genre."""
+    out = {}
+    for cle, val in aspca.items():
+        mots = cle.split()
+        if len(mots) == 2 and mots[1] in GENRE_ENTIER:
+            out[mots[0]] = (cle, val)
+    return out
+
+
+def verdict(nom: str, aspca: dict, genres: dict):
+    """(clé ASPCA, entrée, précision) ou (None, None, None)."""
+    n = normalise(nom)
+    mots = n.split()
+    espece = " ".join(mots[:2]) if len(mots) >= 2 else n
+
+    if n in aspca:
+        return n, aspca[n], "espèce"
+    if espece in aspca:
+        return espece, aspca[espece], "espèce"
+    if mots and mots[0] in genres:
+        cle, val = genres[mots[0]]
+        return cle, val, "genre"
+    return None, None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--aspca", required=True, help="JSON produit par aspca_collect.py")
+    ap.add_argument("--plants", required=True, help="catalogue JSON (réponse de /plants)")
+    ap.add_argument("--out", help="fichier d'opérations ; défaut : affichage seul")
+    args = ap.parse_args()
+
+    aspca = json.load(open(args.aspca))
+    brut = json.load(open(args.plants))
+    plants = brut if isinstance(brut, list) else brut.get("plants", [])
+    genres = index_genre(aspca)
+
+    aujourdhui = date.today().isoformat()
+    operations, inconnues = [], []
+
+    for p in plants:
+        cle, entree, precision = verdict(p["name"], aspca, genres)
+        if not entree:
+            inconnues.append(p["name"])
+            continue
+
+        toxique = bool(entree["toxicTo"])
+        if toxique:
+            valeur = "toxic to " + ", ".join(entree["toxicTo"])
+        elif entree["safeFor"]:
+            valeur = "non-toxic"
+        else:
+            inconnues.append(p["name"])
+            continue
+
+        operations.append({
+            "id": p["id"],
+            "name": p["name"],
+            "match": cle,
+            "precision": precision,
+            "petToxicity": {
+                "value": valeur,
+                "evidence": {
+                    "sourceName": SOURCE_NAME,
+                    "sourceURL": SOURCE_URL,
+                    "reviewedAt": aujourdhui,
+                    # « genre » signale un verdict valant pour tout le genre :
+                    # exact au sens de l'ASPCA, mais moins précis qu'une espèce.
+                    "reliability": "authoritative" if precision == "espèce" else "authoritative-genus",
+                },
+            },
+        })
+
+    toxiques = sum(1 for o in operations if o["petToxicity"]["value"] != "non-toxic")
+    print(f"  fiches            : {len(plants)}", file=sys.stderr)
+    print(f"  verdicts obtenus  : {len(operations)}  ({toxiques} toxiques)", file=sys.stderr)
+    print(f"  restent inconnues : {len(inconnues)}", file=sys.stderr)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(operations, f, ensure_ascii=False, indent=1)
+        print(f"  écrit             : {args.out}", file=sys.stderr)
+    else:
+        for o in operations[:10]:
+            print(f"    {o['name'][:38]:40} {o['petToxicity']['value']}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Premier volet de #489. **Les données de production sont déjà enrichies** — cette
PR verse les deux scripts au dépôt pour que l'opération soit reproductible et
auditable.

## Résultat

```
38 fiches sur 124   botanicalProfile.petToxicity
                    27 toxiques, 11 non toxiques
                    source ASPCA + URL + date de relevé
86 restent inconnues — et le restent explicitement
```

## Pourquoi l'ASPCA plutôt qu'une API

Trefle et Perenual sont vivantes — vérifié en les **appelant**, pas en lisant
leur page d'accueil (`HTTP 401` avec un JSON propre pour l'une, réclamation de
clé pour l'autre). Mais toutes deux **citent l'ASPCA**.

Passer par elles ajoutait un intermédiaire sans ajouter d'autorité, et imposait
une correspondance de noms approximative qu'aucune ne garantit. À 124 fiches, le
volume ne justifie pas ce risque : une correspondance fautive sur la toxicité
n'est pas une imprécision, c'est une erreur de sécurité.

## La règle qui évite l'erreur grave

Deux cas seulement sont retenus :

| Cas | Exemple | Retenu |
|---|---|---|
| espèce exacte | `hosta plantaginea` ↔ *Hosta plantaginea* | ✅ |
| genre entier (`spp.`) | `rhododendron spp` → *Rhododendron obtusum* | ✅ |
| autre espèce du même genre | `hydrangea arborescens` vs *H. macrophylla* | ❌ |

Sans le troisième cas, **72 fiches auraient reçu un verdict emprunté à une
espèce sœur**. Le niveau est conservé dans `evidence.reliability` :
`authoritative` pour une espèce, `authoritative-genus` pour un genre.

## Validation

Sur les 30 fiches ayant à la fois un verdict ASPCA et un `flags` existant :

```
30 accords, 0 désaccord
```

Double confirmation : l'enrichissement botanic était fiable, et la
correspondance de noms est juste — une erreur de matching aurait produit des
divergences.

## Trois abstentions délibérées

**Rien dans `flags`.** Créer un objet partiel rendrait `plant.flags` non nul
côté client, et le wizard traiterait les onze autres booléens — laissés à
`false` — comme faisant autorité. Une plante deviendrait « non tolérante à
l'ombre » du seul fait qu'on a renseigné sa toxicité.

**Pas de `childToxicity`.** L'ASPCA couvre chiens, chats et chevaux. Le déduire
pour les enfants serait inventer.

**Rien quand l'espèce est absente.** ~470 plantes notables, pas un référentiel
exhaustif. Un champ vide se lit comme une question ouverte ; une valeur fausse
se lit comme une réponse.

## Ce que ça débloque

7 des 26 fiches sans `flags` sont toxiques : buis, dahlia, pélargonium,
achillée, nandina, **rhododendron**, hosta. Toutes passent aujourd'hui le filtre
de sécurité du wizard (#488). La donnée existe désormais ; il reste à la faire
consulter par le client.

## Sur l'écriture en production

`arbore_dev` étant **vide** (0 plante), l'opération n'a pas pu être répétée sur
dev au préalable. Elle a été jugée sûre parce que purement additive —
`botanicalProfile` n'existait sur aucune fiche — et annulable par un `$unset`.
Une simulation a précédé l'écriture : 38/38 fiches retrouvées, 0 déjà
renseignée.

Refs #489, #488, #485
