### PR TITLE
fix(ios,data): filtre par difficulté, et enrichissement botanique du catalogue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
         - correspondant
         - continuent
         - infiniment
+        - existantes
 
     revive:
       confidence: 0.8

--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -237,10 +237,23 @@ type LifeCycleInfo struct {
 }
 
 type CareInfo struct {
-	Weekly    []string `json:"weekly" bson:"weekly"`
-	Monthly   []string `json:"monthly" bson:"monthly"`
-	Yearly    []string `json:"yearly" bson:"yearly"`
-	ExtraTips []string `json:"extraTips" bson:"extraTips"`
+	// Difficulty : niveau d'entretien affiché et filtrable (« Facile »,
+	// « Intermédiaire », « Exigeant »). `omitempty` : la fiche reste valide sans.
+	//
+	// Le modèle iOS déclarait ce champ depuis l'origine, mais il était absent
+	// ICI — donc jamais sérialisé, donc toujours nil côté app. Les deux filtres
+	// qui le lisaient s'en trouvaient neutralisés, et celui du catalogue vidait
+	// même la liste : un critère absent n'excluait pas « rien », il excluait
+	// TOUT (#485).
+	//
+	// Ajouter le champ ne le peuple pas : les 124 fiches existantes le laissent
+	// vide. C'est le repli sur `flags.easyCare` côté client qui fait tenir le
+	// filtre en attendant.
+	Difficulty string   `json:"difficulty,omitempty" bson:"difficulty,omitempty"`
+	Weekly     []string `json:"weekly" bson:"weekly"`
+	Monthly    []string `json:"monthly" bson:"monthly"`
+	Yearly     []string `json:"yearly" bson:"yearly"`
+	ExtraTips  []string `json:"extraTips" bson:"extraTips"`
 }
 
 type LanguageData struct {

--- a/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
+++ b/ArboreUi/ArboreUi.xcodeproj/project.pbxproj
@@ -79,8 +79,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		774C3B512ED1FFB100324E07 /* scanRoom */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = scanRoom;
 			sourceTree = "<group>";
 		};
@@ -94,15 +92,11 @@
 		};
 		77DD7AF02D84270800A6F6F1 /* ArboreUiTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ArboreUiTests;
 			sourceTree = "<group>";
 		};
 		77DD7AFA2D84270800A6F6F1 /* ArboreUiUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ArboreUiUITests;
 			sourceTree = "<group>";
 		};

--- a/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi Dev.xcscheme
+++ b/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi Dev.xcscheme
@@ -41,8 +41,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "77DD7AF62D84270800A6F6F1"

--- a/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
+++ b/ArboreUi/ArboreUi.xcodeproj/xcshareddata/xcschemes/ArboreUi.xcscheme
@@ -41,8 +41,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "77DD7AF62D84270800A6F6F1"

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -355,3 +355,50 @@ fileprivate struct PlantFallback {
             ])))
     }
 }
+
+// MARK: - Niveau d'entretien (#485)
+
+extension Plant {
+
+    /// Niveau d'entretien d'une plante, tel qu'un filtre peut l'exploiter.
+    enum CareDifficulty {
+        case easy
+        case moderate
+        case demanding
+    }
+
+    /// Résout le niveau d'entretien, ou `nil` si la donnée est absente.
+    ///
+    /// Deux sources, dans cet ordre :
+    ///
+    /// 1. `care.difficulty`, qui porte les trois niveaux. Le backend ne le
+    ///    sérialisait pas jusqu'à #485 et aucune fiche ne le renseigne encore.
+    /// 2. `flags.easyCare`, présent sur 98 des 124 fiches. Binaire, donc
+    ///    incapable de distinguer « intermédiaire » — d'où le repli, pas le
+    ///    remplacement.
+    ///
+    /// **`nil` signifie « inconnu », pas « ne correspond pas ».** La distinction
+    /// est tout l'objet de #485 : le filtre du catalogue traitait l'absence de
+    /// donnée comme un échec de correspondance et excluait donc la totalité du
+    /// catalogue. Un filtre ne doit jamais cacher ce qu'il ne sait pas juger.
+    func careDifficulty(locale: String = "fr") -> CareDifficulty? {
+        if let raw = translations[locale]?.care?.difficulty?.lowercased(),
+           !raw.isEmpty {
+            // Mots-clés des quatre langues servies par le catalogue.
+            let easy = ["facile", "easy", "simple", "einfach", "leicht", "fácil", "facil", "débutant"]
+            let moderate = ["intermé", "medium", "modér", "mittel", "moderat", "intermedio"]
+            let demanding = ["exigeant", "difficile", "hard", "expert", "anspruchsvoll", "schwer", "dificil", "difícil"]
+
+            // « Exigeant » d'abord : « pas facile » contient « facile ».
+            if demanding.contains(where: raw.contains) { return .demanding }
+            if moderate.contains(where: raw.contains) { return .moderate }
+            if easy.contains(where: raw.contains) { return .easy }
+        }
+
+        if let flags = flags {
+            return flags.easyCare ? .easy : .demanding
+        }
+
+        return nil
+    }
+}

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -382,8 +382,21 @@ extension Plant {
     /// donnée comme un échec de correspondance et excluait donc la totalité du
     /// catalogue. Un filtre ne doit jamais cacher ce qu'il ne sait pas juger.
     func careDifficulty(locale: String = "fr") -> CareDifficulty? {
-        if let raw = translations[locale]?.care?.difficulty?.lowercased(),
-           !raw.isEmpty {
+        // La langue demandée d'abord, puis n'importe quelle autre.
+        //
+        // La difficulté est une CATÉGORIE, pas de la prose : la lire dans une
+        // autre langue reste juste, puisque la reconnaissance est multilingue.
+        // Sans ce repli, une fiche traduite en français seulement perdrait sa
+        // difficulté pour un utilisateur anglophone — la donnée existe, elle
+        // serait simplement ignorée.
+        let candidates = [translations[locale]] + translations
+            .filter { $0.key != locale }
+            .sorted { $0.key < $1.key }        // ordre stable, pas au hasard du dictionnaire
+            .map { $0.value }
+
+        if let raw = candidates
+            .compactMap({ $0?.care?.difficulty?.lowercased() })
+            .first(where: { !$0.isEmpty }) {
             // Mots-clés des quatre langues servies par le catalogue.
             let easy = ["facile", "easy", "simple", "einfach", "leicht", "fácil", "facil", "débutant"]
             let moderate = ["intermé", "medium", "modér", "mittel", "moderat", "intermedio"]

--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -415,3 +415,72 @@ extension Plant {
         return nil
     }
 }
+
+// MARK: - Toxicité (#488)
+
+extension Plant {
+
+    /// Verdict de toxicité pour un public donné.
+    enum ToxicityVerdict {
+        case toxic
+        case safe
+    }
+
+    /// Toxicité pour les animaux, ou `nil` si elle n'est pas établie.
+    ///
+    /// Deux sources, dans cet ordre :
+    ///
+    /// 1. `botanicalProfile.petToxicity` — faisant autorité, avec sa provenance.
+    ///    Renseignée depuis l'ASPCA sur 38 fiches (#489).
+    /// 2. `flags.toxicToPets` — issue de l'enrichissement botanique, présente
+    ///    sur 98 fiches. Confrontée à l'ASPCA sur les 30 fiches couvertes par
+    ///    les deux : **30 accords, 0 désaccord**. C'est ce contrôle qui autorise
+    ///    à lire son `false` comme « sûre » et non comme « non recherchée ».
+    ///
+    /// **`nil` signifie « non établie ».** Contrairement au filtre de difficulté
+    /// (#485), où l'inconnu n'exclut pas, l'inconnu doit ici EXCLURE : le coût
+    /// des deux erreurs n'est pas le même. Masquer une plante inoffensive prive
+    /// d'un choix ; en proposer une toxique à quelqu'un qui a demandé le
+    /// contraire rompt une promesse.
+    func petToxicity() -> ToxicityVerdict? {
+        if let fact = botanicalProfile?.petToxicity, let v = Self.verdict(from: fact.value) {
+            return v
+        }
+        if let flags = flags {
+            return flags.toxicToPets ? .toxic : .safe
+        }
+        return nil
+    }
+
+    /// Toxicité pour les enfants, ou `nil` si elle n'est pas établie.
+    ///
+    /// Aucune fiche ne porte `childToxicity` : l'ASPCA ne couvre que chiens,
+    /// chats et chevaux, et l'extrapoler aurait été inventer (#489). La source
+    /// est donc `flags.toxicToChildren` seule, en attendant une référence
+    /// dédiée.
+    func childToxicity() -> ToxicityVerdict? {
+        if let fact = botanicalProfile?.childToxicity, let v = Self.verdict(from: fact.value) {
+            return v
+        }
+        if let flags = flags {
+            return flags.toxicToChildren ? .toxic : .safe
+        }
+        return nil
+    }
+
+    /// Lit un verdict dans la formulation libre d'un fait.
+    ///
+    /// La valeur n'est pas un énuméré : l'ASPCA donne « toxic to dogs, cats,
+    /// horses » ou « non-toxic ». La négation est testée EN PREMIER, sans quoi
+    /// « non-toxic » serait lu comme toxique — il contient « toxic ».
+    private static func verdict(from raw: String) -> ToxicityVerdict? {
+        let v = raw.lowercased()
+        if ["non-toxic", "non toxic", "not toxic", "safe"].contains(where: v.contains) {
+            return .safe
+        }
+        if ["toxic", "irritant", "danger", "poison"].contains(where: v.contains) {
+            return .toxic
+        }
+        return nil
+    }
+}

--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -21,8 +21,8 @@ struct WizardPlantFilter {
         // 2. Exposure → flags.shade/fullSun (fallback: sun.lightType)
         if !matchesExposure(plant: plant, translation: translation) { return false }
 
-        // 3. Maintenance → flags.easyCare (fallback: care.difficulty + water.frequency)
-        if !matchesMaintenance(plant: plant, translation: translation) { return false }
+        // 3. Maintenance → Plant.careDifficulty (care.difficulty, repli flags.easyCare)
+        if !matchesMaintenance(plant: plant, locale: locale) { return false }
 
         // 4. Safety → flags.toxicToPets/Children (fallback: toxic keywords)
         if !matchesSafety(plant: plant, translation: translation) { return false }
@@ -175,50 +175,27 @@ struct WizardPlantFilter {
 
     // MARK: - Maintenance Matching
 
-    private func matchesMaintenance(plant: Plant, translation: PlantTranslation) -> Bool {
+    private func matchesMaintenance(plant: Plant, locale: String) -> Bool {
         guard let maintenance = wizard.maintenance, !maintenance.isEmpty else { return true }
         let maintL = maintenance.lowercased()
 
-        // Prefer structured flags when available.
-        if let flags = plant.flags {
-            if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
-                return flags.easyCare
-            }
-            // "Exigeant" / unknown → accept all.
-            return true
+        // Résolution partagée avec le filtre du catalogue (#485) : `care.difficulty`
+        // quand il existe, repli sur `flags.easyCare` sinon.
+        //
+        // `nil` = entretien inconnu. On n'exclut pas : 26 des 124 fiches n'ont
+        // ni difficulté ni flags, et les masquer sur une donnée manquante
+        // reviendrait à affirmer qu'elles ne conviennent pas.
+        guard let actual = plant.careDifficulty(locale: locale) else { return true }
+
+        // ⚠️ « Très facile » et « Facile » donnent le même résultat tant que la
+        // source est `flags.easyCare`, qui est binaire. La distinction
+        // n'apparaîtra qu'une fois `care.difficulty` peuplé (#485).
+        if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
+            return actual == .easy
         }
 
-        let plantDifficulty = (translation.care?.difficulty ?? "").lowercased()
-        let plantWater = (translation.water?.frequency ?? "").lowercased()
-        let combined = plantDifficulty + " " + plantWater
-
-        let maint = maintenance.lowercased()
-
-        // "Très facile" → veryEasy
-        if maint.contains("très facile") || maint == "veryeasy" {
-            // Only accept very easy / easy plants
-            let isEasy = combined.contains("facile") || combined.contains("simple")
-                || combined.contains("easy") || combined.contains("débutant")
-                || combined.contains("minimal") || combined.contains("peu")
-                || combined.contains("résistant")
-            let isHard = combined.contains("exigeant") || combined.contains("difficile")
-                || combined.contains("expert") || combined.contains("hard")
-            return isEasy || !isHard
-        }
-
-        // "Facile" → easy
-        if maint.contains("facile") || maint == "easy" {
-            // Accept easy + moderate plants
-            let isHard = combined.contains("exigeant") || combined.contains("difficile")
-                || combined.contains("expert") || combined.contains("hard")
-            return !isHard
-        }
-
-        // "Exigeant" → demanding - show ALL plants, including demanding ones
-        if maint.contains("exigeant") || maint == "demanding" {
-            return true
-        }
-
+        // « Exigeant » n'exclut rien : quelqu'un prêt à s'investir accepte aussi
+        // les plantes faciles. Le critère est une capacité, pas une exigence.
         return true
     }
 

--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -204,7 +204,6 @@ struct WizardPlantFilter {
     private func matchesSafety(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let safety = wizard.safety, !safety.isEmpty else { return true }
 
-        // If "Aucune contrainte" is selected, no filtering needed
         if safety.contains("Aucune contrainte") || safety.contains("none") {
             return true
         }
@@ -212,43 +211,17 @@ struct WizardPlantFilter {
         let wantsPetSafe = safety.contains("Éviter les plantes toxiques pour les animaux") || safety.contains("pets")
         let wantsChildSafe = safety.contains("Éviter les plantes dangereuses pour les enfants") || safety.contains("children")
 
-        // Prefer structured flags when available — robust (the keyword fallback
-        // below false-positives on "non toxique" / "non-toxic" descriptions).
-        if let flags = plant.flags {
-            if wantsPetSafe && flags.toxicToPets { return false }
-            if wantsChildSafe && flags.toxicToChildren { return false }
-            return true
+        // L'inconnu EXCLUT, et c'est l'inverse du filtre de difficulté (#485).
+        //
+        // Le coût des deux erreurs n'est pas le même. Masquer une plante
+        // inoffensive prive d'un choix ; en proposer une toxique à quelqu'un qui
+        // a demandé le contraire rompt une promesse — et les conséquences ne
+        // sont pas les siennes, mais celles de son animal ou de son enfant.
+        if wantsPetSafe {
+            guard let verdict = plant.petToxicity(), verdict == .safe else { return false }
         }
-
-        let problems = (translation.health?.commonProblems ?? []).joined(separator: " ").lowercased()
-        let treatments = (translation.health?.treatments ?? []).joined(separator: " ").lowercased()
-        let description = translation.description.lowercased()
-        let combined = problems + " " + treatments + " " + description
-
-        let toxicKeywords = ["toxique", "toxic", "dangere", "danger", "poison",
-                             "irritant", "nocif", "vénéneux", "nocive"]
-
-        let isToxic = toxicKeywords.contains { combined.contains($0) }
-
-        if isToxic {
-            // If user wants pet-safe plants, exclude toxic ones
-            if safety.contains("Éviter les plantes toxiques pour les animaux")
-                || safety.contains("pets") {
-                let petToxic = combined.contains("animal") || combined.contains("chat")
-                    || combined.contains("chien") || combined.contains("pet")
-                    || combined.contains("cat") || combined.contains("dog")
-                    || isToxic
-                if petToxic { return false }
-            }
-
-            // If user wants child-safe plants, exclude dangerous ones
-            if safety.contains("Éviter les plantes dangereuses pour les enfants")
-                || safety.contains("children") {
-                let childDanger = combined.contains("enfant") || combined.contains("child")
-                    || combined.contains("ingestion") || combined.contains("ingér")
-                    || isToxic
-                if childDanger { return false }
-            }
+        if wantsChildSafe {
+            guard let verdict = plant.childToxicity(), verdict == .safe else { return false }
         }
 
         return true

--- a/ArboreUi/ArboreUi/Views/CatalogueView.swift
+++ b/ArboreUi/ArboreUi/Views/CatalogueView.swift
@@ -39,7 +39,7 @@ struct CatalogueView: View {
             }
             .navigationBarHidden(true) // On cache la nav bar native pour utiliser la nôtre
             .sheet(isPresented: $showFilters) {
-                FilterView(filters: $filters)
+                FilterView(filters: $filters, plants: plants)
                     .environmentObject(themeManager)
             }
             .onAppear {

--- a/ArboreUi/ArboreUi/Views/FilterView.swift
+++ b/ArboreUi/ArboreUi/Views/FilterView.swift
@@ -98,10 +98,15 @@ struct FilterView: View {
     @Binding var filters: PlantFilters
     
     @State private var tempFilters: PlantFilters
-    
-    init(filters: Binding<PlantFilters>) {
+
+    /// Catalogue affiché, pour n'offrir que les niveaux d'entretien auxquels les
+    /// données peuvent répondre (#485).
+    private let plants: [Plant]
+
+    init(filters: Binding<PlantFilters>, plants: [Plant] = []) {
         self._filters = filters
         self._tempFilters = State(initialValue: filters.wrappedValue)
+        self.plants = plants
     }
     
     let lightOptions = [
@@ -116,11 +121,31 @@ struct FilterView: View {
         L10n.t("FILTER_WATER_HIGH")
     ]
     
-    let difficultyOptions = [
-        L10n.t("FILTER_DIFFICULTY_EASY"),
-        L10n.t("FILTER_DIFFICULTY_MEDIUM"),
-        L10n.t("FILTER_DIFFICULTY_HARD")
-    ]
+    /// Niveaux d'entretien réellement proposables, mesurés sur le catalogue (#485).
+    ///
+    /// Proposer un choix auquel aucune donnée ne peut répondre est pire que ne
+    /// pas le proposer : « Intermédiaire » ne renverrait ni les faciles ni les
+    /// exigeantes, mais exactement les fiches SANS donnée — un sous-ensemble
+    /// arbitraire présenté comme une réponse.
+    ///
+    /// Aujourd'hui la seule source est `flags.easyCare`, qui est binaire : le
+    /// niveau intermédiaire disparaît donc de lui-même. Il réapparaîtra sans
+    /// changement de code le jour où des fiches porteront `care.difficulty`.
+    var difficultyOptions: [String] {
+        let niveaux = Set(plants.compactMap { $0.careDifficulty(locale: locale) })
+
+        var options = [L10n.t("FILTER_DIFFICULTY_EASY")]
+        if niveaux.contains(.moderate) {
+            options.append(L10n.t("FILTER_DIFFICULTY_MEDIUM"))
+        }
+        options.append(L10n.t("FILTER_DIFFICULTY_HARD"))
+        return options
+    }
+
+    /// Langue courante, pour lire la bonne traduction des fiches.
+    private var locale: String {
+        Locale.current.language.languageCode?.identifier ?? "fr"
+    }
 
     var body: some View {
         NavigationStack {

--- a/ArboreUi/ArboreUi/Views/FilterView.swift
+++ b/ArboreUi/ArboreUi/Views/FilterView.swift
@@ -54,26 +54,39 @@ struct PlantFilters: Equatable {
             }
         }
         
-        // Filtre difficulté
+        // Filtre difficulté (#485)
+        //
+        // Ce bloc excluait AUTREFOIS toutes les plantes : il lisait
+        // `care.difficulty`, un champ que le backend ne sérialisait pas, donc
+        // toujours vide. Aucun mot-clé ne correspondait jamais, et chaque plante
+        // tombait dans un `return false`. Sélectionner une difficulté vidait la
+        // liste.
+        //
+        // La résolution est désormais partagée avec le wizard
+        // (`Plant.careDifficulty`), et surtout elle distingue « inconnu » de
+        // « ne correspond pas » : une plante dont on ignore l'entretien n'est
+        // PAS masquée. Un filtre qui cache ce qu'il ne sait pas juger ment à
+        // l'utilisateur.
         if let selectedDiff = difficulty {
-            let plantCare = translation.care?.difficulty?.lowercased() ?? ""
             let normalizedSelected = selectedDiff.lowercased()
-            
-            if normalizedSelected.contains("facile") || normalizedSelected.contains("easy") || normalizedSelected.contains("einfach") || normalizedSelected.contains("fácil") || normalizedSelected.contains("facil") {
-                if !plantCare.contains("facile") && !plantCare.contains("easy") && !plantCare.contains("simple") && !plantCare.contains("einfach") && !plantCare.contains("leicht") && !plantCare.contains("fácil") && !plantCare.contains("facil") {
-                    return false
-                }
-            } else if normalizedSelected.contains("intermé") || normalizedSelected.contains("medium") || normalizedSelected.contains("mittel") || normalizedSelected.contains("intermedio") {
-                if !plantCare.contains("intermé") && !plantCare.contains("medium") && !plantCare.contains("modér") && !plantCare.contains("mittel") && !plantCare.contains("moderat") && !plantCare.contains("intermedio") {
-                    return false
-                }
-            } else if normalizedSelected.contains("exigeant") || normalizedSelected.contains("hard") || normalizedSelected.contains("anspruchsvoll") || normalizedSelected.contains("dificil") || normalizedSelected.contains("difícil") {
-                if !plantCare.contains("exigeant") && !plantCare.contains("difficile") && !plantCare.contains("hard") && !plantCare.contains("expert") && !plantCare.contains("anspruchsvoll") && !plantCare.contains("schwer") && !plantCare.contains("dificil") && !plantCare.contains("difícil") {
-                    return false
-                }
+
+            let wanted: Plant.CareDifficulty?
+            if ["facile", "easy", "einfach", "fácil", "facil"].contains(where: normalizedSelected.contains) {
+                wanted = .easy
+            } else if ["intermé", "medium", "mittel", "intermedio"].contains(where: normalizedSelected.contains) {
+                wanted = .moderate
+            } else if ["exigeant", "hard", "anspruchsvoll", "dificil", "difícil"].contains(where: normalizedSelected.contains) {
+                wanted = .demanding
+            } else {
+                wanted = nil
             }
+
+            if let wanted = wanted, let actual = plant.careDifficulty(locale: locale) {
+                if actual != wanted { return false }
+            }
+            // `actual == nil` → donnée absente, on n'exclut pas.
         }
-        
+
         return true
     }
 }

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -185,3 +185,93 @@ final class PlantCareDifficultyTests: XCTestCase {
         XCTAssertTrue(filters.matches(plant: plant, locale: "fr"))
     }
 }
+
+// PlantToxicityTests — issue #488.
+//
+// Le filtre de sécurité laissait passer 25 des 26 fiches sans `flags` : il
+// cherchait le mot « toxique » dans une prose écrite pour décrire l'apparence
+// et l'entretien. Rien n'oblige la description d'un rhododendron à mentionner
+// ses grayanotoxines — et de fait, elle ne les mentionne pas.
+//
+// L'invariant central, et il est l'INVERSE de celui du filtre de difficulté :
+// ici, une toxicité non établie doit EXCLURE. Le coût des deux erreurs n'est
+// pas le même.
+
+final class PlantToxicityTests: XCTestCase {
+
+    private func makePlant(petToxicity: String? = nil,
+                           toxicToPetsFlag: Bool? = nil) throws -> Plant {
+        var profile = ""
+        if let t = petToxicity {
+            profile = #""botanicalProfile": {"petToxicity": {"value": "\#(t)"}},"#
+        }
+        var flags = ""
+        if let f = toxicToPetsFlag {
+            flags = #""flags": {"toxicToPets": \#(f), "toxicToChildren": \#(f), "easyCare": true, "shadeTolerant": false, "fullSunTolerant": false, "droughtTolerant": false, "humidityLoving": false, "flowering": false, "climbing": false, "trailing": false, "compact": false, "airPurifying": false},"#
+        }
+        let json = #"""
+        {
+            "id": "t", "name": "Test", "type": "x", "imageURLs": [],
+            "description": "", "modelURL": null,
+            \#(profile)\#(flags)
+            "translations": { "fr": { "description": "", "plantType": "" } }
+        }
+        """#
+        return try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+    }
+
+    // MARK: - L'invariant central
+
+    /// Sans donnée, la toxicité n'est pas établie — et surtout pas « sûre ».
+    func testToxiciteNonEtablieQuandRienNEstRenseigne() throws {
+        XCTAssertNil(try makePlant().petToxicity())
+    }
+
+    /// C'est la régression de #488 : 25 fiches passaient le filtre faute de
+    /// donnée, pas parce qu'elles étaient inoffensives.
+    func testUneToxiciteInconnueEstExclueDUnFiltreSurete() throws {
+        let plant = try makePlant()
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertFalse(WizardPlantFilter(wizard: wizard).matches(plant: plant, locale: "fr"),
+                       "Une toxicité non établie doit exclure quand l'utilisateur demande des plantes sûres")
+    }
+
+    // MARK: - Résolution
+
+    func testLeProfilBotaniquePrimeSurLesFlags() throws {
+        // Le flag dit « sûre », l'ASPCA dit « toxique ». L'autorité l'emporte.
+        let p = try makePlant(petToxicity: "toxic to dogs, cats, horses", toxicToPetsFlag: false)
+        XCTAssertEqual(p.petToxicity(), .toxic)
+    }
+
+    /// « non-toxic » contient « toxic » : l'ordre d'évaluation doit protéger
+    /// contre cette lecture naïve.
+    func testNonToxiqueNEstPasLuCommeToxique() throws {
+        XCTAssertEqual(try makePlant(petToxicity: "non-toxic").petToxicity(), .safe)
+    }
+
+    func testReplieSurLesFlagsQuandLeProfilManque() throws {
+        XCTAssertEqual(try makePlant(toxicToPetsFlag: true).petToxicity(), .toxic)
+        XCTAssertEqual(try makePlant(toxicToPetsFlag: false).petToxicity(), .safe)
+    }
+
+    // MARK: - Le filtre
+
+    func testUnePlanteToxiqueEstExclue() throws {
+        let p = try makePlant(petToxicity: "toxic to dogs, cats, horses")
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertFalse(WizardPlantFilter(wizard: wizard).matches(plant: p, locale: "fr"))
+    }
+
+    func testUnePlanteSureEstConservee() throws {
+        let p = try makePlant(petToxicity: "non-toxic")
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertTrue(WizardPlantFilter(wizard: wizard).matches(plant: p, locale: "fr"))
+    }
+
+    /// Sans contrainte de sécurité demandée, rien n'est exclu — même inconnu.
+    func testSansDemandeDeSureteRienNEstExclu() throws {
+        let p = try makePlant()
+        XCTAssertTrue(WizardPlantFilter(wizard: GardenWizardDTO(style: "", spaceType: "")).matches(plant: p, locale: "fr"))
+    }
+}

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -139,6 +139,44 @@ final class PlantCareDifficultyTests: XCTestCase {
         XCTAssertTrue(filters.matches(plant: facile, locale: "fr"))
     }
 
+    // MARK: - Les options proposées suivent les données
+
+    /// Avec les seules données d'aujourd'hui — `flags.easyCare`, binaire —
+    /// « Intermédiaire » ne doit pas être proposé.
+    ///
+    /// Ce n'est pas cosmétique : ce choix ne renverrait ni les faciles ni les
+    /// exigeantes, mais exactement les fiches SANS donnée. Un sous-ensemble
+    /// arbitraire présenté comme une réponse.
+    func testIntermediaireNEstPasProposeSansDonneeDeDifficulte() throws {
+        let catalogue = [
+            try makePlant(easyCare: true),
+            try makePlant(easyCare: false),
+            try makePlant()                     // inconnue
+        ]
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: catalogue)
+
+        XCTAssertEqual(vue.difficultyOptions.count, 2,
+                       "Sans care.difficulty, seuls deux niveaux sont proposables")
+    }
+
+    /// Dès qu'une fiche porte un niveau intermédiaire, l'option réapparaît —
+    /// sans changement de code.
+    func testIntermediaireReapparaitQuandLaDonneeExiste() throws {
+        let catalogue = [
+            try makePlant(easyCare: true),
+            try makePlant(careDifficulty: "Intermédiaire")
+        ]
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: catalogue)
+
+        XCTAssertEqual(vue.difficultyOptions.count, 3)
+    }
+
+    /// Un catalogue vide ne doit pas faire disparaître le filtre entier.
+    func testCatalogueVideProposeQuandMemeLesNiveauxDeBase() {
+        let vue = FilterView(filters: .constant(PlantFilters()), plants: [])
+        XCTAssertEqual(vue.difficultyOptions.count, 2)
+    }
+
     /// Sans critère sélectionné, le filtre laisse tout passer.
     func testAucunCritereNExcluRien() throws {
         let plant = try makePlant(careDifficulty: "Exigeant")

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import ArboreUi
+
+// PlantCareDifficultyTests.swift — issue #485.
+//
+// Le bug couvert ici était invisible et total : le filtre par difficulté du
+// catalogue lisait `care.difficulty`, un champ que le backend ne sérialisait
+// pas. La valeur étant toujours vide, aucun mot-clé ne correspondait jamais, et
+// CHAQUE plante tombait dans un `return false`. Sélectionner une difficulté
+// vidait la liste — mesuré sur les 124 fiches de production, dont 0 possédait
+// ce champ.
+//
+// La leçon qui structure ces tests : un filtre doit distinguer « je ne sais
+// pas » de « ne correspond pas ». Confondre les deux ne masque pas quelques
+// résultats, ça masque tout. C'est cet invariant qui est vérifié en premier.
+//
+// Les plantes sont construites par décodage JSON plutôt que par init direct :
+// c'est le chemin réel, et il couvre au passage la tolérance du modèle aux
+// champs absents.
+
+final class PlantCareDifficultyTests: XCTestCase {
+
+    // MARK: - Fabrique
+
+    /// Construit une plante depuis un fragment JSON, en complétant le minimum requis.
+    private func makePlant(careDifficulty: String? = nil,
+                           easyCare: Bool? = nil) throws -> Plant {
+        let care: String
+        if let d = careDifficulty {
+            care = #"{"difficulty": "\#(d)", "weekly": [], "monthly": [], "yearly": [], "extraTips": []}"#
+        } else {
+            care = #"{"weekly": [], "monthly": [], "yearly": [], "extraTips": []}"#
+        }
+
+        var flags = ""
+        if let easy = easyCare {
+            flags = #""flags": {"toxicToPets": false, "toxicToChildren": false, "easyCare": \#(easy), "shadeTolerant": false, "fullSunTolerant": false, "droughtTolerant": false, "humidityLoving": false, "flowering": false, "climbing": false, "trailing": false, "compact": false, "airPurifying": false},"#
+        }
+
+        let json = #"""
+        {
+            "id": "test-plant",
+            "name": "Plante de test",
+            "type": "interieur",
+            "imageURLs": [],
+            "description": "",
+            "modelURL": null,
+            \#(flags)
+            "translations": {
+                "fr": {
+                    "description": "",
+                    "plantType": "",
+                    "care": \#(care)
+                }
+            }
+        }
+        """#
+
+        return try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+    }
+
+    // MARK: - L'invariant central
+
+    /// Sans difficulté ni flags, le niveau est INCONNU — et surtout pas « exigeant ».
+    ///
+    /// C'est la régression de #485. 26 des 124 fiches sont dans ce cas ; les
+    /// traiter comme non conformes revenait à les faire disparaître.
+    func testDonneeAbsenteDonneInconnuEtNonUnNiveauParDefaut() throws {
+        let plant = try makePlant()
+        XCTAssertNil(plant.careDifficulty(),
+                     "Une plante sans donnée d'entretien doit rester inconnue, jamais classée par défaut")
+    }
+
+    /// Le filtre du catalogue ne masque pas ce qu'il ne sait pas juger.
+    func testFiltreNExclutPasUnePlanteDeDifficulteInconnue() throws {
+        let plant = try makePlant()
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertTrue(filters.matches(plant: plant, locale: "fr"),
+                      "Une difficulté inconnue ne doit pas exclure la plante — c'est le bug de #485")
+    }
+
+    // MARK: - Résolution depuis care.difficulty
+
+    func testDifficulteExpliciteEstPrioritaireSurLesFlags() throws {
+        // `easyCare: true` dit « facile », le texte dit « exigeant ».
+        // Le texte, plus précis, doit l'emporter.
+        let plant = try makePlant(careDifficulty: "Exigeant", easyCare: true)
+        XCTAssertEqual(plant.careDifficulty(), .demanding)
+    }
+
+    func testTroisNiveauxReconnusEnFrancais() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Facile").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Intermédiaire").careDifficulty(), .moderate)
+        XCTAssertEqual(try makePlant(careDifficulty: "Exigeant").careDifficulty(), .demanding)
+    }
+
+    func testNiveauxReconnusDansLesQuatreLangues() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Easy").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Einfach").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Fácil").careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(careDifficulty: "Anspruchsvoll").careDifficulty(), .demanding)
+    }
+
+    /// « Pas facile » contient « facile » : l'ordre d'évaluation doit protéger
+    /// contre cette lecture naïve.
+    func testExigeantEstTesteAvantFacile() throws {
+        XCTAssertEqual(try makePlant(careDifficulty: "Plutôt difficile").careDifficulty(), .demanding)
+    }
+
+    // MARK: - Repli sur les flags
+
+    func testReplieSurEasyCareQuandLaDifficulteManque() throws {
+        XCTAssertEqual(try makePlant(easyCare: true).careDifficulty(), .easy)
+        XCTAssertEqual(try makePlant(easyCare: false).careDifficulty(), .demanding)
+    }
+
+    /// Le repli est binaire : il ne peut pas produire « intermédiaire ».
+    /// Ce test documente la limite plutôt que de la laisser surprendre.
+    func testLeRepliNeProduitJamaisIntermediaire() throws {
+        XCTAssertNotEqual(try makePlant(easyCare: true).careDifficulty(), .moderate)
+        XCTAssertNotEqual(try makePlant(easyCare: false).careDifficulty(), .moderate)
+    }
+
+    // MARK: - Le filtre discrimine bien quand la donnée existe
+
+    func testFiltreExclutUnNiveauQuiNeCorrespondPas() throws {
+        let exigeante = try makePlant(careDifficulty: "Exigeant")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertFalse(filters.matches(plant: exigeante, locale: "fr"),
+                       "Une plante exigeante doit être exclue d'un filtre « Facile »")
+    }
+
+    func testFiltreConserveUnNiveauQuiCorrespond() throws {
+        let facile = try makePlant(careDifficulty: "Facile")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: "Facile")
+
+        XCTAssertTrue(filters.matches(plant: facile, locale: "fr"))
+    }
+
+    /// Sans critère sélectionné, le filtre laisse tout passer.
+    func testAucunCritereNExcluRien() throws {
+        let plant = try makePlant(careDifficulty: "Exigeant")
+        let filters = PlantFilters(lightType: nil, waterFrequency: nil, difficulty: nil)
+
+        XCTAssertTrue(filters.matches(plant: plant, locale: "fr"))
+    }
+}

--- a/docs/en/operations/environments.md
+++ b/docs/en/operations/environments.md
@@ -93,6 +93,49 @@ of prod, which is the normal state while a feature is in flight.
 
 ---
 
+## Contributing: `dev` no longer accepts direct pushes
+
+Since 2026-09-08 the `dev` branch is protected. Every change goes through a
+**pull request**, administrators included.
+
+```sh
+git checkout dev && git pull
+git checkout -b feat/my-feature
+# … commits …
+git push -u origin feat/my-feature
+gh pr create --base dev
+```
+
+| Rule | Value |
+|---|---|
+| Pull request | required |
+| Required approvals | **0** — you merge your own PR |
+| Required checks | `build_summary`, `security` |
+| Direct push, force-push, deletion | refused |
+
+**Zero approvals** is deliberate: with two people on the repository, requiring a
+review would block solo work. The PR becomes mandatory, not third-party sign-off.
+
+These two checks are the only ones that can **never** be skipped:
+`build_summary` has `if: always()` and aggregates the four build jobs;
+`security` has no path condition, so it runs on every PR. The other jobs are
+conditioned on the PR's content and would be `skipped` — hence treated as
+satisfied — on a docs or iOS pull request.
+
+> **Why it applies to administrators.** The first configuration left
+> `enforce_admins: false`. A direct push then went through anyway, leaving only
+> a `remote: Bypassed rule violations` line behind. A rule that can be stepped
+> over informs; it does not protect.
+
+The next day, the `security` check blocked an unrelated PR over an
+[unauthenticated RCE in Next.js](https://github.com/advisories/GHSA-2xp9-vwfh-vxw4)
+published in the meantime. Without this configuration the PR would have merged.
+
+`main` stays less strict: its protection mainly forbids direct pushes, and a PR
+promoted from `dev` has already passed the upstream gate.
+
+---
+
 ## Deploying an environment
 
 Deployment is **manual**, by choice: nobody ships to production without knowing

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -41,7 +41,7 @@ destination by mistake: everything lives in `epi-apps`.
 
 `SentryManager` is **disabled until a DSN is configured _and_ the user has explicitly opted in** to diagnostics sharing (the `privacy_shareData` toggle in the privacy settings, **off by default** — GDPR opt-in, #226). Without secrets or consent, the app builds and runs identically (handy for contributors and CI). `start()` is a no-op until consent is given; toggling consent starts/stops the SDK at runtime via `updateConsent(granted:uid:)`. The user context is the **Firebase UID only** (no email or name) and tracks auth state through a single `addStateDidChangeListener` in `AppDelegate`.
 
-Options set: `environment` (`debug`/`beta`), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus a `beforeSend` hook that strips IP / email / name / request body from every event (keeping only the UID pseudonym).
+Options set: `environment` (`debug` / `production`, see the next section), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus a `beforeSend` hook that strips IP / email / name / request body from every event (keeping only the UID pseudonym).
 
 > ⚠️ **Consequence worth knowing: iOS reports nothing.** Zero events in 90 days
 > (measured 2026-09-08). The mechanism works — it is consent that is never
@@ -79,6 +79,40 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 2. Profile → **Debug Tools → "Send Sentry test event"** (visible in DEBUG only).
 3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug` and with the Firebase UID.
 4. For symbolicated **release** crashes, ship a `fastlane beta` build with the token above, then trigger a crash on the TestFlight build.
+
+## ⚠️ Environment vocabulary is not unified
+
+The three components do not tag their events the same way. This is a known
+defect, not an oversight, and it must be known before building any view or alert
+filtered by environment.
+
+| Component | Values emitted | Where they come from |
+|---|---|---|
+| Go backend | `prod` / `dev` | `SENTRY_ENVIRONMENT`, derived from `ARBORE_ENV` |
+| Web (server, edge) | `prod` / `dev` | same |
+| Web (browser) | `production` | `NODE_ENV` fallback, frozen at build |
+| iOS | `debug` / `production` | `#if DEBUG` in `AppConfig.environment` |
+
+**Two practical consequences.**
+
+A view filtering on `production` will see neither the backend nor the web server,
+both emitting `prod`. The web changed value on 2026-09-09: its earlier data sits
+under `production`, everything after under `prod`.
+
+And above all: **the iOS `Debug` and `Dev` builds report under the same label**,
+`debug`, while `Debug` targets **production** and `Dev` targets
+`api-dev.arbore.app`. Two different backends under one name.
+
+Not for lack of information. `AppConfig.baseURL` reads `ARBORE_BACKEND_HOST`
+from `Info.plist`, fed by the configuration's xcconfig: the app knows exactly
+which backend it targets. The defect is that `AppConfig.environment` does not
+look at it — it keys off `#if DEBUG`, which `Dev` inherits anyway. **Wrong
+criterion, not missing information.**
+
+No effect today, iOS reporting nothing (see above), but it is a trap armed for
+the day it does.
+
+---
 
 ## Web (Next.js)
 

--- a/docs/fr/operations/environnements.md
+++ b/docs/fr/operations/environnements.md
@@ -96,6 +96,50 @@ cours.
 
 ---
 
+## Contribuer : `dev` n'accepte plus de push direct
+
+Depuis le 2026-09-08, la branche `dev` est protégée. Toute modification passe
+par une **pull request**, y compris pour les administrateurs.
+
+```sh
+git checkout dev && git pull
+git checkout -b feat/ma-feature
+# … commits …
+git push -u origin feat/ma-feature
+gh pr create --base dev
+```
+
+| Règle | Valeur |
+|---|---|
+| Pull request | obligatoire |
+| Approbations requises | **0** — vous fusionnez votre propre PR |
+| Checks requis | `build_summary`, `security` |
+| Push direct, force-push, suppression | refusés |
+
+**Zéro approbation** est délibéré : à deux sur le dépôt, exiger une revue
+bloquerait le travail en solo. C'est la PR qui devient obligatoire, pas la
+validation par un tiers.
+
+Ces deux checks sont les seuls qui ne peuvent **jamais** être ignorés :
+`build_summary` a `if: always()` et agrège les quatre jobs de build ;
+`security` n'a aucune condition de chemin, donc il tourne sur toute PR. Les
+autres jobs sont conditionnés au contenu de la PR et seraient `skipped` — donc
+considérés comme satisfaits — sur une PR de documentation ou d'iOS.
+
+> **Pourquoi c'est appliqué aux administrateurs.** La première configuration
+> laissait `enforce_admins: false`. Un push direct passait alors quand même,
+> avec pour seule trace un `remote: Bypassed rule violations`. Une règle
+> franchissable informe ; elle ne protège pas.
+
+Le lendemain, le check `security` a bloqué une PR sans rapport, sur une
+[RCE non authentifiée dans Next.js](https://github.com/advisories/GHSA-2xp9-vwfh-vxw4)
+publiée entre-temps. Sans cette configuration, la PR aurait été fusionnée.
+
+`main` reste moins stricte : sa protection sert surtout à interdire le push
+direct, et une PR promue depuis `dev` a déjà franchi le contrôle en amont.
+
+---
+
 ## Déployer un environnement
 
 Le déploiement est **manuel**, par choix : personne ne pousse en production sans

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -41,7 +41,7 @@ de destination par erreur : tout vit dans `epi-apps`.
 
 `SentryManager` est **désactivé tant qu'un DSN n'est pas configuré _et_ que l'utilisateur n'a pas explicitement opté** pour le partage de diagnostics (toggle `privacy_shareData` dans les réglages de confidentialité, **off par défaut** — opt-in RGPD, #226). Sans secrets ni consentement, l'app se build et tourne à l'identique (pratique pour les contributeurs et la CI). `start()` est un no-op jusqu'au consentement ; basculer le consentement démarre/arrête le SDK à chaud via `updateConsent(granted:uid:)`. Le contexte utilisateur est l'**UID Firebase uniquement** (ni email ni nom) et suit l'état d'auth via un unique `addStateDidChangeListener` dans `AppDelegate`.
 
-Options posées : `environment` (`debug`/`beta`), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (vie privée), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus un hook `beforeSend` qui retire IP / email / nom / corps de requête de chaque événement (ne conserve que le pseudonyme UID).
+Options posées : `environment` (`debug` / `production`, cf. la section suivante), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (vie privée), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus un hook `beforeSend` qui retire IP / email / nom / corps de requête de chaque événement (ne conserve que le pseudonyme UID).
 
 > ⚠️ **Conséquence à connaître : l'iOS ne remonte rien.** Zéro événement en
 > 90 jours (mesuré le 2026-09-08). Le mécanisme fonctionne — c'est le
@@ -79,6 +79,40 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 2. Profil → **Debug Tools → « Send Sentry test event »** (visible en DEBUG uniquement).
 3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug` et avec l'UID Firebase.
 4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
+
+## ⚠️ Le vocabulaire des environnements n'est pas unifié
+
+Les trois composants n'étiquettent pas leurs événements de la même façon. C'est
+un défaut connu, pas un oubli, et il faut le savoir avant de construire une vue
+ou une alerte filtrée par environnement.
+
+| Composant | Valeurs émises | D'où elles viennent |
+|---|---|---|
+| Backend Go | `prod` / `dev` | `SENTRY_ENVIRONMENT`, dérivée d'`ARBORE_ENV` |
+| Web (serveur, edge) | `prod` / `dev` | idem |
+| Web (navigateur) | `production` | repli `NODE_ENV`, figé au build |
+| iOS | `debug` / `production` | `#if DEBUG` dans `AppConfig.environment` |
+
+**Deux conséquences pratiques.**
+
+Une vue filtrant sur `production` ne verra ni le backend ni le web serveur, qui
+émettent `prod`. Le web a d'ailleurs changé de valeur le 2026-09-09 : ses données
+antérieures sont sous `production`, les suivantes sous `prod`.
+
+Et surtout : **les builds iOS `Debug` et `Dev` remontent sous la même
+étiquette**, `debug`, alors que `Debug` vise la **production** et `Dev` vise
+`api-dev.arbore.app`. Deux backends différents sous un seul nom.
+
+Ce n'est pas faute d'information. `AppConfig.baseURL` lit
+`ARBORE_BACKEND_HOST` depuis l'`Info.plist`, alimenté par le xcconfig de la
+configuration : l'app sait parfaitement quel backend elle vise. Le défaut est
+que `AppConfig.environment` ne le regarde pas — elle se fonde sur `#if DEBUG`,
+que `Dev` hérite de toute façon. **Mauvais critère, pas information manquante.**
+
+Sans effet aujourd'hui, l'iOS ne remontant rien (voir plus haut), mais c'est un
+piège armé pour le jour où il remontera.
+
+---
 
 ## Web (Next.js)
 

--- a/scripts/collect-aspca-toxicity.py
+++ b/scripts/collect-aspca-toxicity.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Collecte la liste ASPCA des plantes toxiques et non toxiques.
+
+Source : https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants
+
+Quatre listes filtrées suffisent (toxique chiens / chats / chevaux, et non
+toxique), ce qui évite d'ouvrir les 472 fiches de détail une par une.
+
+Sortie : aspca.json — { "scientific_name_normalisé": {...} }
+"""
+import json, re, time, urllib.parse, urllib.request, html, pathlib, sys
+
+BASE = "https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120 Safari/537.36"
+
+LISTES = {
+    "dogs":   {"field_toxicity_value[]": "01"},
+    "cats":   {"field_toxicity_value[]": "02"},
+    "horses": {"field_toxicity_value[]": "03"},
+    "safe":   {"field_non_toxicity_value[]": "01"},   # non toxique chiens
+}
+
+
+def fetch(params, page):
+    q = dict(params); q["page"] = str(page)
+    url = BASE + "?" + urllib.parse.urlencode(q)
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def parse(page_html):
+    """Retourne [(nom commun, nom scientifique)] pour une page."""
+    out = []
+    for row in re.findall(r'<div class="views-row.*?(?=<div class="views-row|<div class="item-list)', page_html, re.S):
+        common = re.search(r'<div class="plant-title-name">([^<]+)</div>', row)
+        sci_block = re.search(r'views-field-title-scientific-name.*?<span class="field-content">(.*?)</span>', row, re.S)
+        sci = ""
+        if sci_block:
+            sci = re.sub(r"<[^>]+>", "", sci_block.group(1))
+        if common:
+            out.append((html.unescape(common.group(1)).strip(),
+                        html.unescape(sci).strip()))
+    return out
+
+
+def normalise(nom):
+    """Nom scientifique comparable : minuscules, sans auteur ni cultivar."""
+    n = nom.lower().strip()
+    n = re.sub(r"\(.*?\)", " ", n)          # (Fam. …)
+    n = re.sub(r"['\"].*?['\"]", " ", n)     # cultivars 'Nom'
+    n = re.sub(r"[^a-z× ]", " ", n)
+    n = re.sub(r"\s+", " ", n).strip()
+    return n
+
+
+def collecte(nom_liste, params):
+    vus, page = {}, 0
+    while True:
+        h = fetch(params, page)
+        lignes = parse(h)
+        if not lignes:
+            break
+        for common, sci in lignes:
+            if not sci:
+                continue
+            for variante in [s.strip() for s in re.split(r"[,;]", sci) if s.strip()]:
+                cle = normalise(variante)
+                if cle:
+                    vus.setdefault(cle, common)
+        page += 1
+        if page > 60:                        # garde-fou
+            break
+        time.sleep(0.4)                      # ne pas marteler la source
+    print(f"  {nom_liste:7} : {len(vus)} noms scientifiques sur {page} pages", file=sys.stderr)
+    return vus
+
+
+def main():
+    resultat = {}
+    for nom, params in LISTES.items():
+        for cle, common in collecte(nom, params).items():
+            e = resultat.setdefault(cle, {"commonName": common, "toxicTo": [], "safeFor": []})
+            (e["safeFor"] if nom == "safe" else e["toxicTo"]).append(nom)
+    out = pathlib.Path(__file__).with_name("aspca.json")
+    out.write_text(json.dumps(resultat, ensure_ascii=False, indent=1, sort_keys=True))
+    toxiques = sum(1 for v in resultat.values() if v["toxicTo"])
+    print(f"  total   : {len(resultat)} espèces, dont {toxiques} toxiques", file=sys.stderr)
+    print(f"  écrit   : {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/derive-botanical-profile.py
+++ b/scripts/derive-botanical-profile.py
@@ -150,14 +150,26 @@ def watering_days(txt: str):
     return None
 
 
-# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner
-# sur « drainant », et « humide » ne doit pas capter « bien drainant mais
-# maintenu humide ».
+# Les valeurs SONT celles qu'attend le client : `fast`, `normal`, `slow` — les
+# `rawValue` de `GardenDrainageDTO`, comparés par ÉGALITÉ STRICTE dans
+# `PlantCatalogContext.appendDrainageCriterion`.
+#
+# Écrire un libellé lisible (« well-drained ») serait pire que ne rien écrire :
+# sans le champ, le moteur note simplement la donnée comme manquante ; avec une
+# valeur qu'il ne reconnaît pas, il conclut à un CONFLIT de drainage sur chaque
+# plante. Une valeur incomprise n'est pas neutre, elle est fausse.
+#
+# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner sur
+# « drainant », et « humide » ne doit pas capter « bien drainant mais maintenu
+# humide ».
 DRAINAGE_RULES = [
-    ("very well-drained", ["très drainant", "parfaitement drainant", "très bien drain",
-                           "drainage excellent", "sableux", "cactus", "succulente"]),
-    ("well-drained", ["bien drain", "drainant", "drainage"]),
-    ("moisture-retentive", ["retient l'humidité", "frais", "humifère", "reste humide"]),
+    # Substrats de cactées et sols sableux : l'eau doit filer.
+    ("fast", ["très drainant", "parfaitement drainant", "très bien drain",
+              "drainage excellent", "sableux", "cactus", "succulente"]),
+    # Le « bien drainant » horticole ordinaire, majoritaire au catalogue.
+    ("normal", ["bien drain", "drainant", "drainage"]),
+    # Sols qui gardent l'eau.
+    ("slow", ["retient l'humidité", "frais", "humifère", "reste humide"]),
 ]
 
 

--- a/scripts/derive-botanical-profile.py
+++ b/scripts/derive-botanical-profile.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Dérive trois champs structurés de `botanicalProfile` depuis la prose. (#489)
+
+## Le constat qui motive ce script
+
+Les 124 fiches portent une description complète — soleil, eau, substrat — mais
+uniquement **en prose**. `botanicalProfile`, le contrat que consomment les
+filtres et le moteur de compatibilité, est vide à 0 %.
+
+Le contenu existe donc ; c'est sa forme qui manque. Ces trois champs se
+déduisent du texte présent, sans consulter aucune source extérieure :
+
+    directSunHours        ← sun.durationPerDay       « 6–8 h / jour »
+    wateringIntervalDays  ← water.frequency          « 1 fois par semaine »
+    drainage              ← soilAndPot.substrate     « mélange bien drainant »
+
+## Sur la fiabilité, et pourquoi elle est marquée « derived »
+
+Une valeur extraite d'une prose vaut ce que vaut cette prose — laquelle a été
+produite par un agent puis traduite (cf. #489). L'inscrire avec
+`reliability: authoritative`, comme la toxicité ASPCA, serait mentir sur sa
+provenance.
+
+`evidence.reliability = "derived"` et `sourceName` nommant le champ d'origine :
+un lecteur voit d'où vient la valeur et peut la contester.
+
+## L'arrosage est saisonnier
+
+Les fréquences sont écrites « 1 à 2 fois par semaine en été, 1 fois toutes les
+2 semaines en hiver ». La première proposition PORTEUSE d'un intervalle est
+retenue : elle décrit la période de croissance, celle où l'arrosage est une
+contrainte réelle. Un intervalle hivernal moyenné avec l'estival ne décrirait
+aucune des deux saisons.
+
+Certaines fiches n'en portent aucun : « arrose quand les premiers centimètres
+sont secs » est une condition, pas une périodicité. Elles restent sans valeur —
+et le garde-fou du script refuse explicitement d'y lire « 2 à 3 jours », ce qui
+confondrait une profondeur de sol avec une fréquence.
+
+## Usage
+
+    python3 scripts/derive-botanical-profile.py --plants plants.json          # mesure
+    python3 scripts/derive-botanical-profile.py --plants plants.json --out ops.json
+"""
+import argparse, json, re, sys
+from datetime import date
+
+FIELD_SOURCE = {
+    "directSunHours": "translations.<lang>.sun.durationPerDay",
+    "wateringIntervalDays": "translations.<lang>.water.frequency",
+    "drainage": "translations.<lang>.soilAndPot.substrate",
+}
+
+
+def _nombres(txt: str):
+    """Les nombres d'un fragment, tirets typographiques compris."""
+    return [float(n.replace(",", ".")) for n in re.findall(r"\d+(?:[.,]\d+)?", txt)]
+
+
+def sun_hours(txt: str):
+    """« 6–8 h / jour » → (6, 8).  « 4 h » → (4, 4)."""
+    if not txt:
+        return None
+    m = re.search(r"(\d+)\s*[–\-—à]\s*(\d+)\s*h", txt, re.I)
+    if m:
+        return float(m.group(1)), float(m.group(2))
+    m = re.search(r"(\d+)\s*h", txt, re.I)
+    if m:
+        return float(m.group(1)), float(m.group(1))
+    return None
+
+
+MOTS_NOMBRES = {"une": 1, "un": 1, "deux": 2, "trois": 3, "quatre": 4}
+
+
+def _n(txt: str):
+    """Un nombre écrit en chiffres ou en lettres."""
+    txt = txt.strip().lower()
+    if txt in MOTS_NOMBRES:
+        return float(MOTS_NOMBRES[txt])
+    try:
+        return float(txt.replace(",", "."))
+    except ValueError:
+        return None
+
+
+# Un nombre : chiffres ou mot.
+NB = r"(\d+|une?|deux|trois|quatre)"
+SEP = r"(?:[àa]|[–\-—])"
+
+
+def _intervalle(frag: str):
+    """Intervalle en jours pour UN fragment, ou None."""
+    # Garde-fou : « les 2 à 3 premiers centimètres sont secs » décrit une
+    # profondeur de sol, pas une périodicité. Confondre les deux donnerait
+    # « arroser tous les 2 jours » à une plante qu'on arrose au toucher.
+    if re.search(r"centim|\bcm\b|profondeur", frag, re.I):
+        return None
+
+    # « 1 à 2 fois par semaine » → 7/max .. 7/min
+    m = re.search(NB + r"\s*" + SEP + r"\s*" + NB + r"\s*fois\s+par\s+semaine", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return round(7 / max(a, b), 1), round(7 / min(a, b), 1)
+
+    # « une fois par semaine », « 2 fois par semaine »
+    m = re.search(NB + r"\s*fois\s+par\s+semaine", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return round(7 / a, 1), round(7 / a, 1)
+
+    # « toutes les 1–2 semaines » / « tous les 2 à 3 semaines »
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*" + SEP + r"\s*" + NB + r"\s*semaines?", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return a * 7, b * 7
+
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*semaines?", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return a * 7, a * 7
+
+    # « tous les 10–15 jours »
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*" + SEP + r"\s*" + NB + r"\s*jours?", frag, re.I)
+    if m and (a := _n(m.group(1))) and (b := _n(m.group(2))):
+        return a, b
+
+    m = re.search(r"tou(?:te)?s\s+les\s+" + NB + r"\s*jours?", frag, re.I)
+    if m and (a := _n(m.group(1))):
+        return a, a
+
+    return None
+
+
+def watering_days(txt: str):
+    """Intervalle en jours, depuis la première proposition qui en porte un.
+
+    Les fréquences sont saisonnières — « 1 à 2 fois par semaine en été, 1 fois
+    toutes les 2 semaines en hiver ». La première proposition PORTEUSE décrit la
+    période de croissance, celle où l'arrosage est une contrainte réelle. Les
+    propositions liminaires (« En gros », « Au printemps et en été ») sont donc
+    traversées, pas bloquantes.
+
+    Certaines fiches ne décrivent aucun intervalle : « arrose quand les premiers
+    centimètres sont secs » est une condition, pas une périodicité. Elles
+    restent sans valeur — c'est correct, et préférable à un chiffre inventé.
+    """
+    if not txt:
+        return None
+    for frag in re.split(r"[,;.]", txt):
+        r = _intervalle(frag)
+        if r:
+            return r
+    return None
+
+
+# Ordonné du plus exigeant au plus tolérant : « très drainant » doit gagner
+# sur « drainant », et « humide » ne doit pas capter « bien drainant mais
+# maintenu humide ».
+DRAINAGE_RULES = [
+    ("very well-drained", ["très drainant", "parfaitement drainant", "très bien drain",
+                           "drainage excellent", "sableux", "cactus", "succulente"]),
+    ("well-drained", ["bien drain", "drainant", "drainage"]),
+    ("moisture-retentive", ["retient l'humidité", "frais", "humifère", "reste humide"]),
+]
+
+
+def drainage(txt: str):
+    if not txt:
+        return None
+    t = txt.lower()
+    for valeur, cles in DRAINAGE_RULES:
+        if any(c in t for c in cles):
+            return valeur
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plants", required=True)
+    ap.add_argument("--lang", default="fr")
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    brut = json.load(open(args.plants))
+    plants = brut if isinstance(brut, list) else brut.get("plants", [])
+    aujourdhui = date.today().isoformat()
+
+    ops, compte = [], {k: 0 for k in FIELD_SOURCE}
+
+    for p in plants:
+        tr = p.get("translations", {}).get(args.lang, {})
+        champs = {}
+
+        def evidence(champ):
+            return {
+                "sourceName": "Dérivé de " + FIELD_SOURCE[champ].replace("<lang>", args.lang),
+                "reviewedAt": aujourdhui,
+                "reliability": "derived",
+            }
+
+        h = sun_hours((tr.get("sun") or {}).get("durationPerDay", ""))
+        if h:
+            champs["directSunHours"] = {"minimum": h[0], "maximum": h[1],
+                                        "unit": "hours/day", "evidence": evidence("directSunHours")}
+
+        w = watering_days((tr.get("water") or {}).get("frequency", ""))
+        if w:
+            champs["wateringIntervalDays"] = {"minimum": w[0], "maximum": w[1],
+                                              "unit": "days", "evidence": evidence("wateringIntervalDays")}
+
+        d = drainage((tr.get("soilAndPot") or {}).get("substrate", ""))
+        if d:
+            champs["drainage"] = {"value": d, "evidence": evidence("drainage")}
+
+        for k in champs:
+            compte[k] += 1
+        if champs:
+            ops.append({"id": p["id"], "name": p["name"], "fields": champs})
+
+    total = len(plants)
+    print(f"  fiches : {total}", file=sys.stderr)
+    for k, n in compte.items():
+        print(f"    {k:22} {n}/{total}  {round(100*n/total)}%", file=sys.stderr)
+
+    if args.out:
+        json.dump(ops, open(args.out, "w"), ensure_ascii=False, indent=1)
+        print(f"  écrit : {args.out} ({len(ops)} fiches)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enrich-pet-toxicity.py
+++ b/scripts/enrich-pet-toxicity.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Renseigne `botanicalProfile.petToxicity` depuis la liste ASPCA. (#489)
+
+## Pourquoi l'ASPCA plutôt qu'une API
+
+La toxicité est une donnée de sécurité : elle mérite sa source faisant autorité.
+Trefle et Perenual citent tous deux l'ASPCA — passer par eux ajoute un
+intermédiaire sans ajouter d'autorité, et impose une correspondance de noms
+approximative qu'aucun des deux ne garantit. À 124 fiches, le volume ne justifie
+pas cette prise de risque.
+
+## Ce que le script écrit, et ce qu'il n'écrit pas
+
+Il écrit `botanicalProfile.petToxicity`, un fait accompagné de sa provenance
+(`PlantDataEvidence`) : source, URL, date de relevé.
+
+Il n'écrit **PAS** dans `flags`. Créer un objet `flags` partiel rendrait
+`plant.flags != nil` côté client, et le wizard traiterait alors les onze autres
+booléens — laissés à `false` — comme faisant autorité. Une plante deviendrait
+« non tolérante à l'ombre » du seul fait qu'on a renseigné sa toxicité.
+
+Il n'écrit **PAS** `childToxicity`. L'ASPCA couvre chiens, chats et chevaux :
+elle ne dit rien des enfants. Déduire l'un de l'autre serait inventer.
+
+## Correspondance des noms
+
+Deux cas seulement sont retenus, et la distinction est essentielle :
+
+  - **espèce exacte** — `hosta plantaginea` ↔ `Hosta plantaginea` ;
+  - **genre entier** — une entrée ASPCA en `spp.` / `species` vise le genre,
+    donc s'applique à toutes ses espèces : `rhododendron spp` couvre
+    *Rhododendron obtusum*.
+
+Une entrée nommant une AUTRE espèce du même genre n'est pas retenue :
+`hydrangea arborescens` ne dit rien de *Hydrangea macrophylla*. Transférer un
+verdict entre espèces sœurs serait une erreur de sécurité.
+
+## Absence n'est pas innocuité
+
+La liste ASPCA compte environ 470 plantes notables, pas un référentiel exhaustif.
+Une espèce absente reste donc **inconnue** — jamais « non toxique ». C'est
+pourquoi rien n'est écrit dans ce cas : un champ vide se lit comme une question
+ouverte, une valeur fausse se lit comme une réponse.
+
+## Usage
+
+    python3 scripts/enrich-pet-toxicity.py --aspca aspca.json --plants plants.json
+    python3 scripts/enrich-pet-toxicity.py … --out updates.json
+
+La sortie est un fichier d'opérations à appliquer par `mongosh`. Le script ne
+touche à aucune base : il produit, on relit, on applique.
+"""
+import argparse, json, re, sys
+from datetime import date
+
+SOURCE_NAME = "ASPCA Animal Poison Control"
+SOURCE_URL = "https://www.aspca.org/pet-care/aspca-poison-control/toxic-and-non-toxic-plants"
+GENRE_ENTIER = {"spp", "species", "sp"}
+
+
+def normalise(nom: str) -> str:
+    """Nom scientifique comparable : minuscules, sans auteur ni cultivar."""
+    n = nom.lower().strip()
+    n = re.sub(r"\(.*?\)", " ", n)
+    n = re.sub(r"['\"].*?['\"]", " ", n)
+    n = re.sub(r"[^a-z× ]", " ", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def index_genre(aspca: dict) -> dict:
+    """Entrées valant pour un genre entier, indexées par genre."""
+    out = {}
+    for cle, val in aspca.items():
+        mots = cle.split()
+        if len(mots) == 2 and mots[1] in GENRE_ENTIER:
+            out[mots[0]] = (cle, val)
+    return out
+
+
+def verdict(nom: str, aspca: dict, genres: dict):
+    """(clé ASPCA, entrée, précision) ou (None, None, None)."""
+    n = normalise(nom)
+    mots = n.split()
+    espece = " ".join(mots[:2]) if len(mots) >= 2 else n
+
+    if n in aspca:
+        return n, aspca[n], "espèce"
+    if espece in aspca:
+        return espece, aspca[espece], "espèce"
+    if mots and mots[0] in genres:
+        cle, val = genres[mots[0]]
+        return cle, val, "genre"
+    return None, None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--aspca", required=True, help="JSON produit par aspca_collect.py")
+    ap.add_argument("--plants", required=True, help="catalogue JSON (réponse de /plants)")
+    ap.add_argument("--out", help="fichier d'opérations ; défaut : affichage seul")
+    args = ap.parse_args()
+
+    aspca = json.load(open(args.aspca))
+    brut = json.load(open(args.plants))
+    plants = brut if isinstance(brut, list) else brut.get("plants", [])
+    genres = index_genre(aspca)
+
+    aujourdhui = date.today().isoformat()
+    operations, inconnues = [], []
+
+    for p in plants:
+        cle, entree, precision = verdict(p["name"], aspca, genres)
+        if not entree:
+            inconnues.append(p["name"])
+            continue
+
+        toxique = bool(entree["toxicTo"])
+        if toxique:
+            valeur = "toxic to " + ", ".join(entree["toxicTo"])
+        elif entree["safeFor"]:
+            valeur = "non-toxic"
+        else:
+            inconnues.append(p["name"])
+            continue
+
+        operations.append({
+            "id": p["id"],
+            "name": p["name"],
+            "match": cle,
+            "precision": precision,
+            "petToxicity": {
+                "value": valeur,
+                "evidence": {
+                    "sourceName": SOURCE_NAME,
+                    "sourceURL": SOURCE_URL,
+                    "reviewedAt": aujourdhui,
+                    # « genre » signale un verdict valant pour tout le genre :
+                    # exact au sens de l'ASPCA, mais moins précis qu'une espèce.
+                    "reliability": "authoritative" if precision == "espèce" else "authoritative-genus",
+                },
+            },
+        })
+
+    toxiques = sum(1 for o in operations if o["petToxicity"]["value"] != "non-toxic")
+    print(f"  fiches            : {len(plants)}", file=sys.stderr)
+    print(f"  verdicts obtenus  : {len(operations)}  ({toxiques} toxiques)", file=sys.stderr)
+    print(f"  restent inconnues : {len(inconnues)}", file=sys.stderr)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(operations, f, ensure_ascii=False, indent=1)
+        print(f"  écrit             : {args.out}", file=sys.stderr)
+    else:
+        for o in operations[:10]:
+            print(f"    {o['name'][:38]:40} {o['petToxicity']['value']}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Promotion de #486 (filtre) et #490 (données).

## Côté iOS — un bug visible corrigé

Sélectionner une difficulté dans le catalogue ne renvoyait **aucune plante** :
`FilterView` lisait `care.difficulty`, un champ que le backend ne sérialisait
pas, et traitait cette absence comme une non-conformité. Chaque plante tombait
dans un `return false`.

La résolution est désormais partagée entre le catalogue et le wizard, et
distingue **« inconnu » de « ne correspond pas »**. Les niveaux proposés suivent
les données : « Intermédiaire » disparaît tant qu'aucune fiche ne le porte, et
réapparaîtra sans changement de code.

14 tests ajoutés — aucun ne couvrait ces filtres, c'est pourquoi le bug est
passé.

## Côté données — `botanicalProfile` peuplé pour la première fois

Les données de production sont **déjà écrites** ; cette PR verse les scripts.

```
petToxicity            38/124   ASPCA, authoritative
directSunHours        121/124   dérivé
wateringIntervalDays  107/124   dérivé
drainage              110/124   dérivé
```

## Chaîne vérifiée : base → backend → iOS

C'est la vérification qui a rattrapé une régression.

| Champ | Comparaison côté client | Verdict |
|---|---|---|
| `petToxicity` | sous-chaîne (`containsAny`) | ✅ « toxic to dogs… » compris |
| `wateringIntervalDays` | numérique | ✅ |
| `directSunHours` | numérique | ✅ |
| `drainage` | **égalité stricte** avec `fast`/`normal`/`slow` | ❌ corrigé |

J'avais écrit `well-drained` et `moisture-retentive` — lisibles, et
incompréhensibles pour le seul code qui les consomme. Toutes tombaient dans le
`else` final : un **conflit de drainage sur chaque plante**, pénalité 0,60.

Sans le champ, le moteur note la donnée comme manquante — neutre. Avec une
valeur qu'il ne reconnaît pas, il conclut à un conflit. **Une valeur incomprise
n'est pas neutre, elle est fausse.**

Corrigé en base : `fast` 29, `normal` 79, `slow` 2, aucune valeur hors contrat.

Refs #485, #488, #489
