### PR TITLE
fix(ios): le filtre de sécurité consulte la toxicité, et exclut ce qu'il ignore

### DIFF
--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -415,3 +415,72 @@ extension Plant {
         return nil
     }
 }
+
+// MARK: - Toxicité (#488)
+
+extension Plant {
+
+    /// Verdict de toxicité pour un public donné.
+    enum ToxicityVerdict {
+        case toxic
+        case safe
+    }
+
+    /// Toxicité pour les animaux, ou `nil` si elle n'est pas établie.
+    ///
+    /// Deux sources, dans cet ordre :
+    ///
+    /// 1. `botanicalProfile.petToxicity` — faisant autorité, avec sa provenance.
+    ///    Renseignée depuis l'ASPCA sur 38 fiches (#489).
+    /// 2. `flags.toxicToPets` — issue de l'enrichissement botanique, présente
+    ///    sur 98 fiches. Confrontée à l'ASPCA sur les 30 fiches couvertes par
+    ///    les deux : **30 accords, 0 désaccord**. C'est ce contrôle qui autorise
+    ///    à lire son `false` comme « sûre » et non comme « non recherchée ».
+    ///
+    /// **`nil` signifie « non établie ».** Contrairement au filtre de difficulté
+    /// (#485), où l'inconnu n'exclut pas, l'inconnu doit ici EXCLURE : le coût
+    /// des deux erreurs n'est pas le même. Masquer une plante inoffensive prive
+    /// d'un choix ; en proposer une toxique à quelqu'un qui a demandé le
+    /// contraire rompt une promesse.
+    func petToxicity() -> ToxicityVerdict? {
+        if let fact = botanicalProfile?.petToxicity, let v = Self.verdict(from: fact.value) {
+            return v
+        }
+        if let flags = flags {
+            return flags.toxicToPets ? .toxic : .safe
+        }
+        return nil
+    }
+
+    /// Toxicité pour les enfants, ou `nil` si elle n'est pas établie.
+    ///
+    /// Aucune fiche ne porte `childToxicity` : l'ASPCA ne couvre que chiens,
+    /// chats et chevaux, et l'extrapoler aurait été inventer (#489). La source
+    /// est donc `flags.toxicToChildren` seule, en attendant une référence
+    /// dédiée.
+    func childToxicity() -> ToxicityVerdict? {
+        if let fact = botanicalProfile?.childToxicity, let v = Self.verdict(from: fact.value) {
+            return v
+        }
+        if let flags = flags {
+            return flags.toxicToChildren ? .toxic : .safe
+        }
+        return nil
+    }
+
+    /// Lit un verdict dans la formulation libre d'un fait.
+    ///
+    /// La valeur n'est pas un énuméré : l'ASPCA donne « toxic to dogs, cats,
+    /// horses » ou « non-toxic ». La négation est testée EN PREMIER, sans quoi
+    /// « non-toxic » serait lu comme toxique — il contient « toxic ».
+    private static func verdict(from raw: String) -> ToxicityVerdict? {
+        let v = raw.lowercased()
+        if ["non-toxic", "non toxic", "not toxic", "safe"].contains(where: v.contains) {
+            return .safe
+        }
+        if ["toxic", "irritant", "danger", "poison"].contains(where: v.contains) {
+            return .toxic
+        }
+        return nil
+    }
+}

--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -204,7 +204,6 @@ struct WizardPlantFilter {
     private func matchesSafety(plant: Plant, translation: PlantTranslation) -> Bool {
         guard let safety = wizard.safety, !safety.isEmpty else { return true }
 
-        // If "Aucune contrainte" is selected, no filtering needed
         if safety.contains("Aucune contrainte") || safety.contains("none") {
             return true
         }
@@ -212,43 +211,17 @@ struct WizardPlantFilter {
         let wantsPetSafe = safety.contains("Éviter les plantes toxiques pour les animaux") || safety.contains("pets")
         let wantsChildSafe = safety.contains("Éviter les plantes dangereuses pour les enfants") || safety.contains("children")
 
-        // Prefer structured flags when available — robust (the keyword fallback
-        // below false-positives on "non toxique" / "non-toxic" descriptions).
-        if let flags = plant.flags {
-            if wantsPetSafe && flags.toxicToPets { return false }
-            if wantsChildSafe && flags.toxicToChildren { return false }
-            return true
+        // L'inconnu EXCLUT, et c'est l'inverse du filtre de difficulté (#485).
+        //
+        // Le coût des deux erreurs n'est pas le même. Masquer une plante
+        // inoffensive prive d'un choix ; en proposer une toxique à quelqu'un qui
+        // a demandé le contraire rompt une promesse — et les conséquences ne
+        // sont pas les siennes, mais celles de son animal ou de son enfant.
+        if wantsPetSafe {
+            guard let verdict = plant.petToxicity(), verdict == .safe else { return false }
         }
-
-        let problems = (translation.health?.commonProblems ?? []).joined(separator: " ").lowercased()
-        let treatments = (translation.health?.treatments ?? []).joined(separator: " ").lowercased()
-        let description = translation.description.lowercased()
-        let combined = problems + " " + treatments + " " + description
-
-        let toxicKeywords = ["toxique", "toxic", "dangere", "danger", "poison",
-                             "irritant", "nocif", "vénéneux", "nocive"]
-
-        let isToxic = toxicKeywords.contains { combined.contains($0) }
-
-        if isToxic {
-            // If user wants pet-safe plants, exclude toxic ones
-            if safety.contains("Éviter les plantes toxiques pour les animaux")
-                || safety.contains("pets") {
-                let petToxic = combined.contains("animal") || combined.contains("chat")
-                    || combined.contains("chien") || combined.contains("pet")
-                    || combined.contains("cat") || combined.contains("dog")
-                    || isToxic
-                if petToxic { return false }
-            }
-
-            // If user wants child-safe plants, exclude dangerous ones
-            if safety.contains("Éviter les plantes dangereuses pour les enfants")
-                || safety.contains("children") {
-                let childDanger = combined.contains("enfant") || combined.contains("child")
-                    || combined.contains("ingestion") || combined.contains("ingér")
-                    || isToxic
-                if childDanger { return false }
-            }
+        if wantsChildSafe {
+            guard let verdict = plant.childToxicity(), verdict == .safe else { return false }
         }
 
         return true

--- a/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCareDifficultyTests.swift
@@ -185,3 +185,93 @@ final class PlantCareDifficultyTests: XCTestCase {
         XCTAssertTrue(filters.matches(plant: plant, locale: "fr"))
     }
 }
+
+// PlantToxicityTests — issue #488.
+//
+// Le filtre de sécurité laissait passer 25 des 26 fiches sans `flags` : il
+// cherchait le mot « toxique » dans une prose écrite pour décrire l'apparence
+// et l'entretien. Rien n'oblige la description d'un rhododendron à mentionner
+// ses grayanotoxines — et de fait, elle ne les mentionne pas.
+//
+// L'invariant central, et il est l'INVERSE de celui du filtre de difficulté :
+// ici, une toxicité non établie doit EXCLURE. Le coût des deux erreurs n'est
+// pas le même.
+
+final class PlantToxicityTests: XCTestCase {
+
+    private func makePlant(petToxicity: String? = nil,
+                           toxicToPetsFlag: Bool? = nil) throws -> Plant {
+        var profile = ""
+        if let t = petToxicity {
+            profile = #""botanicalProfile": {"petToxicity": {"value": "\#(t)"}},"#
+        }
+        var flags = ""
+        if let f = toxicToPetsFlag {
+            flags = #""flags": {"toxicToPets": \#(f), "toxicToChildren": \#(f), "easyCare": true, "shadeTolerant": false, "fullSunTolerant": false, "droughtTolerant": false, "humidityLoving": false, "flowering": false, "climbing": false, "trailing": false, "compact": false, "airPurifying": false},"#
+        }
+        let json = #"""
+        {
+            "id": "t", "name": "Test", "type": "x", "imageURLs": [],
+            "description": "", "modelURL": null,
+            \#(profile)\#(flags)
+            "translations": { "fr": { "description": "", "plantType": "" } }
+        }
+        """#
+        return try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+    }
+
+    // MARK: - L'invariant central
+
+    /// Sans donnée, la toxicité n'est pas établie — et surtout pas « sûre ».
+    func testToxiciteNonEtablieQuandRienNEstRenseigne() throws {
+        XCTAssertNil(try makePlant().petToxicity())
+    }
+
+    /// C'est la régression de #488 : 25 fiches passaient le filtre faute de
+    /// donnée, pas parce qu'elles étaient inoffensives.
+    func testUneToxiciteInconnueEstExclueDUnFiltreSurete() throws {
+        let plant = try makePlant()
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertFalse(WizardPlantFilter(wizard: wizard).matches(plant: plant, locale: "fr"),
+                       "Une toxicité non établie doit exclure quand l'utilisateur demande des plantes sûres")
+    }
+
+    // MARK: - Résolution
+
+    func testLeProfilBotaniquePrimeSurLesFlags() throws {
+        // Le flag dit « sûre », l'ASPCA dit « toxique ». L'autorité l'emporte.
+        let p = try makePlant(petToxicity: "toxic to dogs, cats, horses", toxicToPetsFlag: false)
+        XCTAssertEqual(p.petToxicity(), .toxic)
+    }
+
+    /// « non-toxic » contient « toxic » : l'ordre d'évaluation doit protéger
+    /// contre cette lecture naïve.
+    func testNonToxiqueNEstPasLuCommeToxique() throws {
+        XCTAssertEqual(try makePlant(petToxicity: "non-toxic").petToxicity(), .safe)
+    }
+
+    func testReplieSurLesFlagsQuandLeProfilManque() throws {
+        XCTAssertEqual(try makePlant(toxicToPetsFlag: true).petToxicity(), .toxic)
+        XCTAssertEqual(try makePlant(toxicToPetsFlag: false).petToxicity(), .safe)
+    }
+
+    // MARK: - Le filtre
+
+    func testUnePlanteToxiqueEstExclue() throws {
+        let p = try makePlant(petToxicity: "toxic to dogs, cats, horses")
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertFalse(WizardPlantFilter(wizard: wizard).matches(plant: p, locale: "fr"))
+    }
+
+    func testUnePlanteSureEstConservee() throws {
+        let p = try makePlant(petToxicity: "non-toxic")
+        let wizard = GardenWizardDTO(style: "", spaceType: "", safety: ["Éviter les plantes toxiques pour les animaux"])
+        XCTAssertTrue(WizardPlantFilter(wizard: wizard).matches(plant: p, locale: "fr"))
+    }
+
+    /// Sans contrainte de sécurité demandée, rien n'est exclu — même inconnu.
+    func testSansDemandeDeSureteRienNEstExclu() throws {
+        let p = try makePlant()
+        XCTAssertTrue(WizardPlantFilter(wizard: GardenWizardDTO(style: "", spaceType: "")).matches(plant: p, locale: "fr"))
+    }
+}


### PR DESCRIPTION
Ferme #488.

## Le défaut

Le critère « éviter les plantes toxiques pour les animaux » laissait passer
**25 des 26 fiches sans `flags`**. Il cherchait le mot « toxique » dans une prose
écrite pour décrire l'apparence et l'entretien.

Rien n'oblige la description d'un rhododendron à mentionner ses grayanotoxines —
et de fait, elle ne les mentionne pas. La seule fiche qui déclenchait le repli,
`Nandina domestica`, le devait à une phrase **ajoutée à la main en avril**
(#87). Le filtre reposait sur une rédaction, pas sur une propriété des données.

## La correction

`Plant.petToxicity()` résout un verdict depuis deux sources :

| Priorité | Source | Couverture |
|---|---|---|
| 1 | `botanicalProfile.petToxicity` — ASPCA, avec provenance | 38 fiches |
| 2 | `flags.toxicToPets` — enrichissement botanique | 98 fiches |

Lire le `false` des flags comme « sûre » plutôt que « non recherchée » est
autorisé par un contrôle : sur les 30 fiches couvertes par les **deux** sources,
**30 accords, 0 désaccord**.

Le repli mots-clés est **supprimé**. Il ne produisait qu'un faux sentiment de
couverture.

## L'inconnu exclut — et c'est l'inverse de #485

Dans le filtre de difficulté, une donnée inconnue n'exclut pas. Ici, une
toxicité non établie exclut. Ce n'est pas une incohérence : **le coût des deux
erreurs diffère**.

Masquer une plante inoffensive prive d'un choix. En proposer une toxique à
quelqu'un qui a demandé le contraire rompt une promesse — et les conséquences ne
sont pas les siennes, mais celles de son animal ou de son enfant.

## Périmètre

```
106/124  ont un verdict   (98 par les flags, 8 de plus par l'ASPCA)
 18/124  restent inconnues → écartées quand la sûreté est demandée
```

Les sept fiches toxiques que #488 dénonçait — buis, dahlia, pélargonium,
achillée, nandina, **rhododendron**, hosta — sont désormais exclues.

## Tests

8 ajoutés, dont le premier garde l'invariant qui a lâché. **22 au total** sur
les deux filtres, tous verts. Build iOS réussi.

Closes #488
