### PR TITLE
docs: l'état réel des données botaniques, et pourquoi « 0 vérifiée » reste juste

### DIFF
--- a/docs/en/operations/botanical-data-audit.md
+++ b/docs/en/operations/botanical-data-audit.md
@@ -84,6 +84,37 @@ The report distinguishes:
 - verified coverage;
 - plants certifiable on critical fields.
 
+## Enrichment tools
+
+Three scripts, to run in this order. None writes to the database: they produce
+an operations file to be reviewed before applying it with `mongosh`.
+
+```sh
+# 1. Collect the ASPCA list (toxicity to dogs / cats / horses)
+python3 scripts/collect-aspca-toxicity.py          # → aspca.json
+
+# 2. Match against the catalogue and produce the operations
+python3 scripts/enrich-pet-toxicity.py \
+  --aspca aspca.json --plants plants.json --out ops.json
+
+# 3. Derive sun, watering and drainage from each plant's prose
+python3 scripts/derive-botanical-profile.py \
+  --plants plants.json --out derived.json
+```
+
+The expected plants file is a `GET /plants` export, as for the audit.
+
+**Two rules baked into these scripts, not to be undone:**
+
+Name matching only accepts an exact species, or an ASPCA entry in `spp.` which
+covers the whole genus. An entry naming a **different** species of the same genus
+is rejected — `hydrangea arborescens` says nothing about *Hydrangea macrophylla*.
+Without this rule, 72 plants would receive a borrowed verdict.
+
+Derivation rejects any fragment mentioning centimetres: "water when the top 2–3
+centimetres are dry" describes a soil depth, not a periodicity. Reading it as
+"every 2–3 days" would be a fivefold error, invisible on review.
+
 ## Acceptance criteria
 
 A verified value has:

--- a/docs/en/operations/botanical-data-audit.md
+++ b/docs/en/operations/botanical-data-audit.md
@@ -2,14 +2,60 @@
 
 ## Current baseline
 
-Read-only audit of the production `arbore.plants` collection, performed on July 23, 2026:
+Audit of the production `arbore.plants` collection, taken on September 9, 2026:
 
-- 124 catalog plants;
-- 0 `botanicalProfile`;
-- 0 plant certifiable on critical constraints;
-- 0 verified values out of 1,860 possible values (124 plants × 15 fields).
+```
+124 catalog plants
+123 now carry a botanicalProfile
+  0 plants certifiable on critical constraints
+  0 verified values out of 1,860 possible
+```
 
-The engine must therefore show at most **Probably compatible** until profiles are populated. Legacy prose and `PlantFlags` remain weak hints and can never produce **Suitable**.
+Four fields were populated on September 9 (#489):
+
+| Field | Coverage | Provenance |
+|---|---|---|
+| `petToxicity` | 38/124 | ASPCA, named and dated source |
+| `directSunHours` | 121/124 | derived from `sun.durationPerDay` |
+| `wateringIntervalDays` | 107/124 | derived from `water.frequency` |
+| `drainage` | 110/124 | derived from `soilAndPot.substrate` |
+
+**"0 verified values" remains exact, and that is not a contradiction.** The audit
+only accepts `reliability: high`, which this document reserves for review by a
+horticulturist or botanist — step 5 of the population plan. None of these values
+has been reviewed by a human.
+
+The vocabulary says so:
+
+| Value | Meaning |
+|---|---|
+| `high` | reviewed by a competent human — **none to date** |
+| `authoritative` | authoritative source, machine-collected (ASPCA) |
+| `authoritative-genus` | same, but the verdict holds for the genus, not the species |
+| `derived` | transcribed from the plant's own prose |
+
+> ⚠️ **One nuance to settle.** Step 3 of the plan asks to complete fields
+> "**without inferring** a missing value from the text". The three `derived`
+> fields transcribe an explicitly written number — "6–8 h / jour" becomes
+> `{minimum: 6, maximum: 8}` — rather than inferring one. The line is thin and
+> deserves a ruling: these values may be kept as hints, or removed if the rule
+> is to be strict.
+
+The engine must therefore still show at most **Probably compatible**. Legacy
+prose and `PlantFlags` remain weak hints and can never produce **Suitable**.
+
+## What the filters already consume
+
+Independently of certification, two iOS filters read this data:
+
+- **safety** (#488) — `botanicalProfile.petToxicity` first, `flags.toxicToPets`
+  next. An **unestablished** toxicity **excludes** the plant when the user asks
+  for safe plants: 40 of 124 remain in that case;
+- **difficulty** (#485) — `care.difficulty`, never populated to date, then
+  `flags.easyCare`. Here the unknown **does not exclude**.
+
+The two rules differ deliberately: hiding a harmless plant denies a choice,
+offering a toxic one breaks a promise.
 
 ## Running the audit
 

--- a/docs/fr/operations/botanical-data-audit.md
+++ b/docs/fr/operations/botanical-data-audit.md
@@ -85,6 +85,38 @@ Le rapport distingue :
 - couverture vérifiée ;
 - plante certifiable sur les champs critiques.
 
+## Outils d'enrichissement
+
+Trois scripts, à lancer dans cet ordre. Aucun n'écrit en base : ils produisent
+un fichier d'opérations que l'on relit avant de l'appliquer par `mongosh`.
+
+```sh
+# 1. Collecter la liste ASPCA (toxicité chiens / chats / chevaux)
+python3 scripts/collect-aspca-toxicity.py          # → aspca.json
+
+# 2. Rapprocher le catalogue et produire les opérations
+python3 scripts/enrich-pet-toxicity.py \
+  --aspca aspca.json --plants plants.json --out ops.json
+
+# 3. Dériver soleil, arrosage et drainage depuis la prose des fiches
+python3 scripts/derive-botanical-profile.py \
+  --plants plants.json --out derived.json
+```
+
+Le fichier de plantes attendu est un export de `GET /plants`, comme pour l'audit.
+
+**Deux règles inscrites dans ces scripts, à ne pas défaire :**
+
+Le rapprochement des noms ne retient que l'espèce exacte, ou une entrée ASPCA en
+`spp.` qui vise le genre entier. Une entrée nommant une **autre** espèce du même
+genre est écartée — `hydrangea arborescens` ne dit rien de *Hydrangea
+macrophylla*. Sans cette règle, 72 fiches recevraient un verdict emprunté.
+
+La dérivation refuse tout fragment mentionnant des centimètres : « arrose quand
+les 2 à 3 premiers centimètres sont secs » décrit une profondeur de sol, pas une
+périodicité. En tirer « tous les 2 à 3 jours » serait une erreur d'un facteur
+cinq, invisible à la relecture.
+
 ## Critères d'acceptation
 
 Une valeur vérifiée possède :

--- a/docs/fr/operations/botanical-data-audit.md
+++ b/docs/fr/operations/botanical-data-audit.md
@@ -2,14 +2,61 @@
 
 ## Référence actuelle
 
-Audit en lecture seule de la collection de production `arbore.plants`, réalisé le 23 juillet 2026 :
+Audit de la collection de production `arbore.plants`, relevé le 9 septembre 2026 :
 
-- 124 plantes au catalogue ;
-- 0 profil `botanicalProfile` ;
-- 0 plante certifiable sur les contraintes critiques ;
-- 0 valeur vérifiée sur 1 860 valeurs possibles (124 plantes × 15 champs).
+```
+124 plantes au catalogue
+123 portent désormais un botanicalProfile
+  0 plante certifiable sur les contraintes critiques
+  0 valeur vérifiée sur 1 860 possibles
+```
 
-Le moteur doit donc afficher au mieux **Probablement compatible** tant que les profils ne sont pas renseignés. Les anciens textes et `PlantFlags` restent des indices faibles et ne permettent jamais d'afficher **Adaptée**.
+Quatre champs ont été renseignés le 9 septembre (#489) :
+
+| Champ | Couverture | Provenance |
+|---|---|---|
+| `petToxicity` | 38/124 | ASPCA, source nommée et datée |
+| `directSunHours` | 121/124 | dérivé de `sun.durationPerDay` |
+| `wateringIntervalDays` | 107/124 | dérivé de `water.frequency` |
+| `drainage` | 110/124 | dérivé de `soilAndPot.substrate` |
+
+**« 0 valeur vérifiée » reste exact, et ce n'est pas une contradiction.** L'audit
+n'accepte que `reliability: high`, réservée par ce document à une relecture par
+un horticulteur ou un botaniste — étape 5 du plan de remplissage. Aucune de ces
+valeurs n'a été relue par un humain.
+
+Le vocabulaire employé le dit :
+
+| Valeur | Signification |
+|---|---|
+| `high` | relue par un humain compétent — **aucune à ce jour** |
+| `authoritative` | source faisant autorité, collectée automatiquement (ASPCA) |
+| `authoritative-genus` | idem, mais le verdict vaut pour le genre, pas l'espèce |
+| `derived` | transcrite depuis la prose de la fiche |
+
+> ⚠️ **Une nuance à trancher.** L'étape 3 du plan demande de « compléter les
+> champs **sans déduire** une valeur absente depuis le texte ». Les trois champs
+> `derived` transcrivent un nombre explicitement écrit — « 6–8 h / jour » devient
+> `{minimum: 6, maximum: 8}` — plutôt qu'ils ne l'infèrent. La frontière est
+> mince et mérite d'être arbitrée : ces valeurs peuvent être conservées comme
+> indices, ou retirées si la règle doit être stricte.
+
+Le moteur doit donc toujours afficher au mieux **Probablement compatible**. Les
+anciens textes et `PlantFlags` restent des indices faibles et ne permettent
+jamais d'afficher **Adaptée**.
+
+## Ce que les filtres consomment déjà
+
+Indépendamment de la certification, deux filtres iOS lisent ces données :
+
+- **sécurité** (#488) — `botanicalProfile.petToxicity` d'abord, `flags.toxicToPets`
+  ensuite. Une toxicité **non établie exclut** la plante quand l'utilisateur
+  demande des plantes sûres : 40 fiches sur 124 subsistent alors ;
+- **difficulté** (#485) — `care.difficulty`, jamais renseigné à ce jour, puis
+  `flags.easyCare`. Ici l'inconnu **n'exclut pas**.
+
+Les deux règles diffèrent délibérément : masquer une plante inoffensive prive
+d'un choix, en proposer une toxique rompt une promesse.
 
 ## Lancer l'audit
 


### PR DESCRIPTION
La référence de `botanical-data-audit.md` datait du 23 juillet et annonçait
0 `botanicalProfile`. Il y en a désormais **123 sur 124**.

```
petToxicity            38/124   ASPCA, source nommée et datée
directSunHours        121/124   dérivé de sun.durationPerDay
wateringIntervalDays  107/124   dérivé de water.frequency
drainage              110/124   dérivé de soilAndPot.substrate
```

## Le chiffre qui n'a pas bougé, et c'est correct

**« 0 valeur vérifiée sur 1 860 » reste exact.** L'audit n'accepte que
`reliability: high`, que ce document réserve à une relecture par un horticulteur
— étape 5 du plan — et dont il **interdit explicitement l'attribution par une
IA**.

Aucune de ces valeurs n'a été relue par un humain. Le vocabulaire le dit plutôt
que de le masquer :

| Valeur | Signification |
|---|---|
| `high` | relue par un humain compétent — **aucune à ce jour** |
| `authoritative` | source faisant autorité, collectée automatiquement |
| `authoritative-genus` | verdict valant pour le genre, pas l'espèce |
| `derived` | transcrite depuis la prose de la fiche |

## Une nuance signalée, pas arbitrée

L'étape 3 du plan demande de compléter les champs « **sans déduire** une valeur
absente depuis le texte ». Les trois champs `derived` transcrivent un nombre
explicitement écrit — « 6–8 h / jour » → `{minimum: 6, maximum: 8}` — plutôt
qu'ils ne l'infèrent.

La frontière est mince, et c'est votre règle. Le document pose la question au
lieu de la trancher : ces valeurs peuvent rester des indices, ou être retirées.

## Ce que les filtres consomment

Nouvelle section sur les deux filtres iOS et leurs règles **opposées** face à
l'inconnu — la sécurité exclut, la difficulté non. Cette asymétrie est
délibérée et se perdrait si elle n'était pas écrite.

Refs #489, #488, #485
