### PR TITLE
feat(ios): rapports de plantage anonymes, et politique de confidentialité 2.4

### DIFF
--- a/ArboreUi/ArboreUi/Config/AppConfig.swift
+++ b/ArboreUi/ArboreUi/Config/AppConfig.swift
@@ -69,10 +69,10 @@ struct AppConfig {
     /// numérique. Ce changement matériel doit être re-consenti.
     /// https://arbore.app/privacy et https://arbore.app/terms. Les nouveaux
     /// consentements sont horodatés avec cette version.
-    static let privacyPolicyVersion = "2.3"
+    static let privacyPolicyVersion = "2.4"
 
     /// Date de dernière mise à jour de la politique
-    static let privacyPolicyLastUpdate = "23 July 2026"
+    static let privacyPolicyLastUpdate = "9 September 2026"
 
     /// URL publique de la politique de confidentialité (FR/EN).
     /// Champ obligatoire App Store Connect + liens in-app.

--- a/ArboreUi/ArboreUi/Config/ConsentDefaults.swift
+++ b/ArboreUi/ArboreUi/Config/ConsentDefaults.swift
@@ -20,7 +20,15 @@ enum ConsentDefaults {
     static let profilePublic = false
     /// Activité masquée par défaut.
     static let showActivity = false
-    /// Diagnostics (Sentry) — opt-in strict (issue #226). Gate effectif : `SentryManager.hasConsent`.
+    /// Diagnostics (Sentry) — opt-in (issue #226), dont la portée a changé
+    /// avec #469 : il ne conditionne plus la COLLECTE mais l'IDENTIFICATION.
+    ///
+    /// Sans consentement, les plantages remontent en régime anonyme : aucun
+    /// identifiant, pas de hiérarchie de vues, pas de fil d'Ariane réseau. Avec,
+    /// l'UID Firebase est joint et permet de corréler plusieurs plantages.
+    ///
+    /// Reste `false` par défaut : le régime enrichi, lui, demande bien un
+    /// consentement explicite.
     static let analytics = false
     /// Marketing — opt-in strict.
     static let marketing = false

--- a/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
+++ b/ArboreUi/ArboreUi/LoginAuth/AppDelegate.swift
@@ -15,9 +15,12 @@ import UserNotifications
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool{
         // Sentry en premier (issue #205), AVANT Firebase, pour capturer aussi un
-        // éventuel crash pendant l'init de Firebase. No-op si pas de DSN ou si
-        // l'utilisateur n'a pas consenti au diagnostic (opt-in RGPD, issue #226) ;
-        // réactivé par SentryManager.updateConsent dès qu'il accepte.
+        // éventuel crash pendant l'init de Firebase. No-op sans DSN.
+        //
+        // Depuis #469, la collecte ne dépend PLUS du consentement : sans lui,
+        // elle tourne en régime anonyme — aucun identifiant, pas de hiérarchie
+        // de vues, pas de fil d'Ariane réseau, pas de traces. Le consentement
+        // n'ajoute que le rattachement à un compte.
         SentryManager.start()
 
         FirebaseApp.configure()

--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -26,25 +26,48 @@ enum SentryManager {
     /// Vrai si l'utilisateur a consenti au partage des données de diagnostic.
     static var hasConsent: Bool { UserDefaults.standard.bool(forKey: consentKey) }
 
-    /// Vrai si le crash reporting doit être actif : DSN présent ET consentement donné.
-    static var isEnabled: Bool { isConfigured && hasConsent }
+    /// Vrai si le crash reporting tourne — DSN présent suffit désormais (#469).
+    ///
+    /// L'opt-in ne conditionne plus la COLLECTE, mais l'IDENTIFICATION. Voir
+    /// `start()` pour ce que cela change concrètement.
+    static var isEnabled: Bool { isConfigured }
 
-    /// Démarre Sentry si (et seulement si) un DSN est configuré ET que
-    /// l'utilisateur a donné son consentement diagnostic. Appelée au tout début
-    /// de `AppDelegate.didFinishLaunchingWithOptions`, AVANT
-    /// `FirebaseApp.configure()`, pour capturer un éventuel crash d'init — mais
-    /// sans consentement c'est un no-op (RGPD : aucune collecte avant opt-in).
-    /// Re-déclenchée par `updateConsent(...)` quand l'utilisateur accepte.
+    /// Démarre Sentry dès qu'un DSN est configuré. Appelée au tout début de
+    /// `AppDelegate.didFinishLaunchingWithOptions`, AVANT `FirebaseApp.configure()`,
+    /// pour capturer un éventuel crash d'initialisation.
+    ///
+    /// ## Deux régimes, et ce qui les sépare
+    ///
+    /// **Sans consentement — anonyme.** Aucun identifiant ne quitte l'appareil :
+    /// ni UID Firebase, ni identifiant d'installation, ni adresse IP. Pas de
+    /// hiérarchie de vues (elle contient les textes affichés), pas de fil
+    /// d'Ariane réseau (les URL portent des identifiants de jardin), pas de
+    /// traces de performance. Il reste la pile d'appel, la version de l'app et
+    /// le modèle d'appareil — de quoi corriger un plantage, pas de quoi
+    /// reconnaître quelqu'un.
+    ///
+    /// **Avec consentement — rattaché.** L'UID Firebase est joint, ce qui permet
+    /// de relier plusieurs plantages au même compte et de répondre à un
+    /// signalement précis. La hiérarchie de vues et les traces reviennent.
+    ///
+    /// ## Pourquoi la collecte anonyme n'attend pas le consentement
+    ///
+    /// Le RGPD porte sur les données à caractère personnel (art. 4). Une donnée
+    /// véritablement anonyme — qui ne permet plus d'identifier une personne, ni
+    /// directement ni par recoupement — sort de son champ (considérant 26).
+    ///
+    /// Le régime anonyme ci-dessous vise ce seuil, et c'est pourquoi il retire
+    /// l'UID : un pseudonyme reste une donnée personnelle, si stable qu'il
+    /// permet de suivre un individu dans le temps.
+    ///
+    /// ⚠️ **Deux conditions ne dépendent pas de ce code et doivent être tenues :**
+    /// la politique de confidentialité doit décrire cette collecte, et le
+    /// réglage Sentry « Prevent Storing of IP Addresses » doit être activé côté
+    /// projet — le SDK n'envoie pas l'IP, mais l'ingest la voit passer.
     static func start() {
         guard isConfigured else {
             #if DEBUG
             print("ℹ️ Sentry désactivé (aucun DSN dans Secrets.xcconfig).")
-            #endif
-            return
-        }
-        guard hasConsent else {
-            #if DEBUG
-            print("ℹ️ Sentry en attente du consentement diagnostic (opt-in RGPD).")
             #endif
             return
         }
@@ -55,24 +78,27 @@ enum SentryManager {
             options.releaseName = AppConfig.sentryReleaseName
             options.dist = AppConfig.buildNumber
 
-            // 10% de transactions de performance : marge confortable sous le
-            // free tier (5k events/mois) pour la beta.
-            options.tracesSampleRate = 0.1
+            let consenti = hasConsent
 
-            // Vie privée : pas de capture d'écran (peut contenir des données
-            // personnelles). La hiérarchie de vues (structure, sans pixels)
-            // reste utile pour diagnostiquer les crashs d'UI.
+            // Traces de performance : seulement avec consentement. Leurs noms de
+            // transaction portent des chemins tels que `/gardens/<id>` — un
+            // identifiant de ressource, donc un fil à tirer. Sans consentement,
+            // seuls les plantages remontent.
+            options.tracesSampleRate = consenti ? 0.1 : 0.0
+
+            // Jamais de capture d'écran : elle peut montrer n'importe quoi.
             options.attachScreenshot = false
-            options.attachViewHierarchy = true
+
+            // La hiérarchie de vues contient les TEXTES affichés — noms de
+            // jardin, de plantes, saisies en cours. Utile pour diagnostiquer un
+            // crash d'UI, incompatible avec l'anonymat.
+            options.attachViewHierarchy = consenti
 
             // Minimisation RGPD : ne jamais joindre les PII collectées « par
             // défaut » par le SDK (adresse IP, etc.).
             options.sendDefaultPii = false
 
-            // Défense en profondeur : on retire explicitement de chaque event
-            // l'IP, l'identité (e-mail/nom) et le payload de requête avant
-            // envoi. On conserve volontairement `user.userId` = UID Firebase,
-            // pseudonyme nécessaire pour corréler les crashs d'un même compte.
+            // Défense en profondeur, appliquée à CHAQUE événement.
             options.beforeSend = { event in
                 event.user?.ipAddress = nil
                 event.user?.email = nil
@@ -81,7 +107,29 @@ enum SentryManager {
                 event.user?.data = nil
                 event.serverName = nil
                 event.request = nil
+
+                // Sans consentement : aucun identifiant, pas même celui que le
+                // SDK génère par installation. `user = nil` les emporte tous.
+                //
+                // C'est CE point qui fait la différence entre « pseudonymisé »
+                // et « anonyme ». Un identifiant stable, même dépourvu de nom,
+                // suit un individu dans le temps — et reste donc une donnée
+                // personnelle.
+                if !consenti {
+                    event.user = nil
+                }
                 return event
+            }
+
+            // Fil d'Ariane : sans consentement, on écarte les traces réseau. Les
+            // URL de l'app portent des identifiants (`/gardens/<id>`,
+            // `/plants/<id>`) qui rattacheraient l'événement à des ressources
+            // précises — donc, par recoupement, à leur propriétaire.
+            options.beforeBreadcrumb = { crumb in
+                if !consenti && (crumb.type == "http" || crumb.category == "http") {
+                    return nil
+                }
+                return crumb
             }
 
             #if DEBUG
@@ -90,23 +138,31 @@ enum SentryManager {
         }
     }
 
-    /// Réagit à un changement du consentement diagnostic depuis
-    /// PrivacySettingsView : démarre Sentry à l'acceptation (et réattache le
-    /// contexte user si l'utilisateur était déjà connecté), le coupe au retrait.
+    /// Réagit à un changement du consentement depuis PrivacySettingsView.
+    ///
+    /// Le retrait ne coupe PLUS la collecte : il la ramène au régime anonyme
+    /// (#469). Sentry est donc redémarré pour que les options — hiérarchie de
+    /// vues, traces, fil d'Ariane réseau — soient réévaluées, et le contexte
+    /// utilisateur est effacé.
+    ///
+    /// Redémarrer plutôt que reconfigurer : `SentrySDK` fige ses options au
+    /// démarrage, et les modifier après coup laisserait la hiérarchie de vues
+    /// active alors que l'utilisateur vient de la refuser.
     static func updateConsent(granted: Bool, uid: String?) {
         guard isConfigured else { return }
-        if granted {
-            if !SentrySDK.isEnabled { start() }
-            if let uid { setUser(uid: uid) }
-        } else {
-            SentrySDK.close()
+        SentrySDK.close()
+        start()
+        if granted, let uid {
+            setUser(uid: uid)
         }
     }
 
     /// Rattache les events au user via son UID Firebase (pseudonyme).
-    /// On n'envoie ni e-mail ni nom à Sentry : minimisation des données (RGPD).
+    ///
+    /// **Sans consentement, c'est un no-op** : le pseudonyme est précisément ce
+    /// qui distingue une donnée anonyme d'une donnée personnelle.
     static func setUser(uid: String) {
-        guard isEnabled else { return }
+        guard isEnabled, hasConsent else { return }
         let user = Sentry.User()        // Sentry.User, à ne pas confondre avec le modèle `User` de l'app
         user.userId = uid
         SentrySDK.setUser(user)

--- a/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
@@ -25,7 +25,8 @@ struct PrivacyPolicyView: View {
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM4", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM5", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM6", comment: ""),
-                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM7", comment: "")
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM7", comment: ""),
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM8", comment: "")
                 ],
                 themeManager: themeManager
             )
@@ -50,7 +51,8 @@ struct PrivacyPolicyView: View {
                     NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM1", comment: ""),
                     String(format: NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM2", comment: ""), brandName),
                     NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM3", comment: ""),
-                    NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM4", comment: "")
+                    NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM4", comment: ""),
+                    NSLocalizedString("PRIVACY_SECTION_LEGAL_ITEM5", comment: "")
                 ],
                 themeManager: themeManager
             )

--- a/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacySettingsView.swift
@@ -41,8 +41,10 @@ struct PrivacySettingsView: View {
                 )
                 .onChange(of: shareData) { _, newValue in
                     recordConsentChange(type: "analytics", granted: newValue)
-                    // Ce toggle gouverne le crash reporting Sentry : on démarre /
-                    // coupe le SDK selon le consentement diagnostic (issue #226).
+                    // Ce réglage ne gouverne plus la COLLECTE mais l'IDENTIFICATION
+                    // (#469) : les plantages remontent de toute façon, en régime
+                    // anonyme. L'activer y ajoute l'UID Firebase. Sentry est
+                    // redémarré pour que ses options soient réévaluées.
                     SentryManager.updateConsent(granted: newValue, uid: Auth.auth().currentUser?.uid)
                 }
             }

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -241,7 +241,7 @@
 "PRIVACY_HEADER_TITLE" = "%@ respektiert deine Privatsphäre.";
 "PRIVACY_HEADER_SUBTITLE" = "Diese Richtlinie erklärt, welche personenbezogenen Daten wir verarbeiten, warum, mit wem, wie lange und welche Rechte du nach der DSGVO hast.";
 "PRIVACY_LAST_UPDATED" = "Zuletzt aktualisiert: %@ — Version %@";
-"PRIVACY_LAST_UPDATED_DATE" = "23. Juli 2026";
+"PRIVACY_LAST_UPDATED_DATE" = "9. September 2026";
 
 // Daten, die wir sammeln
 "PRIVACY_SECTION_DATA_TITLE" = "Daten, die wir verarbeiten";
@@ -252,6 +252,7 @@
 "PRIVACY_SECTION_DATA_ITEM5" = "Bleiben auf deinem Gerät: rohe Kamera- und LiDAR-Bilder, Bewegung und ARKit-Weltkarten. Ein Foto wird nur für Chat oder Diagnose hochgeladen.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Gesundheitsdiagnose & Assistent: Fotos, die du für eine Diagnose sendest, sowie deine Nachrichten werden an unsere Server und anschließend an Google (Gemini) zur Analyse übermittelt, auch außerhalb der Europäischen Union.";
 "PRIVACY_SECTION_DATA_ITEM7" = "Technische Protokolle: Deine IP-Adresse wird verarbeitet, um Missbrauch zu begrenzen und den Dienst abzusichern. Sie wird nie in der Datenbank gespeichert und erscheint in den Server-Protokollen nur gekürzt (zum Beispiel 92.184.105.x).";
+"PRIVACY_SECTION_DATA_ITEM8" = "Absturzberichte: standardmäßig anonym — Aufrufliste, App-Version und Gerätemodell, ohne jede Kennung. Wenn du „Diagnosedaten mit meinem Konto verknüpfen“ aktivierst, wird deine Firebase-Kennung ergänzt, um mehrere Vorfälle zu verknüpfen.";
 
 // Warum wir sie nutzen
 "PRIVACY_SECTION_USAGE_TITLE" = "Warum wir diese Daten nutzen";
@@ -267,6 +268,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Berechtigte Interessen: %@ absichern und verbessern.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Einwilligung: Kamera, Fotos, Standort, Kalender und Mitteilungen.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Gesetzliche Pflicht und Rechenschaftspflicht: Nachweis der Einwilligung aufbewahren.";
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Außerhalb der DSGVO: Anonyme Absturzberichte enthalten keine Daten, die dich identifizierbar machen (Erwägungsgrund 26). Die Verknüpfung mit deinem Konto beruht dagegen auf Einwilligung.";
 
 // Aufbewahrung
 "PRIVACY_SECTION_RETENTION_TITLE" = "Aufbewahrung";
@@ -276,7 +278,7 @@
 
 // Weitergabe
 "PRIVACY_SECTION_SHARING_TITLE" = "Weitergabe & Empfänger";
-"PRIVACY_SECTION_SHARING_ITEM1" = "Auftragsverarbeiter: Firebase und Google (einschließlich Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI und Sentry bei aktivierter Diagnose.";
+"PRIVACY_SECTION_SHARING_ITEM1" = "Auftragsverarbeiter: Firebase und Google (inkl. Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI und Sentry für Absturzberichte.";
 "PRIVACY_SECTION_SHARING_ITEM2" = "Keine Werbung und kein app-übergreifendes Tracking.";
 "PRIVACY_SECTION_SHARING_ITEM3" = "Wir verkaufen deine Daten niemals. Übermittlungen beschränken sich auf das Notwendige und sind vertraglich geregelt.";
 

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -327,8 +327,8 @@
 "PRIVACYSETTINGS_ACTIVITY_TITLE" = "Meine Aktivität anzeigen";
 "PRIVACYSETTINGS_ACTIVITY_SUB" = "Erlaube das Anzeigen deiner letzten Gartenaktivitäten.";
 
-"PRIVACYSETTINGS_DATASHARING_TITLE" = "Daten für Analytics teilen";
-"PRIVACYSETTINGS_DATASHARING_SUB" = "Hilf uns, Funktionen und Zuverlässigkeit zu verbessern. Es werden keine persönlichen Inhalte verkauft.";
+"PRIVACYSETTINGS_DATASHARING_TITLE" = "Diagnosedaten mit meinem Konto verknüpfen";
+"PRIVACYSETTINGS_DATASHARING_SUB" = "Abstürze werden uns immer anonym gemeldet. Wenn du dies aktivierst, wird deine Konto-Kennung ergänzt, um mehrere Vorfälle zu verknüpfen und auf eine konkrete Meldung zu antworten.";
 
 // Privacy Policy link
 "PRIVACYSETTINGS_READ_POLICY" = "Unsere Datenschutzerklärung lesen";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -348,8 +348,8 @@
 "PRIVACYSETTINGS_ACTIVITY_TITLE" = "Show my activity";
 "PRIVACYSETTINGS_ACTIVITY_SUB" = "Allow showing your recent garden updates.";
 
-"PRIVACYSETTINGS_DATASHARING_TITLE" = "Share data for analytics";
-"PRIVACYSETTINGS_DATASHARING_SUB" = "Help us improve features and reliability. No personal content is sold.";
+"PRIVACYSETTINGS_DATASHARING_TITLE" = "Link diagnostics to my account";
+"PRIVACYSETTINGS_DATASHARING_SUB" = "Crashes are always reported anonymously. Turning this on adds your account identifier, so several incidents can be linked and a specific report answered.";
 
 // Privacy Policy link
 "PRIVACYSETTINGS_READ_POLICY" = "Read our Privacy Policy";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -260,7 +260,7 @@
 "PRIVACY_HEADER_TITLE" = "%@ respects your privacy.";
 "PRIVACY_HEADER_SUBTITLE" = "This policy explains what personal data we process, why, with whom, how long we keep it, and the rights you have under the GDPR.";
 "PRIVACY_LAST_UPDATED" = "Last updated: %@ — version %@";
-"PRIVACY_LAST_UPDATED_DATE" = "23 July 2026";
+"PRIVACY_LAST_UPDATED_DATE" = "September 9, 2026";
 
 // Data we collect
 "PRIVACY_SECTION_DATA_TITLE" = "Data we process";
@@ -271,6 +271,7 @@
 "PRIVACY_SECTION_DATA_ITEM5" = "Kept on your device: raw camera and LiDAR images, motion data and ARKit world maps. A photo is uploaded only when you add it to chat or plant diagnosis.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Health diagnosis & assistant: photos you submit for a diagnosis, and your messages, are sent to our servers and then to Google (Gemini) for analysis, including outside the European Union.";
 "PRIVACY_SECTION_DATA_ITEM7" = "Technical logs: your IP address is processed to limit abuse and keep the service secure. It is never stored in the database, and only appears in server logs in truncated form (for example 92.184.105.x).";
+"PRIVACY_SECTION_DATA_ITEM8" = "Crash reports: anonymous by default — call stack, app version and device model, with no identifier at all. If you turn on “Link diagnostics to my account”, your Firebase identifier is added so several incidents can be linked.";
 
 // Why we use it
 "PRIVACY_SECTION_USAGE_TITLE" = "Why we use this data";
@@ -286,6 +287,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Legitimate interests: securing and improving %@.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Consent: camera, photos, location, calendar and notifications.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Legal obligation and accountability: keeping proof of consent.";
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Outside GDPR: anonymous crash reports contain no data allowing you to be identified (recital 26). Linking them to your account, however, relies on consent.";
 
 // Retention
 "PRIVACY_SECTION_RETENTION_TITLE" = "Retention";
@@ -295,7 +297,7 @@
 
 // Sharing
 "PRIVACY_SECTION_SHARING_TITLE" = "Sharing & recipients";
-"PRIVACY_SECTION_SHARING_ITEM1" = "Sub-processors: Firebase and Google (including Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI and Sentry if you enable diagnostics.";
+"PRIVACY_SECTION_SHARING_ITEM1" = "Processors: Firebase and Google (including Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI, and Sentry for crash reports.";
 "PRIVACY_SECTION_SHARING_ITEM2" = "No advertising and no cross-app tracking.";
 "PRIVACY_SECTION_SHARING_ITEM3" = "We never sell your data. Transfers are limited to what is necessary and governed by contract.";
 

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -241,7 +241,7 @@
 "PRIVACY_HEADER_TITLE" = "%@ respeta tu privacidad.";
 "PRIVACY_HEADER_SUBTITLE" = "Esta política explica qué datos personales tratamos, por qué, con quién, durante cuánto tiempo y los derechos que tienes según el RGPD.";
 "PRIVACY_LAST_UPDATED" = "Última actualización: %@ — versión %@";
-"PRIVACY_LAST_UPDATED_DATE" = "23 de julio de 2026";
+"PRIVACY_LAST_UPDATED_DATE" = "9 de septiembre de 2026";
 
 // Datos que recopilamos
 "PRIVACY_SECTION_DATA_TITLE" = "Datos que tratamos";
@@ -252,6 +252,7 @@
 "PRIVACY_SECTION_DATA_ITEM5" = "Permanecen en tu dispositivo: imágenes brutas de cámara y LiDAR, movimiento y mapas ARKit. Solo se envía una foto si la añades al chat o al diagnóstico.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Diagnóstico de salud y asistente: las fotos que envías para un diagnóstico, así como tus mensajes, se transmiten a nuestros servidores y luego a Google (Gemini) para su análisis, incluso fuera de la Unión Europea.";
 "PRIVACY_SECTION_DATA_ITEM7" = "Registros técnicos: tu dirección IP se trata para limitar los abusos y proteger el servicio. Nunca se guarda en la base de datos y solo aparece truncada en los registros del servidor (por ejemplo 92.184.105.x).";
+"PRIVACY_SECTION_DATA_ITEM8" = "Informes de fallos: anónimos por defecto — pila de llamadas, versión de la app y modelo de dispositivo, sin ningún identificador. Si activas «Vincular los diagnósticos a mi cuenta», se añade tu identificador de Firebase para vincular varios incidentes.";
 
 // Por qué los usamos
 "PRIVACY_SECTION_USAGE_TITLE" = "Por qué usamos estos datos";
@@ -267,6 +268,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Intereses legítimos: proteger y mejorar %@.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Consentimiento: cámara, fotos, ubicación, calendario y notificaciones.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Obligación legal y responsabilidad proactiva: conservar la prueba del consentimiento.";
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Fuera del RGPD: los informes de fallos anónimos no contienen datos que permitan identificarte (considerando 26). Vincularlos a tu cuenta sí se basa en el consentimiento.";
 
 // Conservación
 "PRIVACY_SECTION_RETENTION_TITLE" = "Conservación";
@@ -276,7 +278,7 @@
 
 // Compartición
 "PRIVACY_SECTION_SHARING_TITLE" = "Comparticion y destinatarios";
-"PRIVACY_SECTION_SHARING_ITEM1" = "Encargados: Firebase y Google (incluido Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI y Sentry si activas los diagnósticos.";
+"PRIVACY_SECTION_SHARING_ITEM1" = "Encargados: Firebase y Google (incluido Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI y Sentry para los informes de fallos.";
 "PRIVACY_SECTION_SHARING_ITEM2" = "Sin publicidad y sin seguimiento entre aplicaciones.";
 "PRIVACY_SECTION_SHARING_ITEM3" = "Nunca vendemos tus datos. Las transferencias se limitan a lo necesario y están reguladas por contrato.";
 

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -327,8 +327,8 @@
 "PRIVACYSETTINGS_ACTIVITY_TITLE" = "Mostrar mi actividad";
 "PRIVACYSETTINGS_ACTIVITY_SUB" = "Permite mostrar tus actualizaciones recientes del jardín.";
 
-"PRIVACYSETTINGS_DATASHARING_TITLE" = "Compartir datos para analíticas";
-"PRIVACYSETTINGS_DATASHARING_SUB" = "Ayúdanos a mejorar funciones y fiabilidad. No se vende contenido personal.";
+"PRIVACYSETTINGS_DATASHARING_TITLE" = "Vincular los diagnósticos a mi cuenta";
+"PRIVACYSETTINGS_DATASHARING_SUB" = "Los fallos siempre se nos comunican de forma anónima. Activar esto añade tu identificador de cuenta, para vincular varios incidentes y responder a un informe concreto.";
 
 // Privacy Policy link
 "PRIVACYSETTINGS_READ_POLICY" = "Leer nuestra política de privacidad";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -348,8 +348,8 @@
 "PRIVACYSETTINGS_ACTIVITY_TITLE" = "Afficher mon activité";
 "PRIVACYSETTINGS_ACTIVITY_SUB" = "Permet d’afficher tes mises à jour récentes de jardin.";
 
-"PRIVACYSETTINGS_DATASHARING_TITLE" = "Partager des données pour l’analytics";
-"PRIVACYSETTINGS_DATASHARING_SUB" = "Aide-nous à améliorer les fonctionnalités et la fiabilité. Aucun contenu personnel n’est vendu.";
+"PRIVACYSETTINGS_DATASHARING_TITLE" = "Rattacher les diagnostics à mon compte";
+"PRIVACYSETTINGS_DATASHARING_SUB" = "Les plantages nous sont toujours signalés de façon anonyme. Activer ceci y ajoute ton identifiant de compte, pour relier plusieurs incidents et répondre à un signalement précis.";
 
 // Lien vers la politique
 "PRIVACYSETTINGS_READ_POLICY" = "Lire notre politique de confidentialité";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -260,7 +260,7 @@
 "PRIVACY_HEADER_TITLE" = "%@ respecte ta vie privée.";
 "PRIVACY_HEADER_SUBTITLE" = "Cette politique explique quelles données personnelles nous traitons, pourquoi, avec qui, combien de temps, et les droits dont tu disposes au titre du RGPD.";
 "PRIVACY_LAST_UPDATED" = "Dernière mise à jour : %@ — version %@";
-"PRIVACY_LAST_UPDATED_DATE" = "23 juillet 2026";
+"PRIVACY_LAST_UPDATED_DATE" = "9 septembre 2026";
 
 // Données collectées
 "PRIVACY_SECTION_DATA_TITLE" = "Données que nous traitons";
@@ -271,6 +271,7 @@
 "PRIVACY_SECTION_DATA_ITEM5" = "Restent sur ton appareil : images brutes de la caméra et du LiDAR, mouvement et cartes spatiales ARKit. Une photo n’est envoyée que si tu l’ajoutes au chatbot ou au diagnostic.";
 "PRIVACY_SECTION_DATA_ITEM6" = "Diagnostic santé & assistant : les photos que tu envoies pour un diagnostic, ainsi que tes messages, sont transmis à nos serveurs puis à Google (Gemini) pour être analysés, y compris hors de l'Union européenne.";
 "PRIVACY_SECTION_DATA_ITEM7" = "Journaux techniques : ton adresse IP est traitée pour limiter les abus et sécuriser le service. Elle n’est jamais enregistrée en base, et n’apparaît dans les journaux serveur que tronquée (par exemple 92.184.105.x).";
+"PRIVACY_SECTION_DATA_ITEM8" = "Rapports de plantage : anonymes par défaut — pile d’appel, version de l’app et modèle d’appareil, sans aucun identifiant. Si tu actives « Rattacher les diagnostics à mon compte », ton identifiant Firebase y est ajouté pour relier plusieurs incidents.";
 
 // Pourquoi nous les utilisons
 "PRIVACY_SECTION_USAGE_TITLE" = "Pourquoi nous utilisons ces données";
@@ -286,6 +287,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Intérêts légitimes : sécuriser et améliorer %@.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Consentement : caméra, photos, localisation, calendrier et notifications.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Obligation légale et responsabilité : conserver la preuve du consentement.";
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Hors RGPD : les rapports de plantage anonymes ne contiennent aucune donnée permettant de t’identifier (considérant 26). Les rattacher à ton compte relève, lui, du consentement.";
 
 // Conservation
 "PRIVACY_SECTION_RETENTION_TITLE" = "Conservation";
@@ -295,7 +297,7 @@
 
 // Partage
 "PRIVACY_SECTION_SHARING_TITLE" = "Partage & destinataires";
-"PRIVACY_SECTION_SHARING_ITEM1" = "Sous-traitants : Firebase et Google (dont Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI et Sentry si tu actives les diagnostics.";
+"PRIVACY_SECTION_SHARING_ITEM1" = "Sous-traitants : Firebase et Google (dont Gemini), Apple, MongoDB Atlas, Cloudflare, Unsplash, Mistral, OpenAI, et Sentry pour les rapports de plantage.";
 "PRIVACY_SECTION_SHARING_ITEM2" = "Aucune publicité et aucun suivi entre applications.";
 "PRIVACY_SECTION_SHARING_ITEM3" = "Nous ne vendons jamais tes données. Les transferts sont limités au nécessaire et encadrés par contrat.";
 


### PR DESCRIPTION
Promotion de #495.

## Ce que ça change

L'app remonte désormais les plantages **sans attendre le consentement**, en
régime anonyme : aucun identifiant ne quitte l'appareil — ni compte, ni
identifiant d'installation, ni adresse IP. Le consentement ne conditionne plus
la collecte mais l'identification.

Motif : l'iOS n'avait produit **aucun événement en 90 jours**. Le mécanisme
fonctionnait ; c'est le consentement qui n'était jamais donné, faute d'être
proposé.

## L'annonce précède la collecte

La politique de confidentialité a été publiée **avant** cette promotion —
[Arbore_SiteVitrine#5](https://github.com/ArboreTeam/Arbore_SiteVitrine/pull/5),
déjà en ligne. `arbore.app/privacy` est en version 2.4 et décrit les deux
régimes ; les chaînes de l'app suivent la même version.

Trois affirmations y étaient devenues fausses, dont « Sentry — uniquement si
vous activez ce partage ». Elles sont corrigées.

## Périmètre

Cette PR ne touche **que l'app iOS**. Backend et web sont inchangés : les
déploiements serveur aligneront les commits sans modifier de comportement.

Ce qui portera le changement aux utilisateurs, c'est un **build TestFlight** —
le build 28 actuel a l'ancien comportement.

## Vérification restante

Après le premier build incluant cette PR : les événements de `arbore-frontend`
doivent arriver **sans champ `user`**. C'est le seul contrôle qui prouve
l'anonymat en conditions réelles.

Le manque de tests sur cette logique est suivi par #496.

Refs #469
