### PR TITLE
fix(ios): retirer l'identifiant d'installation, et rendre l'anonymisation testable

### DIFF
--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -97,45 +97,70 @@ enum SentryManager {
             // Minimisation RGPD : ne jamais joindre les PII collectées « par
             // défaut » par le SDK (adresse IP, etc.).
             options.sendDefaultPii = false
-
             // Défense en profondeur, appliquée à CHAQUE événement.
-            options.beforeSend = { event in
-                event.user?.ipAddress = nil
-                event.user?.email = nil
-                event.user?.username = nil
-                event.user?.name = nil
-                event.user?.data = nil
-                event.serverName = nil
-                event.request = nil
+            // La logique vit dans `scrub` et `filtrer`, hors de ces closures,
+            // pour être vérifiable sans démarrer le SDK (#496, #498).
+            options.beforeSend = { Self.scrub($0, consenti: consenti) }
+            options.beforeBreadcrumb = { Self.filtrer($0, consenti: consenti) }
 
-                // Sans consentement : aucun identifiant, pas même celui que le
-                // SDK génère par installation. `user = nil` les emporte tous.
-                //
-                // C'est CE point qui fait la différence entre « pseudonymisé »
-                // et « anonyme ». Un identifiant stable, même dépourvu de nom,
-                // suit un individu dans le temps — et reste donc une donnée
-                // personnelle.
-                if !consenti {
-                    event.user = nil
-                }
-                return event
-            }
-
-            // Fil d'Ariane : sans consentement, on écarte les traces réseau. Les
-            // URL de l'app portent des identifiants (`/gardens/<id>`,
-            // `/plants/<id>`) qui rattacheraient l'événement à des ressources
-            // précises — donc, par recoupement, à leur propriétaire.
-            options.beforeBreadcrumb = { crumb in
-                if !consenti && (crumb.type == "http" || crumb.category == "http") {
-                    return nil
-                }
-                return crumb
-            }
 
             #if DEBUG
             options.debug = true
             #endif
         }
+    }
+
+    // MARK: - Anonymisation
+
+    /// Retire d'un événement ce qui pourrait désigner une personne.
+    ///
+    /// Extraite de `start()` pour être vérifiable. La relecture n'avait pas
+    /// suffi : elle avait laissé passer `device_app_hash`, découvert sur le
+    /// premier événement réel (#498). Une closure imbriquée n'est atteignable
+    /// par aucun test.
+    ///
+    /// Dans les DEUX régimes : IP, e-mail, nom, corps de requête.
+    ///
+    /// Sans consentement, deux retraits de plus :
+    ///
+    /// - `user` en entier, ce qui emporte l'UID Firebase et l'identifiant que le
+    ///   SDK génère de lui-même ;
+    /// - `device_app_hash` dans le contexte `app` — un identifiant
+    ///   d'INSTALLATION, stable d'un lancement à l'autre. Il ne vit PAS dans
+    ///   `user`, ce qui l'avait fait échapper au premier correctif.
+    ///
+    /// `app_id` est délibérément CONSERVÉ : vérifié contre le dSYM téléversé,
+    /// c'est l'UUID du binaire, identique pour tous les porteurs d'un même
+    /// build. Le retirer casserait la symbolication sans rien gagner.
+    static func scrub(_ event: Event, consenti: Bool) -> Event {
+        event.user?.ipAddress = nil
+        event.user?.email = nil
+        event.user?.username = nil
+        event.user?.name = nil
+        event.user?.data = nil
+        event.serverName = nil
+        event.request = nil
+
+        guard !consenti else { return event }
+
+        event.user = nil
+        if var contexts = event.context, var app = contexts["app"] {
+            app.removeValue(forKey: "device_app_hash")
+            contexts["app"] = app
+            event.context = contexts
+        }
+        return event
+    }
+
+    /// Écarte les fils d'Ariane qui rattacheraient l'événement à des ressources.
+    ///
+    /// Les URL de l'app portent `/gardens/<id>` et `/plants/<id>` : par
+    /// recoupement, elles désignent leur propriétaire.
+    static func filtrer(_ crumb: Breadcrumb, consenti: Bool) -> Breadcrumb? {
+        if !consenti && (crumb.type == "http" || crumb.category == "http") {
+            return nil
+        }
+        return crumb
     }
 
     /// Réagit à un changement du consentement depuis PrivacySettingsView.

--- a/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
+++ b/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+import Sentry
+@testable import ArboreUi
+
+// SentryAnonymisationTests — issues #496 et #498.
+//
+// Ces tests existent à cause d'un échec précis. Le 9 septembre, #495 a instauré
+// un régime anonyme et j'ai affirmé, après relecture, qu'aucun identifiant ne
+// quittait l'appareil. La politique de confidentialité publique l'a affirmé le
+// lendemain.
+//
+// Le PREMIER événement réel a démenti les deux : `device_app_hash`, un
+// identifiant d'installation stable, passait toujours. Il ne vit pas dans
+// `user` mais dans le contexte `app` — un angle mort que la relecture ne
+// pouvait pas voir, et qu'aucun test ne pouvait attraper puisque la logique
+// vivait dans une closure imbriquée.
+//
+// D'où l'extraction de `scrub` et `filtrer`, et d'où ces tests. Ils gardent une
+// promesse écrite sur arbore.app/privacy — pas une préférence d'implémentation.
+
+final class SentryAnonymisationTests: XCTestCase {
+
+    private func evenement(avecUtilisateur uid: String? = nil,
+                           deviceAppHash: String? = "abc123",
+                           appId: String? = "BCA5EA99-112D-3DF0-BDB4-0D6553E5B2FE") -> Event {
+        let e = Event()
+        if let uid {
+            let u = Sentry.User()
+            u.userId = uid
+            u.email = "quelquun@exemple.fr"
+            u.ipAddress = "92.184.105.12"
+            e.user = u
+        }
+        var app: [String: Any] = [:]
+        if let deviceAppHash { app["device_app_hash"] = deviceAppHash }
+        if let appId { app["app_id"] = appId }
+        e.context = ["app": app]
+        return e
+    }
+
+    private func app(_ e: Event) -> [String: Any] { (e.context?["app"]) ?? [:] }
+
+    // MARK: - Sans consentement : l'anonymat
+
+    /// L'invariant que la politique publique promet.
+    func testSansConsentementAucunUtilisateurNeSubsiste() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "firebase-uid-123"), consenti: false)
+        XCTAssertNil(e.user, "Aucun identifiant de compte ne doit subsister")
+    }
+
+    /// La régression de #498 : `user = nil` ne suffisait pas.
+    func testSansConsentementLIdentifiantDInstallationEstRetire() {
+        let e = SentryManager.scrub(evenement(), consenti: false)
+        XCTAssertNil(app(e)["device_app_hash"],
+                     "device_app_hash est un identifiant d'installation : il doit partir avec le reste")
+    }
+
+    /// L'UUID du binaire reste — il ne désigne pas une personne, et la
+    /// symbolication en dépend.
+    func testLUUIDDuBinaireEstConserve() {
+        let e = SentryManager.scrub(evenement(), consenti: false)
+        XCTAssertEqual(app(e)["app_id"] as? String, "BCA5EA99-112D-3DF0-BDB4-0D6553E5B2FE",
+                       "app_id est l'UUID du binaire, identique pour tous : le retirer casserait la symbolication")
+    }
+
+    /// Un contexte `app` absent ne doit pas faire échouer le nettoyage.
+    func testUnContexteAbsentNeCassePas() {
+        let e = Event()
+        XCTAssertNoThrow(SentryManager.scrub(e, consenti: false))
+    }
+
+    // MARK: - Avec consentement : le régime enrichi
+
+    func testAvecConsentementLIdentifiantDeCompteEstConserve() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "firebase-uid-123"), consenti: true)
+        XCTAssertEqual(e.user?.userId, "firebase-uid-123")
+    }
+
+    /// Même consenti, l'identité directe ne part jamais — minimisation RGPD.
+    func testMemeConsentiNiIPNiEmailNePartent() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: true)
+        XCTAssertNil(e.user?.ipAddress)
+        XCTAssertNil(e.user?.email)
+        XCTAssertNil(e.user?.name)
+        XCTAssertNil(e.user?.username)
+    }
+
+    // MARK: - Fils d'Ariane
+
+    /// Les URL portent `/gardens/<id>` : par recoupement, elles désignent
+    /// leur propriétaire.
+    func testSansConsentementLesTracesReseauSontEcartees() {
+        let c = Breadcrumb()
+        c.type = "http"
+        c.category = "http"
+        XCTAssertNil(SentryManager.filtrer(c, consenti: false))
+    }
+
+    func testAvecConsentementLesTracesReseauPassent() {
+        let c = Breadcrumb()
+        c.type = "http"
+        c.category = "http"
+        XCTAssertNotNil(SentryManager.filtrer(c, consenti: true))
+    }
+
+    /// Les autres fils d'Ariane — navigation, cycle de vie — ne portent pas
+    /// d'identifiant et restent utiles au diagnostic.
+    func testLesAutresFilsDArianePassentDansLesDeuxCas() {
+        let c = Breadcrumb()
+        c.category = "ui.lifecycle"
+        XCTAssertNotNil(SentryManager.filtrer(c, consenti: false))
+        XCTAssertNotNil(SentryManager.filtrer(c, consenti: true))
+    }
+}


### PR DESCRIPTION
Corrige #498. Ferme #496 au passage.

## Ce que le premier événement réel a montré

```
device_app_hash   226da8f729d73d674a481059b0f4c33686566369
app.device        226da8f729d73d674a481059b0f4c33686566369
```

`device_app_hash` est un identifiant d'**installation**, stable d'un lancement à
l'autre. Mon `event.user = nil` de #495 vidait bien l'objet `user` — mais cet
identifiant vit dans le contexte `app`. **La ligne était juste, son périmètre
trop étroit.**

Et `arbore.app/privacy` affirme depuis avant-hier : « aucun identifiant — ni
votre compte, ni un identifiant d'installation ».

## `app_id` est conservé, et c'est vérifié

Le contexte porte aussi `app_id: BCA5EA99-112D-3DF0-BDB4-0D6553E5B2FE`.
Comparé au journal de build :

```
app_id            BCA5EA99-112D-3DF0-BDB4-0D6553E5B2FE
dSYM téléversé    bca5ea99-112d-3df0-bdb4-0d6553e5b2fe
```

C'est l'UUID du **binaire** — identique pour tous les porteurs d'un build, et
indispensable à la symbolication. Le retirer aurait coûté les piles d'appel sans
rien gagner en confidentialité.

## L'anonymisation devient vérifiable

`scrub()` et `filtrer()` sortent de `start()`. La logique vivait dans des
closures imbriquées, atteignables par aucun test — c'est exactement ce que #496
signalait, et ce qui a laissé passer ce défaut.

**9 tests**, et le test central a été vérifié par neutralisation :

```
avec la ligne de retrait     TEST SUCCEEDED
sans la ligne de retrait     TEST FAILED     ← il garde réellement quelque chose
```

Un test qui passe dans les deux cas ne protège de rien. Celui-ci a été éprouvé.

## ⚠️ Ce que ça ne corrige pas

`user.geo` descend au niveau **ville** (« FR, Paris »), ajouté par Sentry
**après** ingestion. Aucun nettoyage côté client ne peut l'atteindre.

Deux issues possibles, aucune dans cette PR :

- une règle *Advanced Data Scrubbing* dans le projet Sentry ;
- ou corriger la politique pour annoncer la localisation approximative.

Tant que ni l'un ni l'autre, **`arbore.app/privacy` reste partiellement
inexact** — moins qu'avant, mais pas exact.

Refs #498, #496, #495
