### PR TITLE
fix(ios): gel de 2 s à la suggestion, et questions du wizard contournables

### DIFF
--- a/ArboreUi/ArboreUi/ARGarden/PlantCatalogView.swift
+++ b/ArboreUi/ArboreUi/ARGarden/PlantCatalogView.swift
@@ -540,7 +540,7 @@ private actor PlantCatalogMemoryCache {
 private enum PlantCatalogBuilder {
     static func index(_ plants: [Plant]) async -> [PlantCatalogIndexedPlant] {
         await Task.detached(priority: .userInitiated) {
-            PlantCatalogTraits.clearSearchableTextCache()
+            PlantCatalogTraits.clearCaches()
             return plants.map { plant in
                 PlantCatalogIndexedPlant(
                     plant: plant,

--- a/ArboreUi/ArboreUi/Models/PlantCatalogContext.swift
+++ b/ArboreUi/ArboreUi/Models/PlantCatalogContext.swift
@@ -1106,6 +1106,39 @@ enum PlantCatalogTraits {
     /// normalized text across all inference families.
     private static let searchableTextCache = NSCache<NSString, NSString>()
 
+    /// Caching the normalized text was not enough: `snapshot(for:)` re-ran every
+    /// inference family on every call — `kinds` alone performs 36 substring
+    /// scans over the plant's prose in all four languages. The garden wizard
+    /// evaluates the whole catalog at once, so the cost landed on the main
+    /// thread as a 2-second hang (#499).
+    ///
+    /// A plant's traits do not change between two evaluations, so the snapshot
+    /// is memoized like the text it derives from. `NSCache` stores objects, and
+    /// the snapshot is a struct, hence the box.
+    private final class SnapshotBox {
+        let value: PlantCatalogTraitsSnapshot
+        init(_ value: PlantCatalogTraitsSnapshot) { self.value = value }
+    }
+
+    private static let snapshotCache = NSCache<NSString, SnapshotBox>()
+
+    /// The identifier alone is not a sound cache key. A snapshot is derived
+    /// from the plant's prose *and* its flags, and the same id can carry a
+    /// different payload within one process — a catalog refresh after the data
+    /// was edited server-side, or two fixtures sharing an id in a test. Folding
+    /// the flags into the key makes the memoization observe what it depends on
+    /// rather than assume it never changes.
+    private static func cacheKey(for plant: Plant) -> NSString {
+        guard let flags = plant.flags else { return "\(plant.id)|-" as NSString }
+        let bits = [
+            flags.toxicToPets, flags.toxicToChildren, flags.easyCare,
+            flags.shadeTolerant, flags.fullSunTolerant, flags.droughtTolerant,
+            flags.humidityLoving, flags.flowering, flags.climbing,
+            flags.trailing, flags.compact, flags.airPurifying
+        ].map { $0 ? "1" : "0" }.joined()
+        return "\(plant.id)|\(bits)" as NSString
+    }
+
     struct SunlightTolerances {
         let shade: Bool
         let fullSun: Bool
@@ -1113,12 +1146,21 @@ enum PlantCatalogTraits {
         var hasKnownValue: Bool { shade || fullSun }
     }
 
-    static func clearSearchableTextCache() {
+    /// Both caches are purged together: a snapshot is derived from the
+    /// searchable text, so keeping one while dropping the other would serve
+    /// traits computed from prose that no longer exists.
+    static func clearCaches() {
         searchableTextCache.removeAllObjects()
+        snapshotCache.removeAllObjects()
     }
 
     static func snapshot(for plant: Plant) -> PlantCatalogTraitsSnapshot {
-        PlantCatalogTraitsSnapshot(
+        let key = cacheKey(for: plant)
+        if let cached = snapshotCache.object(forKey: key) {
+            return cached.value
+        }
+
+        let value = PlantCatalogTraitsSnapshot(
             searchableText: searchableText(for: plant),
             sunlightTolerances: sunlightTolerances(for: plant),
             goals: goals(for: plant),
@@ -1133,6 +1175,9 @@ enum PlantCatalogTraits {
             needsLittlePruning: needsLittlePruning(plant),
             hasLongBloom: hasLongBloom(plant)
         )
+
+        snapshotCache.setObject(SnapshotBox(value), forKey: key)
+        return value
     }
 
     static func searchableText(for plant: Plant) -> String {

--- a/ArboreUi/ArboreUi/Views/GardenSteps/AISuggestionStepView.swift
+++ b/ArboreUi/ArboreUi/Views/GardenSteps/AISuggestionStepView.swift
@@ -27,8 +27,13 @@ struct AISuggestionStepView: View {
     @State private var acceptedPlantIds: Set<String> = []
     @State private var showAllPlants = false
 
-    // Engine
-    private let engine = GardenSuggestionEngine(targetPlantCount: 7)
+    // Engine — built inside the background task, so nothing of it is shared
+    // across threads.
+    private let targetPlantCount = 7
+
+    /// The "AI is thinking" animation has a floor, not an added delay: the
+    /// computation runs during it, and we only wait out whatever is left.
+    private let generationAnimationFloor: TimeInterval = 1.2
 
     // MARK: - Colors
 
@@ -331,6 +336,10 @@ struct AISuggestionStepView: View {
 
     // MARK: - Actions
 
+    /// Explicitly main-actor bound so the `Task` below inherits that context:
+    /// the detached work is the only part that leaves the main thread, and the
+    /// `@State` mutations that follow are guaranteed to come back to it.
+    @MainActor
     private func generateSuggestion() {
         isGenerating = true
 
@@ -353,14 +362,27 @@ struct AISuggestionStepView: View {
                 : state.conditionalAnswers
         ))
 
-        // Simulate a brief "AI thinking" delay for UX delight,
-        // actual computation is < 50ms
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-            let result = engine.suggest(
-                from: dto,
-                plants: allPlants,
-                locale: Locale.current.language.languageCode?.identifier ?? "fr"
-            )
+        // This used to run on the main thread behind a 1.2 s delay, under a
+        // comment claiming the computation took under 50 ms. The first real
+        // Sentry event measured 2 000 ms on an iPhone 17 Pro (#499): ranking
+        // the whole catalog is not view work, and older hardware fares worse.
+        let plants = allPlants
+        let locale = Locale.current.language.languageCode?.identifier ?? "fr"
+        let count = targetPlantCount
+        let floor = generationAnimationFloor
+
+        Task {
+            let startedAt = Date()
+
+            let result = await Task.detached(priority: .userInitiated) {
+                GardenSuggestionEngine(targetPlantCount: count)
+                    .suggest(from: dto, plants: plants, locale: locale)
+            }.value
+
+            let remaining = floor - Date().timeIntervalSince(startedAt)
+            if remaining > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            }
 
             withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
                 self.suggestion = result

--- a/ArboreUi/ArboreUi/Views/GardenSteps/QuestionnaireView.swift
+++ b/ArboreUi/ArboreUi/Views/GardenSteps/QuestionnaireView.swift
@@ -309,6 +309,10 @@ struct GardenWizardView: View {
     @StateObject private var state = GardenWizardState()
     @State private var currentStep: GardenWizardStep = .intro
 
+    /// Sens de la dernière navigation, pour que la transition glisse du bon
+    /// côté. Le geste est parti (#500), l'animation reste.
+    @State private var isMovingForward = true
+
     // Step `scanMethod` déclenche immédiatement l'un de ces deux flows
     // selon la méthode choisie par l'utilisateur :
     // - perimeter → ouvre ARViewContainerMesure pour tracer la boundary
@@ -373,9 +377,55 @@ struct GardenWizardView: View {
         visibleSteps.firstIndex(of: currentStep) ?? 0
     }
 
+    /// L'étape affichée. `soil` reste dans l'énumération même hors jardin :
+    /// `visibleSteps` l'écarte alors de la navigation, donc `currentStep` ne
+    /// peut pas s'y poser.
+    @ViewBuilder
+    private var currentStepView: some View {
+        switch currentStep {
+        case .intro:
+            IntroStepView(onNext: goToNext)
+        case .style:
+            StyleStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .spaceType:
+            SpaceTypeStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .exposure:
+            ExposureStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .maintenance:
+            MaintenanceStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .safety:
+            SafetyStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .soil:
+            SoilStepView(state: state, onNext: goToNext, onBack: goToPrevious)
+        case .scanMethod:
+            ScanMethodStepView(
+                state: state,
+                onStartScan: startScanFlow,
+                onBack: goToPrevious
+            )
+        case .aiSuggestion:
+            AISuggestionStepView(
+                state: state,
+                allPlants: allCataloguePlants,
+                onPlaceInAR: startFinalPlacement(with:),
+                onBack: goToPrevious,
+                selectedPlants: $aiSelectedPlants
+            )
+        }
+    }
+
+    /// Conserve le glissement latéral du style `.page`, dans le sens de la
+    /// navigation : ce qu'on retire, c'est le geste, pas l'animation.
+    private var stepTransition: AnyTransition {
+        isMovingForward
+            ? .asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading))
+            : .asymmetric(insertion: .move(edge: .leading), removal: .move(edge: .trailing))
+    }
+
     private func goToNext() {
         let nextIndex = currentIndex + 1
         if nextIndex < visibleSteps.count {
+            isMovingForward = true
             withAnimation(.easeInOut) { currentStep = visibleSteps[nextIndex] }
         }
     }
@@ -383,6 +433,7 @@ struct GardenWizardView: View {
     private func goToPrevious() {
         let prevIndex = currentIndex - 1
         if prevIndex >= 0 {
+            isMovingForward = false
             withAnimation(.easeInOut) { currentStep = visibleSteps[prevIndex] }
         }
     }
@@ -609,47 +660,25 @@ struct GardenWizardView: View {
                         .padding(.bottom, 12)
                 }
 
-                TabView(selection: $currentStep) {
-                    IntroStepView(onNext: goToNext)
-                        .tag(GardenWizardStep.intro)
-
-                    StyleStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                        .tag(GardenWizardStep.style)
-
-                    SpaceTypeStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                        .tag(GardenWizardStep.spaceType)
-
-                    ExposureStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                        .tag(GardenWizardStep.exposure)
-
-                    MaintenanceStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                        .tag(GardenWizardStep.maintenance)
-
-                    SafetyStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                        .tag(GardenWizardStep.safety)
-
-                    if state.spaceType == .garden {
-                        SoilStepView(state: state, onNext: goToNext, onBack: goToPrevious)
-                            .tag(GardenWizardStep.soil)
-                    }
-
-                    ScanMethodStepView(
-                        state: state,
-                        onStartScan: startScanFlow,
-                        onBack: goToPrevious
-                    )
-                    .tag(GardenWizardStep.scanMethod)
-
-                    AISuggestionStepView(
-                        state: state,
-                        allPlants: allCataloguePlants,
-                        onPlaceInAR: startFinalPlacement(with:),
-                        onBack: goToPrevious,
-                        selectedPlants: $aiSelectedPlants
-                    )
-                    .tag(GardenWizardStep.aiSuggestion)
+                // Une seule étape est montée à la fois, et seuls `goToNext` /
+                // `goToPrevious` la changent.
+                //
+                // C'était auparavant un `TabView` en style `.page`. Sa pagination
+                // au doigt n'était utile à rien — la navigation a toujours été
+                // pilotée par les boutons — mais elle laissait glisser d'une
+                // question à l'autre sans y répondre, jusqu'à la validation
+                // (#500, remonté par un bêta-testeur). Chaque étape verrouille
+                // pourtant son bouton « Continuer » tant qu'aucune réponse n'est
+                // donnée : le glissement était la seule porte dérobée, et sauter
+                // une question ne produisait pas d'erreur mais une recommandation
+                // qui ignorait ce critère en silence.
+                ZStack {
+                    currentStepView
+                        .id(currentStep)
+                        .transition(stepTransition)
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
             }
 
             // bouton close
@@ -767,6 +796,7 @@ struct GardenWizardView: View {
         // ✅ super important: quand tu ré-ouvres un wizard, on repart de 0
         .onAppear {
             currentStep = .intro
+            isMovingForward = true
             state.scanMethod = nil
             // Reset des champs liés au tracé pour éviter qu'un ancien tracé
             // ne soit réutilisé sur une session wizard fraîche (sinon, lors

--- a/ArboreUi/ArboreUiTests/PlantCatalogTraitsCacheTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantCatalogTraitsCacheTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import ArboreUi
+
+// PlantCatalogTraitsCacheTests — issue #499.
+//
+// Le premier événement Sentry réel a mesuré un gel de 2 000 ms à la validation
+// du questionnaire, sur un iPhone 17 Pro. Coupable : `PlantCatalogTraits.snapshot`,
+// qui relançait chaque famille d'inférence à chaque appel — `kinds` seul balaie
+// 36 motifs dans la prose des quatre langues — pour les 124 plantes du catalogue,
+// sur le fil principal.
+//
+// Le texte normalisé était déjà mis en cache ; le snapshot qui en dérive ne
+// l'était pas. Ces tests gardent la mémoïsation qui corrige ça, et la clé qui
+// la rend sûre.
+
+final class PlantCatalogTraitsCacheTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PlantCatalogTraits.clearCaches()
+    }
+
+    override func tearDown() {
+        // Les caches sont globaux au processus : ne pas les rendre ne
+        // laisserait aux tests suivants que des traits fabriqués ici.
+        PlantCatalogTraits.clearCaches()
+        super.tearDown()
+    }
+
+    // MARK: - La mémoïsation existe
+
+    /// Le garde-fou de #499. Il ne mesure pas une durée absolue — elle dépend
+    /// de la machine — mais le rapport entre deux passes sur le même matériel :
+    /// retirer la mémoïsation les ramène au même ordre de grandeur et fait
+    /// échouer le test.
+    func testRelireLesMemesPlantesEstUnOrdreDeGrandeurPlusRapide() throws {
+        // Charge volontairement petite : une inférence complète coûte ~15 ms
+        // par plante, ce qui suffit à creuser un écart net sans facturer des
+        // secondes à la CI. C'est le même ordre de grandeur que l'événement
+        // réel — 124 plantes, 2 000 ms.
+        let plantes = try (0..<6).map { try plante(id: "cache-\($0)") }
+        let passes = 2
+
+        let calcule = duree {
+            for _ in 0..<passes {
+                PlantCatalogTraits.clearCaches()
+                for p in plantes { _ = PlantCatalogTraits.snapshot(for: p) }
+            }
+        }
+
+        for p in plantes { _ = PlantCatalogTraits.snapshot(for: p) }   // préchauffage
+        let memoise = duree {
+            for _ in 0..<passes {
+                for p in plantes { _ = PlantCatalogTraits.snapshot(for: p) }
+            }
+        }
+
+        print("[#499] \(plantes.count) plantes × \(passes) passes — "
+              + "calculées \(Int(calcule * 1000)) ms, mémoïsées \(Int(memoise * 1000)) ms")
+
+        XCTAssertLessThan(
+            memoise * 5, calcule,
+            "Les traits doivent être servis depuis le cache, pas recalculés : "
+            + "\(Int(calcule * 1000)) ms recalculés contre \(Int(memoise * 1000)) ms mémoïsés"
+        )
+    }
+
+    /// Ce que la mémoïsation ne doit surtout pas changer : le résultat.
+    func testLeResultatMemoiseEstIdentiqueAuResultatCalcule() throws {
+        let p = try plante(id: "identique", type: "Arbre d'ornement")
+
+        let calcule = PlantCatalogTraits.snapshot(for: p)
+        let relu = PlantCatalogTraits.snapshot(for: p)
+
+        XCTAssertEqual(relu.searchableText, calcule.searchableText)
+        XCTAssertEqual(relu.kinds, calcule.kinds)
+        XCTAssertEqual(relu.size, calcule.size)
+        XCTAssertEqual(relu.goals, calcule.goals)
+        XCTAssertEqual(relu.habits, calcule.habits)
+    }
+
+    // MARK: - La clé observe ce dont le résultat dépend
+
+    /// L'identifiant seul serait une clé fausse : le snapshot dépend aussi des
+    /// drapeaux, et deux charges différentes peuvent porter le même id — une
+    /// actualisation du catalogue après édition côté serveur, ou deux fixtures
+    /// de test. Sans ce garde-fou, la seconde plante hériterait des traits de
+    /// la première, silencieusement.
+    func testDeuxPlantesDeMemeIdMaisDeDrapeauxDifferentsNePartagentPasLeursTraits() throws {
+        let ombre = try plante(id: "meme-id", shadeTolerant: true)
+        let soleil = try plante(id: "meme-id", fullSunTolerant: true)
+
+        let traitsOmbre = PlantCatalogTraits.snapshot(for: ombre)
+        let traitsSoleil = PlantCatalogTraits.snapshot(for: soleil)
+
+        XCTAssertTrue(traitsOmbre.sunlightTolerances.shade)
+        XCTAssertFalse(traitsOmbre.sunlightTolerances.fullSun)
+        XCTAssertFalse(traitsSoleil.sunlightTolerances.shade)
+        XCTAssertTrue(traitsSoleil.sunlightTolerances.fullSun)
+    }
+
+    /// Une plante sans drapeaux ne doit pas hériter de ceux d'une homonyme.
+    func testUnePlanteSansDrapeauxADroitASaPropreEntree() throws {
+        let avec = try plante(id: "legacy", easyCare: true)
+        let sans = try plante(id: "legacy", includeFlags: false)
+
+        XCTAssertTrue(PlantCatalogTraits.snapshot(for: avec).isEasyCare)
+        XCTAssertNotEqual(
+            PlantCatalogTraits.snapshot(for: sans).isEasyCare,
+            true,
+            "Sans drapeau, la facilité d'entretien se déduit de la prose, pas de l'homonyme"
+        )
+    }
+
+    // MARK: - Outils
+
+    private func duree(_ bloc: () -> Void) -> TimeInterval {
+        let debut = Date()
+        bloc()
+        return Date().timeIntervalSince(debut)
+    }
+
+    /// Une fiche réaliste : c'est la prose des quatre langues qui coûte cher,
+    /// une fixture vide ne mesurerait rien.
+    private func plante(
+        id: String,
+        type: String = "Plante d'intérieur",
+        includeFlags: Bool = true,
+        easyCare: Bool = false,
+        shadeTolerant: Bool = false,
+        fullSunTolerant: Bool = false
+    ) throws -> Plant {
+        var json: [String: Any] = [
+            "id": id,
+            "name": "Plante \(id)",
+            "type": type,
+            "imageURLs": [],
+            "description": "Un feuillage persistant, port buissonnant, "
+                + "appréciant une lumière indirecte et un sol drainant.",
+            "translations": [
+                "fr": traduction(
+                    "Feuillage persistant au port buissonnant, à installer en lumière indirecte.",
+                    type: type, lumiere: "Lumière indirecte vive", duree: "4 à 6 heures par jour"),
+                "en": traduction(
+                    "Evergreen foliage with a bushy habit, best grown in bright indirect light.",
+                    type: "Houseplant", lumiere: "Bright indirect light", duree: "4 to 6 hours a day"),
+                "es": traduction(
+                    "Follaje perenne de porte arbustivo, se cultiva con luz indirecta.",
+                    type: "Planta de interior", lumiere: "Luz indirecta", duree: "4 a 6 horas al día"),
+                "de": traduction(
+                    "Immergrünes Laub mit buschigem Wuchs, für indirektes Licht.",
+                    type: "Zimmerpflanze", lumiere: "Indirektes Licht", duree: "4 bis 6 Stunden täglich")
+            ]
+        ]
+
+        if includeFlags {
+            json["flags"] = [
+                "toxicToPets": false, "toxicToChildren": false,
+                "easyCare": easyCare,
+                "shadeTolerant": shadeTolerant, "fullSunTolerant": fullSunTolerant,
+                "droughtTolerant": false, "humidityLoving": false,
+                "flowering": false, "climbing": false, "trailing": false,
+                "compact": false, "airPurifying": false
+            ]
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(Plant.self, from: data)
+    }
+
+    private func traduction(
+        _ description: String,
+        type: String,
+        lumiere: String,
+        duree: String
+    ) -> [String: Any] {
+        [
+            "description": description,
+            "plantType": type,
+            "sun": ["lightType": lumiere, "durationPerDay": duree],
+            "lifeCycle": ["growth": "Croissance modérée au printemps et en été",
+                          "flowering": "Floraison discrète, estivale"],
+            "care": ["difficulty": "Facile"]
+        ]
+    }
+}


### PR DESCRIPTION
Deux défauts remontés en validant le build 29, indépendants l'un de l'autre.
Ils partent ensemble parce qu'ils voyageront dans le même build.

## #499 — Le gel de 2 secondes

Premier événement réel capté par l'instrumentation Sentry, sur un iPhone 17 Pro :

```
App Hanging: App hanging for at least 2000 ms.
Culprit: PlantCatalogTraits.containsAny
```

Deux causes, corrigées toutes les deux.

**Le calcul était refait à chaque appel.** Le texte normalisé était mis en
cache ; le snapshot qui en dérive ne l'était pas. `snapshot(for:)` relançait
chaque famille d'inférence — `kinds` seul balaie 36 motifs dans la prose des
quatre langues — pour les 124 plantes, à chaque évaluation.

Le snapshot est désormais mémoïsé. **La clé n'est pas le seul identifiant** :
le résultat dépend aussi des drapeaux, et un même id peut porter une charge
différente — une actualisation du catalogue après édition côté serveur, ou deux
fixtures partageant un id. Sans ça, `PlantCatalogContextTests` aurait cassé : il
réutilise `id: "plant"` avec des drapeaux opposés, et la seconde plante aurait
hérité des traits de la première. Silencieusement.

**Le calcul était sur le fil principal.** `generateSuggestion` tournait dans un
`DispatchQueue.main.asyncAfter`, sous ce commentaire :

```swift
// Simulate a brief "AI thinking" delay for UX delight,
// actual computation is < 50ms
```

C'était 2 000 ms. Le calcul passe dans un `Task.detached`, et l'animation
devient un plancher plutôt qu'un délai ajouté : elle tourne pendant le calcul,
on n'attend que ce qui manque.

## #500 — Les questions contournables

Un bêta-testeur a trouvé qu'on pouvait faire défiler horizontalement le
questionnaire pour sauter des questions, puis valider.

Sauter une question ne produisait pas d'erreur. Elle produisait **une
recommandation qui ignorait ce critère sans le dire** : `matchesMaintenance`,
`matchesSafety` et les autres commencent tous par `guard let … else { return
true }`. Un critère absent ne filtre rien.

Gênant surtout pour la sécurité : contourner « éviter les plantes toxiques »
revenait à ne pas poser la question, et #488 ne s'appliquait pas.

Le `TabView` en style `.page` offrait cette pagination gratuitement — et elle
n'a jamais servi : la navigation est pilotée par `goToNext`/`goToPrevious`, et
chaque étape verrouille déjà son « Continuer » tant qu'aucune réponse n'est
donnée. Le glissement était la seule porte dérobée. Elle est fermée ; l'animation
latérale reste et suit maintenant le sens de la navigation.

`safety` fait exception et l'assume : une sélection vide y est une réponse, celle
de qui n'a ni animal ni enfant.

## Vérification

280 tests, 0 échec, sur simulateur local.

Quatre nouveaux tests gardent la mémoïsation. Celui qui la mesure ne compare pas
à une durée absolue — elle dépend de la machine — mais deux passes sur le même
matériel. **Éprouvé par neutralisation** : en retirant l'écriture en cache, il
échoue à 170 ms contre 180 ms, soit aucun gain.

C'est la leçon de #498, appliquée d'emblée : un test qu'on n'a pas vu échouer ne
prouve rien.

## Ce que ça ne fait pas

Le correctif #498 est sur `main` mais **pas chez les testeurs** — le build 29
porte encore le défaut. Un build 30 portera les trois.

Refs #499, #500
