### PR TITLE
docs(observabilité): consigner ce que les premiers événements réels ont trouvé

### DIFF
--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -11,19 +11,37 @@ Crash and performance reporting for Arbore. **iOS**, **web** and the **Go/Gin ba
 
 ---
 
-## Measured state — 2026-09-08
+## Measured state — 2026-09-10
 
 Read from the Sentry organization, not inferred from configuration. Re-measure
 rather than trust: these figures age.
 
-| project | SDK | traffic over 90 days |
+| project | SDK | state |
 |---|---|---|
-| `arbore-frontend` (iOS) | ✅ | **nothing at all** |
-| `frontend-web-arbore` | ✅ | 192,800 spans, 0 errors |
-| `arbore-backend` | ❌ absent from `go.mod` | empty |
+| `arbore-frontend` (iOS) | ✅ | **reporting since build 29** (anonymous regime, #495) |
+| `frontend-web-arbore` | ✅ | 192,800 spans |
+| `arbore-backend` | ✅ since #388 | panics, 5xx and startup failures |
 
-**Zero errors across all three projects.** That is not a sign of health, it is
-the measurement of what is not wired up — see the two sections below.
+### What the instrumentation found on day one
+
+The 2026-09-08 reading showed "zero errors across all three projects". That was
+not a sign of health, it was the measurement of what was not wired up. Two days
+later the first real events delivered three defects no code review had caught:
+
+| event | defect | issue |
+|---|---|---|
+| `App Hanging: 2000 ms` | plant traits recomputed on every call, on the main thread | #499 |
+| first anonymous event | `device_app_hash` was leaving the device without consent | #498 |
+| — | wizard questions skippable by swiping, found validating the same build | #500 |
+
+The second one is the one to remember: **the anonymisation had been declared
+sound after a code review, and the public privacy policy asserted it the next
+day.** A real event contradicted both. A review cannot see what an SDK adds by
+itself.
+
+Hence the rule that now applies to this project: **verify against a real event
+after every build**, and only write into the policy what has been observed
+leaving the device.
 
 A Sentry organization `arbore` also exists, **empty**. It must not be used as a
 destination by mistake: everything lives in `epi-apps`.
@@ -39,16 +57,43 @@ destination by mistake: everything lives in `epi-apps`.
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
 | dSYM upload | `fastlane/Fastfile` → `beta` lane |
 
-`SentryManager` is **disabled until a DSN is configured _and_ the user has explicitly opted in** to diagnostics sharing (the `privacy_shareData` toggle in the privacy settings, **off by default** — GDPR opt-in, #226). Without secrets or consent, the app builds and runs identically (handy for contributors and CI). `start()` is a no-op until consent is given; toggling consent starts/stops the SDK at runtime via `updateConsent(granted:uid:)`. The user context is the **Firebase UID only** (no email or name) and tracks auth state through a single `addStateDidChangeListener` in `AppDelegate`.
+`SentryManager` is **disabled until a DSN is configured**. Without secrets, the
+app builds and runs identically (handy for contributors and CI).
 
-Options set: `environment` (`debug` / `production`, see the next section), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus a `beforeSend` hook that strips IP / email / name / request body from every event (keeping only the UID pseudonym).
+It no longer **depends on consent to start**, however (#469, #495). The
+reasoning: a crash could only be observed on devices whose owners had enabled a
+setting they were never offered, which amounted to observing nothing. So two
+regimes coexist, and consent picks which one applies:
 
-> ⚠️ **Consequence worth knowing: iOS reports nothing.** Zero events in 90 days
-> (measured 2026-09-08). The mechanism works — it is consent that is never
-> given, because it is never offered. The whole chain, DSN and dSYM upload
-> included, is in place and has no effect. A launch crash on a tester's device
-> is today indistinguishable from a tester who does not open the app. Open
-> decision in #469.
+| | without consent | with consent |
+|---|---|---|
+| `user` (Firebase UID) | dropped | kept |
+| `device_app_hash` | **removed** (#498) | kept |
+| network breadcrumbs | discarded | kept |
+| `tracesSampleRate` | `0` | `0.1` |
+| `attachViewHierarchy` | no | yes |
+
+In both regimes: no IP, no email, no name, no request body.
+
+The logic lives in two pure functions, `scrub(_:consenti:)` and
+`filtrer(_:consenti:)`, precisely so it can be tested — it used to sit inside a
+nested closure, which is what made #498 invisible (#496). Nine tests cover it,
+one of them proven by neutralisation.
+
+> ⚠️ **What is still not anonymous: geolocation.** Sentry derives a city from
+> the IP address **after** ingestion. The "Prevent Storing of IP Addresses"
+> setting removes the address, not the position derived from it, and no client
+> code can reach it. It needs either an *Advanced Data Scrubbing* rule on
+> `$user.geo` under `Settings → Security & Privacy`, or an explicit mention on
+> `arbore.app/privacy`. Tracked in #498.
+
+`app_id` is still sent under both regimes: it is the **binary's UUID**, identical
+across every installation of a given build, and symbolication depends on it. It
+designates nobody — unlike `device_app_hash`, which is per-installation.
+
+Other options set: `environment` (`debug` / `production`, see the next section),
+`releaseName = version+build`, `dist = build`, `attachScreenshot = false`
+(privacy), `sendDefaultPii = false`.
 
 ### iOS setup (one-shot)
 
@@ -80,6 +125,11 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug` and with the Firebase UID.
 4. For symbolicated **release** crashes, ship a `fastlane beta` build with the token above, then trigger a crash on the TestFlight build.
 
+**And the check that actually matters**: after every shipped build, open a real
+event and read its raw JSON — `user`, the `app` context, the breadcrumbs. That
+reading, not CI, is what found #498. Tests guarantee the code removes what it
+was told to remove; they will never tell you nothing else remains.
+
 ## ⚠️ Environment vocabulary is not unified
 
 The three components do not tag their events the same way. This is a known
@@ -109,8 +159,9 @@ which backend it targets. The defect is that `AppConfig.environment` does not
 look at it — it keys off `#if DEBUG`, which `Dev` inherits anyway. **Wrong
 criterion, not missing information.**
 
-No effect today, iOS reporting nothing (see above), but it is a trap armed for
-the day it does.
+That trap is now **fully armed**: since build 29, iOS reports. An event coming
+from a `Dev` build is today indistinguishable from one coming from a `Debug`
+build, even though they target two different backends.
 
 ---
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -11,19 +11,38 @@ Reporting de crashs et de performance pour Arbore. **iOS**, **web** et **backend
 
 ---
 
-## État mesuré — 2026-09-08
+## État mesuré — 2026-09-10
 
 Relevé dans l'organisation Sentry, pas déduit de la configuration. À refaire
 plutôt qu'à croire : ces chiffres vieillissent.
 
-| projet | SDK | trafic sur 90 jours |
+| projet | SDK | état |
 |---|---|---|
-| `arbore-frontend` (iOS) | ✅ | **rien** |
-| `frontend-web-arbore` | ✅ | 192 800 spans, 0 erreur |
-| `arbore-backend` | ❌ absent de `go.mod` | vide |
+| `arbore-frontend` (iOS) | ✅ | **remonte depuis le build 29** (régime anonyme, #495) |
+| `frontend-web-arbore` | ✅ | 192 800 spans |
+| `arbore-backend` | ✅ depuis #388 | panics, 5xx et échecs de démarrage |
 
-**Zéro erreur pour les trois projets.** Ce n'est pas un signe de bonne santé,
-c'est la mesure de ce qui n'est pas branché — voir les deux sections suivantes.
+### Ce que l'instrumentation a trouvé dès le premier jour
+
+Le relevé du 2026-09-08 affichait « zéro erreur pour les trois projets ». Ce
+n'était pas un signe de bonne santé, c'était la mesure de ce qui n'était pas
+branché. Deux jours plus tard, les premiers événements réels ont livré trois
+défauts qu'aucune relecture n'avait vus :
+
+| événement | défaut | issue |
+|---|---|---|
+| `App Hanging: 2000 ms` | traits de plante recalculés à chaque appel, sur le fil principal | #499 |
+| premier événement anonyme | `device_app_hash` quittait l'appareil sans consentement | #498 |
+| — | questions du wizard sautables au doigt, trouvé en validant le même build | #500 |
+
+Le second mérite d'être retenu : **l'anonymisation avait été déclarée conforme
+après relecture, et la politique publique l'avait affirmée le lendemain.** C'est
+l'événement réel qui a démenti les deux. Une relecture ne voit pas ce qu'un SDK
+ajoute lui-même.
+
+D'où la règle qui vaut maintenant pour ce projet : **vérifier sur un événement
+réel après chaque build**, et n'écrire dans la politique que ce qui a été
+observé sortir de l'appareil.
 
 Une organisation Sentry `arbore` existe aussi, **vide**. Elle ne doit pas servir
 de destination par erreur : tout vit dans `epi-apps`.
@@ -39,16 +58,45 @@ de destination par erreur : tout vit dans `epi-apps`.
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
 | Upload dSYM | `fastlane/Fastfile` → lane `beta` |
 
-`SentryManager` est **désactivé tant qu'un DSN n'est pas configuré _et_ que l'utilisateur n'a pas explicitement opté** pour le partage de diagnostics (toggle `privacy_shareData` dans les réglages de confidentialité, **off par défaut** — opt-in RGPD, #226). Sans secrets ni consentement, l'app se build et tourne à l'identique (pratique pour les contributeurs et la CI). `start()` est un no-op jusqu'au consentement ; basculer le consentement démarre/arrête le SDK à chaud via `updateConsent(granted:uid:)`. Le contexte utilisateur est l'**UID Firebase uniquement** (ni email ni nom) et suit l'état d'auth via un unique `addStateDidChangeListener` dans `AppDelegate`.
+`SentryManager` est **désactivé tant qu'un DSN n'est pas configuré**. Sans
+secrets, l'app se build et tourne à l'identique (pratique pour les contributeurs
+et la CI).
 
-Options posées : `environment` (`debug` / `production`, cf. la section suivante), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (vie privée), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus un hook `beforeSend` qui retire IP / email / nom / corps de requête de chaque événement (ne conserve que le pseudonyme UID).
+Il ne dépend en revanche **plus du consentement pour démarrer** (#469, #495).
+Le raisonnement : un crash ne pouvait être observé que chez les utilisateurs
+ayant activé un réglage qu'on ne leur proposait jamais, ce qui revenait à ne
+rien observer. Deux régimes coexistent donc, et le consentement choisit lequel :
 
-> ⚠️ **Conséquence à connaître : l'iOS ne remonte rien.** Zéro événement en
-> 90 jours (mesuré le 2026-09-08). Le mécanisme fonctionne — c'est le
-> consentement qui n'est jamais donné, faute d'être proposé. Toute la chaîne,
-> DSN et upload dSYM compris, est en place et sans effet. Un crash au lancement
-> chez un testeur est aujourd'hui indiscernable d'un testeur qui n'ouvre pas
-> l'app. Arbitrage ouvert dans #469.
+| | sans consentement | avec consentement |
+|---|---|---|
+| `user` (UID Firebase) | supprimé | conservé |
+| `device_app_hash` | **retiré** (#498) | conservé |
+| fils d'Ariane réseau | écartés | conservés |
+| `tracesSampleRate` | `0` | `0.1` |
+| `attachViewHierarchy` | non | oui |
+
+Dans les deux régimes : ni IP, ni email, ni nom, ni corps de requête.
+
+La logique vit dans deux fonctions pures, `scrub(_:consenti:)` et
+`filtrer(_:consenti:)`, précisément pour être testable — elle était auparavant
+enfouie dans une closure imbriquée, et c'est ce qui avait rendu #498 invisible
+(#496). Neuf tests la couvrent, dont un éprouvé par neutralisation.
+
+> ⚠️ **Ce qui n'est toujours pas anonyme : la géolocalisation.** Sentry déduit
+> une ville de l'adresse IP **après** ingestion. Le réglage « Prevent Storing of
+> IP Addresses » supprime l'adresse, pas la position qui en a été tirée, et
+> aucun code client ne peut l'atteindre. Il faut soit une règle *Advanced Data
+> Scrubbing* sur `$user.geo` dans `Settings → Security & Privacy`, soit
+> l'annoncer sur `arbore.app/privacy`. Suivi dans #498.
+
+`app_id` reste envoyé dans les deux régimes : c'est l'**UUID du binaire**,
+identique pour toutes les installations d'un même build, et la symbolication en
+dépend. Il ne désigne personne — contrairement à `device_app_hash`, qui est
+propre à l'installation.
+
+Autres options posées : `environment` (`debug` / `production`, cf. la section
+suivante), `releaseName = version+build`, `dist = build`, `attachScreenshot =
+false` (vie privée), `sendDefaultPii = false`.
 
 ### Setup iOS (one-shot)
 
@@ -80,6 +128,12 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug` et avec l'UID Firebase.
 4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
 
+**Et la vérification qui compte vraiment** : après chaque build livré, ouvrir un
+événement réel et lire son JSON brut — `user`, le contexte `app`, les fils
+d'Ariane. C'est cette lecture, et non la CI, qui a trouvé #498. Les tests
+garantissent que le code retire ce qu'on lui a demandé de retirer ; ils ne
+diront jamais qu'il ne reste rien d'autre.
+
 ## ⚠️ Le vocabulaire des environnements n'est pas unifié
 
 Les trois composants n'étiquettent pas leurs événements de la même façon. C'est
@@ -109,8 +163,9 @@ configuration : l'app sait parfaitement quel backend elle vise. Le défaut est
 que `AppConfig.environment` ne le regarde pas — elle se fonde sur `#if DEBUG`,
 que `Dev` hérite de toute façon. **Mauvais critère, pas information manquante.**
 
-Sans effet aujourd'hui, l'iOS ne remontant rien (voir plus haut), mais c'est un
-piège armé pour le jour où il remontera.
+Ce piège est désormais **armé pour de bon** : depuis le build 29, l'iOS remonte.
+Un événement venu d'un build `Dev` est aujourd'hui indiscernable d'un événement
+venu d'un build `Debug`, alors qu'ils visent deux backends différents.
 
 ---
 


### PR DESCRIPTION
`docs/*/operations/observability.md` décrivait un régime iOS qui n'existe plus
depuis #495, et affirmait deux choses fausses depuis le build 29 :

> `SentryManager` est **désactivé tant qu'un DSN n'est pas configuré _et_ que
> l'utilisateur n'a pas explicitement opté** […]

> ⚠️ **Conséquence à connaître : l'iOS ne remonte rien.**

C'est exactement la classe d'écart qui a produit #498 : une description
plausible, jamais confrontée à ce qui sort réellement de l'appareil.

## Ce qui est consigné

**Les deux régimes**, dans un tableau — sans consentement, `user` et
`device_app_hash` partent, les fils d'Ariane réseau sont écartés, `tracesSampleRate`
tombe à `0`. Dans les deux : ni IP, ni email, ni nom, ni corps de requête.

**Que `app_id` reste envoyé, et pourquoi.** C'est l'UUID du binaire, identique
pour toutes les installations d'un build, et la symbolication en dépend. Il ne
désigne personne — contrairement à `device_app_hash`. Écrit noir sur blanc pour
qu'on ne le retire pas par excès de zèle.

**Que la géolocalisation n'est toujours pas anonyme**, et que le correctif est
hors du dépôt : Sentry déduit la ville de l'IP après ingestion.

**Les trois défauts trouvés en deux jours** — #498, #499, #500 — avec ce qu'il
faut en retenir : l'anonymisation avait été déclarée conforme après relecture, et
la politique publique l'avait affirmée le lendemain. Le premier événement réel a
démenti les deux.

## Deux corrections de fond

Le piège des étiquettes d'environnement passe de « sans effet aujourd'hui » à
**« armé »** : `Debug` et `Dev` remontent sous le même nom `debug` alors qu'ils
visent deux backends différents, et l'iOS remonte maintenant pour de bon.

La section « Vérifier (iOS) » gagne l'étape qui compte : **lire le JSON brut d'un
événement réel après chaque build**. C'est elle, et non la CI, qui a trouvé #498.
Les tests garantissent que le code retire ce qu'on lui a demandé de retirer ; ils
ne diront jamais qu'il ne reste rien d'autre.

FR et EN à parité.

Refs #495, #498, #499, #500
