### PR TITLE
fix(ios): taire Sentry sous XCTest, qui envoyait de faux plantages en production

### DIFF
--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -26,11 +26,30 @@ enum SentryManager {
     /// Vrai si l'utilisateur a consenti au partage des données de diagnostic.
     static var hasConsent: Bool { UserDefaults.standard.bool(forKey: consentKey) }
 
-    /// Vrai si le crash reporting tourne — DSN présent suffit désormais (#469).
+    /// Vrai si le processus courant est piloté par XCTest.
+    ///
+    /// Depuis #469, un DSN suffit à démarrer le SDK. Or les tests instancient
+    /// `AppDelegate`, donc toute machine dont le `Secrets.xcconfig` porte un DSN
+    /// émettait à chaque exécution de la suite — et le lancement du runner
+    /// XCTest est assez lent pour déclencher le détecteur d'app hangs. Résultat
+    /// dans Sentry : un « App Hanging for at least 2000 ms » dont la pile est
+    /// celle de `_XCTestMain`, indiscernable d'un gel chez un testeur tant qu'on
+    /// ne l'a pas lue (#506).
+    ///
+    /// Un test ne doit pas pouvoir écrire dans l'observabilité de production.
+    ///
+    /// La variable est posée par le harnais XCTest lui-même : elle est absente
+    /// de l'app livrée, et sa lecture ne coûte rien.
+    static var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
+    /// Vrai si le crash reporting tourne — DSN présent suffit désormais (#469),
+    /// sauf sous XCTest (#506).
     ///
     /// L'opt-in ne conditionne plus la COLLECTE, mais l'IDENTIFICATION. Voir
     /// `start()` pour ce que cela change concrètement.
-    static var isEnabled: Bool { isConfigured }
+    static var isEnabled: Bool { isConfigured && !isRunningTests }
 
     /// Démarre Sentry dès qu'un DSN est configuré. Appelée au tout début de
     /// `AppDelegate.didFinishLaunchingWithOptions`, AVANT `FirebaseApp.configure()`,
@@ -65,6 +84,13 @@ enum SentryManager {
     /// réglage Sentry « Prevent Storing of IP Addresses » doit être activé côté
     /// projet — le SDK n'envoie pas l'IP, mais l'ingest la voit passer.
     static func start() {
+        guard !isRunningTests else {
+            #if DEBUG
+            print("ℹ️ Sentry désactivé (exécution sous XCTest — cf. #506).")
+            #endif
+            return
+        }
+
         guard isConfigured else {
             #if DEBUG
             print("ℹ️ Sentry désactivé (aucun DSN dans Secrets.xcconfig).")

--- a/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
+++ b/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
@@ -103,6 +103,24 @@ final class SentryAnonymisationTests: XCTestCase {
         XCTAssertNotNil(SentryManager.filtrer(c, consenti: true))
     }
 
+    // MARK: - Muet sous XCTest (#506)
+
+    /// Ce test s'exécute sous XCTest, donc il vérifie la détection dans le seul
+    /// contexte où elle compte. Casser le mécanisme le fait échouer.
+    func testLaPresenceDuHarnaisDeTestEstDetectee() {
+        XCTAssertTrue(SentryManager.isRunningTests,
+                      "Le harnais XCTest pose XCTestConfigurationFilePath : ne pas le voir, "
+                      + "c'est réémettre de faux plantages depuis la suite de tests")
+    }
+
+    /// L'invariant réel : un test ne doit pas pouvoir écrire dans
+    /// l'observabilité de production, DSN configuré ou non.
+    func testLeSDKResteEteintPendantLesTests() {
+        XCTAssertFalse(SentryManager.isEnabled,
+                       "Un DSN présent dans Secrets.xcconfig ne doit pas suffire à faire "
+                       + "émettre la suite de tests (#506)")
+    }
+
     /// Les autres fils d'Ariane — navigation, cycle de vie — ne portent pas
     /// d'identifiant et restent utiles au diagnostic.
     func testLesAutresFilsDArianePassentDansLesDeuxCas() {


### PR DESCRIPTION
Corrige #506.

## Le défaut

`ARBORE-FRONTEND-5` — « App Hanging for at least 2000 ms », 2 occurrences,
`environment: debug`, `release: 0.1.12+25`, `build_type: "simulator"`.

Ce n'était pas un utilisateur. C'était un `xcodebuild test` :

```
at RunTestsFromRunLoop
at _XCTestMain
at -[XCTestDriver run]
at +[XCTInProcessSymbolicationService registerSharedServiceWithConfiguration:]
```

Le gel mesuré est celui du **runner XCTest qui démarre**, pas celui de l'app.

## Pourquoi

Depuis #469 le SDK ne dépend plus du consentement : un DSN suffit. Les tests
instancient `AppDelegate`, donc toute machine dont le `Secrets.xcconfig` porte un
DSN émettait à chaque exécution de la suite.

**La CI n'a jamais été concernée** — `ci.yml` ne fournit aucune variable Sentry,
vérifié. Ce sont les machines de développement qui émettaient : celles qui
lancent la suite le plus souvent.

## Pourquoi ça comptait

Le motif de #469 à l'identique : du bruit qui ressemble à un signal. Le même
jour, deux vrais gels remontaient (#499) — un événement de test s'y confond tant
qu'on n'a pas lu sa pile, et une alerte réglée sur les app hangs se déclencherait
sur des runs de tests.

Un test ne doit pas pouvoir écrire dans l'observabilité de production.

## Le correctif

`start()` sort immédiatement sous XCTest, **avant même de regarder le DSN**. La
détection lit `XCTestConfigurationFilePath`, posée par le harnais lui-même :
absente de l'app livrée, sans coût à l'exécution.

Deux options avaient été écartées : désactiver le tracker d'app hangs en `debug`
priverait les builds Debug d'un signal parfois utile ; un DSN de développement
distinct serait correct mais ajoute un projet Sentry à administrer pour un
problème que trois lignes règlent.

## Vérification

11 tests verts sur `SentryAnonymisationTests`, dont deux nouveaux. Ils
s'exécutent sous XCTest, donc ils vérifient la détection **dans le seul contexte
où elle compte** — casser le mécanisme les fait échouer.

Et la vérification à l'identique, puisque c'est la règle qu'on s'est donnée : un
run du même type (`-only-testing` sur une classe) avait produit **2 événements**
à 11:36 UTC. Après correction, le même geste en produit **0**.

## Suite

Les deux événements de `ARBORE-FRONTEND-5` restent à supprimer ou ignorer dans
Sentry — les laisser fausserait le premier relevé de #469.

Refs #469, #495, #499
