### PR TITLE
docs(ios): annoncer dans l'app la localisation déduite par Sentry

### DIFF
--- a/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
+++ b/ArboreUi/ArboreUi/Views/Profile/PrivacyPolicyView.swift
@@ -26,7 +26,11 @@ struct PrivacyPolicyView: View {
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM5", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM6", comment: ""),
                     NSLocalizedString("PRIVACY_SECTION_DATA_ITEM7", comment: ""),
-                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM8", comment: "")
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM8", comment: ""),
+                    // Localisation déduite par Sentry après ingestion : ni le
+                    // SDK ni une règle de scrubbing ne peuvent l'empêcher, donc
+                    // elle s'annonce (#498).
+                    NSLocalizedString("PRIVACY_SECTION_DATA_ITEM9", comment: "")
                 ],
                 themeManager: themeManager
             )

--- a/ArboreUi/ArboreUi/de.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/de.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "PRIVACY_SECTION_DATA_ITEM7" = "Technische Protokolle: Deine IP-Adresse wird verarbeitet, um Missbrauch zu begrenzen und den Dienst abzusichern. Sie wird nie in der Datenbank gespeichert und erscheint in den Server-Protokollen nur gekürzt (zum Beispiel 92.184.105.x).";
 "PRIVACY_SECTION_DATA_ITEM8" = "Absturzberichte: standardmäßig anonym — Aufrufliste, App-Version und Gerätemodell, ohne jede Kennung. Wenn du „Diagnosedaten mit meinem Konto verknüpfen“ aktivierst, wird deine Firebase-Kennung ergänzt, um mehrere Vorfälle zu verknüpfen.";
 
+"PRIVACY_SECTION_DATA_ITEM9" = "Ungefährer Standort: Sentry leitet aus der Verbindung, die den Bericht sendet, ein Land und eine Stadt ab. Die App sendet ihn nie; deine IP-Adresse wird nicht gespeichert. Das gilt auch für anonyme Berichte.";
 // Warum wir sie nutzen
 "PRIVACY_SECTION_USAGE_TITLE" = "Warum wir diese Daten nutzen";
 "PRIVACY_SECTION_USAGE_ITEM1" = "Die Kernfunktionen von %@ bereitstellen: Gärten in AR erstellen, speichern und wiederherstellen.";

--- a/ArboreUi/ArboreUi/en.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/en.lproj/Localizable.strings
@@ -273,6 +273,7 @@
 "PRIVACY_SECTION_DATA_ITEM7" = "Technical logs: your IP address is processed to limit abuse and keep the service secure. It is never stored in the database, and only appears in server logs in truncated form (for example 92.184.105.x).";
 "PRIVACY_SECTION_DATA_ITEM8" = "Crash reports: anonymous by default — call stack, app version and device model, with no identifier at all. If you turn on “Link diagnostics to my account”, your Firebase identifier is added so several incidents can be linked.";
 
+"PRIVACY_SECTION_DATA_ITEM9" = "Approximate location: Sentry derives a country and city from the connection that sends the report. The app never sends it; your IP address itself is not retained. This happens even on anonymous reports.";
 // Why we use it
 "PRIVACY_SECTION_USAGE_TITLE" = "Why we use this data";
 "PRIVACY_SECTION_USAGE_ITEM1" = "Provide %@’s core features: create, save and restore your gardens in AR.";
@@ -287,8 +288,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Legitimate interests: securing and improving %@.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Consent: camera, photos, location, calendar and notifications.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Legal obligation and accountability: keeping proof of consent.";
-"PRIVACY_SECTION_LEGAL_ITEM5" = "Outside GDPR: anonymous crash reports contain no data allowing you to be identified (recital 26). Linking them to your account, however, relies on consent.";
-
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Outside GDPR: anonymous crash reports are considered to contain no data allowing you to be identified (recital 26) — no account, no installation identifier, no IP address, and the derived location stays at city level. Linking them to your account, however, relies on consent.";
 // Retention
 "PRIVACY_SECTION_RETENTION_TITLE" = "Retention";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Your account, profile and gardens are kept while your account exists.";

--- a/ArboreUi/ArboreUi/es.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/es.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "PRIVACY_SECTION_DATA_ITEM7" = "Registros técnicos: tu dirección IP se trata para limitar los abusos y proteger el servicio. Nunca se guarda en la base de datos y solo aparece truncada en los registros del servidor (por ejemplo 92.184.105.x).";
 "PRIVACY_SECTION_DATA_ITEM8" = "Informes de fallos: anónimos por defecto — pila de llamadas, versión de la app y modelo de dispositivo, sin ningún identificador. Si activas «Vincular los diagnósticos a mi cuenta», se añade tu identificador de Firebase para vincular varios incidentes.";
 
+"PRIVACY_SECTION_DATA_ITEM9" = "Ubicación aproximada: Sentry deduce un país y una ciudad a partir de la conexión que envía el informe. La app nunca la envía; tu dirección IP no se conserva. Esto ocurre incluso en los informes anónimos.";
 // Por qué los usamos
 "PRIVACY_SECTION_USAGE_TITLE" = "Por qué usamos estos datos";
 "PRIVACY_SECTION_USAGE_ITEM1" = "Ofrecer las funciones principales de %@: crear, guardar y restaurar tus jardines en RA.";

--- a/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
+++ b/ArboreUi/ArboreUi/fr.lproj/Localizable.strings
@@ -273,6 +273,7 @@
 "PRIVACY_SECTION_DATA_ITEM7" = "Journaux techniques : ton adresse IP est traitée pour limiter les abus et sécuriser le service. Elle n’est jamais enregistrée en base, et n’apparaît dans les journaux serveur que tronquée (par exemple 92.184.105.x).";
 "PRIVACY_SECTION_DATA_ITEM8" = "Rapports de plantage : anonymes par défaut — pile d’appel, version de l’app et modèle d’appareil, sans aucun identifiant. Si tu actives « Rattacher les diagnostics à mon compte », ton identifiant Firebase y est ajouté pour relier plusieurs incidents.";
 
+"PRIVACY_SECTION_DATA_ITEM9" = "Localisation approximative : Sentry déduit un pays et une ville de la connexion qui transmet le rapport. L’app ne l’envoie jamais ; ton adresse IP, elle, n’est pas conservée. Cette déduction a lieu même sur les rapports anonymes.";
 // Pourquoi nous les utilisons
 "PRIVACY_SECTION_USAGE_TITLE" = "Pourquoi nous utilisons ces données";
 "PRIVACY_SECTION_USAGE_ITEM1" = "Fournir les fonctionnalités principales de %@ : créer, sauvegarder et réafficher tes jardins en RA.";
@@ -287,8 +288,7 @@
 "PRIVACY_SECTION_LEGAL_ITEM2" = "Intérêts légitimes : sécuriser et améliorer %@.";
 "PRIVACY_SECTION_LEGAL_ITEM3" = "Consentement : caméra, photos, localisation, calendrier et notifications.";
 "PRIVACY_SECTION_LEGAL_ITEM4" = "Obligation légale et responsabilité : conserver la preuve du consentement.";
-"PRIVACY_SECTION_LEGAL_ITEM5" = "Hors RGPD : les rapports de plantage anonymes ne contiennent aucune donnée permettant de t’identifier (considérant 26). Les rattacher à ton compte relève, lui, du consentement.";
-
+"PRIVACY_SECTION_LEGAL_ITEM5" = "Hors RGPD : les rapports de plantage anonymes sont considérés comme ne contenant aucune donnée permettant de t’identifier (considérant 26) — ni compte, ni identifiant d’installation, ni adresse IP, et la localisation déduite reste à l’échelle d’une ville. Les rattacher à ton compte relève, lui, du consentement.";
 // Conservation
 "PRIVACY_SECTION_RETENTION_TITLE" = "Conservation";
 "PRIVACY_SECTION_RETENTION_ITEM1" = "Ton compte, ton profil et tes jardins sont conservés tant que ton compte existe.";


### PR DESCRIPTION
Miroir dans l'app de la version 2.5 de `arbore.app/privacy`
(ArboreTeam/Arbore_SiteVitrine#6). Les deux textes doivent dire la même chose —
sans quoi celui que l'utilisateur lit dans l'app devient le plus faux des deux.

## Le défaut

`PRIVACY_SECTION_DATA_ITEM8` énumérait le contenu d'un rapport anonyme et
concluait **« sans aucun identifiant »**. Sentry y ajoute un pays et une ville.

Mesuré le 2026-09-10 sur un événement de contrôle :

```
user.geo: FR, Paris, France
```

Sur un rapport anonyme. Deux règles *Advanced Data Scrubbing* n'y changent rien :
la géolocalisation est dérivée **après** le scrubbing.

## Le contenu

- **`ITEM9`**, nouveau, dans les quatre langues (fr / en / es / de), affiché par
  `PrivacyPolicyView` ;
- **`LEGAL_ITEM5`** passe de « hors RGPD » à « **considérés** hors RGPD », en
  précisant ce que les rapports ne portent pas et que la localisation reste à
  l'échelle d'une ville.

Ce dernier point mérite d'être explicite : c'est une appréciation juridique, pas
un constat technique. La formuler comme un constat n'était plus tenable une fois
la ville connue.

## Ce que le texte ne dit pas

Qu'on ne pourrait pas l'empêcher — parce qu'on le peut.

Un événement portant `user.ip_address: "0.0.0.0"` revient **sans aucune section
`user`** : Relay ne dérive la géolocalisation que lorsqu'il doit deviner l'IP
depuis la connexion. Le levier existe côté client, et tient en trois lignes dans
`scrub()`.

La décision retenue est d'annoncer plutôt que de supprimer. Mais ce n'est pas une
impuissance, et le texte ne doit pas le laisser croire. Le levier est consigné
dans #498.

## Vérification

Les quatre `.strings` passent `plutil -lint`.

Refs #498
