### PR TITLE
fix(ios): couper la géolocalisation à la source, en posant une adresse IP constante

### DIFF
--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -158,8 +158,23 @@ enum SentryManager {
     /// `app_id` est délibérément CONSERVÉ : vérifié contre le dSYM téléversé,
     /// c'est l'UUID du binaire, identique pour tous les porteurs d'un même
     /// build. Le retirer casserait la symbolication sans rien gagner.
+    /// Adresse non routable posée à la place de celle de l'utilisateur.
+    ///
+    /// Effacer l'adresse IP ne suffisait pas : quand la charge n'en porte
+    /// aucune, Sentry prend celle de la connexion et en dérive un pays et une
+    /// ville, qui atterrissent dans `user.geo`. Ça se produisait **même sur les
+    /// rapports anonymes**, et aucune règle de scrubbing ne peut l'empêcher —
+    /// la géolocalisation est calculée après l'étape de nettoyage (#498).
+    ///
+    /// Poser une adresse explicite coupe la déduction à la source : Sentry
+    /// n'essaie plus de deviner. Mesuré — un événement portant cette valeur
+    /// revient sans aucun bloc `user`.
+    ///
+    /// `0.0.0.0` est identique pour toutes les installations : rien
+    /// d'identifiant n'est réintroduit en échange.
+    private static let adresseAnonyme = "0.0.0.0"
+
     static func scrub(_ event: Event, consenti: Bool) -> Event {
-        event.user?.ipAddress = nil
         event.user?.email = nil
         event.user?.username = nil
         event.user?.name = nil
@@ -167,9 +182,19 @@ enum SentryManager {
         event.serverName = nil
         event.request = nil
 
+        // Vaut pour les deux régimes : le consentement porte sur le
+        // rattachement au compte, jamais sur la localisation.
+        event.user?.ipAddress = adresseAnonyme
+
         guard !consenti else { return event }
 
-        event.user = nil
+        // Sans consentement, il ne reste de l'utilisateur que l'adresse
+        // factice. Un `nil` pur rendrait la main à Sentry, qui regarderait
+        // alors la connexion.
+        let anonyme = Sentry.User()
+        anonyme.ipAddress = adresseAnonyme
+        event.user = anonyme
+
         if var contexts = event.context, var app = contexts["app"] {
             app.removeValue(forKey: "device_app_hash")
             contexts["app"] = app

--- a/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
+++ b/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
@@ -43,9 +43,55 @@ final class SentryAnonymisationTests: XCTestCase {
     // MARK: - Sans consentement : l'anonymat
 
     /// L'invariant que la politique publique promet.
-    func testSansConsentementAucunUtilisateurNeSubsiste() {
+    ///
+    /// Le bloc `user` n'est plus supprimé mais vidé : il ne porte qu'une adresse
+    /// factice. Un `nil` pur rendrait la main à Sentry, qui regarderait alors
+    /// l'adresse de la connexion et en dériverait une ville (#498). Ce qui
+    /// compte n'est pas que `user` soit absent — c'est qu'il ne désigne
+    /// personne.
+    func testSansConsentementAucunIdentifiantNeSubsiste() {
         let e = SentryManager.scrub(evenement(avecUtilisateur: "firebase-uid-123"), consenti: false)
-        XCTAssertNil(e.user, "Aucun identifiant de compte ne doit subsister")
+
+        XCTAssertNil(e.user?.userId, "Aucun identifiant de compte ne doit subsister")
+        XCTAssertNil(e.user?.email)
+        XCTAssertNil(e.user?.username)
+        XCTAssertNil(e.user?.name)
+        XCTAssertNil(e.user?.data)
+    }
+
+    // MARK: - L'adresse IP (#498)
+
+    /// Effacer l'IP ne suffisait pas : sans adresse dans la charge, Sentry
+    /// prenait celle de la connexion et en dérivait `user.geo` — pays ET ville,
+    /// y compris sur les rapports anonymes. Aucune règle de scrubbing ne peut
+    /// l'atteindre, la géolocalisation étant calculée après le nettoyage.
+    ///
+    /// Poser une adresse explicite coupe la déduction. Remettre `nil` ici fait
+    /// échouer le test, et rouvre la fuite.
+    func testSansConsentementLAdresseEstRemplaceeEtNonEffacee() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: false)
+
+        XCTAssertEqual(e.user?.ipAddress, "0.0.0.0",
+                       "Une adresse absente laisse Sentry lire celle de la connexion "
+                       + "et en déduire une ville")
+    }
+
+    /// Le consentement porte sur le rattachement au compte, jamais sur la
+    /// localisation : l'adresse est remplacée dans les deux régimes.
+    func testAvecConsentementLAdresseEstAussiRemplacee() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: true)
+
+        XCTAssertEqual(e.user?.ipAddress, "0.0.0.0")
+        XCTAssertEqual(e.user?.userId, "uid", "Le compte, lui, reste rattaché")
+    }
+
+    /// L'adresse posée doit être la même partout : une valeur qui varierait
+    /// redeviendrait un identifiant.
+    func testLAdresseAnonymeEstConstanteEntreDeuxEvenements() {
+        let a = SentryManager.scrub(evenement(avecUtilisateur: "uid-a"), consenti: false)
+        let b = SentryManager.scrub(evenement(avecUtilisateur: "uid-b"), consenti: false)
+
+        XCTAssertEqual(a.user?.ipAddress, b.user?.ipAddress)
     }
 
     /// La régression de #498 : `user = nil` ne suffisait pas.
@@ -77,9 +123,10 @@ final class SentryAnonymisationTests: XCTestCase {
     }
 
     /// Même consenti, l'identité directe ne part jamais — minimisation RGPD.
-    func testMemeConsentiNiIPNiEmailNePartent() {
+    /// L'adresse réelle non plus : elle est remplacée, cf. la section suivante.
+    func testMemeConsentiNiEmailNiNomNePartent() {
         let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: true)
-        XCTAssertNil(e.user?.ipAddress)
+        XCTAssertNotEqual(e.user?.ipAddress, "92.184.105.12", "L'adresse réelle ne doit jamais partir")
         XCTAssertNil(e.user?.email)
         XCTAssertNil(e.user?.name)
         XCTAssertNil(e.user?.username)

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -69,6 +69,7 @@ regimes coexist, and consent picks which one applies:
 |---|---|---|
 | `user` (Firebase UID) | dropped | kept |
 | `device_app_hash` | **removed** (#498) | kept |
+| IP address | **replaced with `0.0.0.0`** | **replaced with `0.0.0.0`** |
 | network breadcrumbs | discarded | kept |
 | `tracesSampleRate` | `0` | `0.1` |
 | `attachViewHierarchy` | no | yes |
@@ -80,12 +81,41 @@ The logic lives in two pure functions, `scrub(_:consenti:)` and
 nested closure, which is what made #498 invisible (#496). Nine tests cover it,
 one of them proven by neutralisation.
 
-> ⚠️ **What is still not anonymous: geolocation.** Sentry derives a city from
-> the IP address **after** ingestion. The "Prevent Storing of IP Addresses"
-> setting removes the address, not the position derived from it, and no client
-> code can reach it. It needs either an *Advanced Data Scrubbing* rule on
-> `$user.geo` under `Settings → Security & Privacy`, or an explicit mention on
-> `arbore.app/privacy`. Tracked in #498.
+### Geolocation, and why scrubbing cannot touch it
+
+Sentry derives a country **and a city** from the IP address and puts them in
+`user.geo`. This happened even on anonymous reports.
+
+The "Prevent Storing of IP Addresses" setting is not enough: it removes the
+address, not the position derived from it.
+
+**Scrubbing rules are not enough either.** Measured on 2026-09-10, five control
+events:
+
+| what was sent | `user.geo` |
+|---|---|
+| no IP in the payload | `FR, France` |
+| no IP + `[Remove][Anything]` rule on `$user.geo` | `FR, France` |
+| no IP + rule on `user.geo` (path, no `$`) | `FR, Paris, France` |
+| `user.ip_address: "0.0.0.0"` | **no `user` block at all** |
+| `user.ip_address: "127.0.0.1"` | **no `user` block at all** |
+
+The third run settles the obvious objection — that the pipeline was not running:
+on that very event, `extra.password` and `extra.api_key` came back `[Filtered]`.
+Scrubbing worked, the rules were active, and they did not match. Geolocation is
+computed **after** the scrubbing stage: the field does not exist yet when the
+rules run.
+
+**Do not add a rule on `user.geo` again.** It would give the illusion of
+protection.
+
+**What works** is on the client, in `scrub()`: set an explicit non-routable
+address instead of clearing the field. Sentry then stops guessing. `0.0.0.0` is
+identical across every installation, so nothing identifying is reintroduced in
+exchange.
+
+It is counter-intuitive and worth remembering: **erasing one piece of data can
+reveal another**, when the erasure hands control back to whoever can guess.
 
 `app_id` is still sent under both regimes: it is the **binary's UUID**, identical
 across every installation of a given build, and symbolication depends on it. It

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -71,6 +71,7 @@ rien observer. Deux régimes coexistent donc, et le consentement choisit lequel 
 |---|---|---|
 | `user` (UID Firebase) | supprimé | conservé |
 | `device_app_hash` | **retiré** (#498) | conservé |
+| adresse IP | **remplacée par `0.0.0.0`** | **remplacée par `0.0.0.0`** |
 | fils d'Ariane réseau | écartés | conservés |
 | `tracesSampleRate` | `0` | `0.1` |
 | `attachViewHierarchy` | non | oui |
@@ -82,12 +83,41 @@ La logique vit dans deux fonctions pures, `scrub(_:consenti:)` et
 enfouie dans une closure imbriquée, et c'est ce qui avait rendu #498 invisible
 (#496). Neuf tests la couvrent, dont un éprouvé par neutralisation.
 
-> ⚠️ **Ce qui n'est toujours pas anonyme : la géolocalisation.** Sentry déduit
-> une ville de l'adresse IP **après** ingestion. Le réglage « Prevent Storing of
-> IP Addresses » supprime l'adresse, pas la position qui en a été tirée, et
-> aucun code client ne peut l'atteindre. Il faut soit une règle *Advanced Data
-> Scrubbing* sur `$user.geo` dans `Settings → Security & Privacy`, soit
-> l'annoncer sur `arbore.app/privacy`. Suivi dans #498.
+### La géolocalisation, et pourquoi le scrubbing n'y peut rien
+
+Sentry dérive un pays **et une ville** de l'adresse IP, et les pose dans
+`user.geo`. Ça se produisait y compris sur les rapports anonymes.
+
+Le réglage « Prevent Storing of IP Addresses » ne suffit pas : il supprime
+l'adresse, pas la position qui en a été tirée.
+
+**Les règles de scrubbing non plus.** Mesuré le 2026-09-10, série de cinq
+événements de contrôle :
+
+| envoi | `user.geo` |
+|---|---|
+| aucune IP dans la charge | `FR, France` |
+| aucune IP + règle `[Remove][Anything]` sur `$user.geo` | `FR, France` |
+| aucune IP + règle sur `user.geo` (chemin, sans `$`) | `FR, Paris, France` |
+| `user.ip_address: "0.0.0.0"` | **aucun bloc `user`** |
+| `user.ip_address: "127.0.0.1"` | **aucun bloc `user`** |
+
+Le troisième essai lève l'objection évidente — le pipeline ne tournerait pas :
+sur ce même événement, `extra.password` et `extra.api_key` revenaient
+`[Filtered]`. Le scrubbing marchait, les règles étaient actives, et elles ne
+matchaient pas. La géolocalisation est calculée **après** l'étape de nettoyage :
+le champ n'existe pas encore quand les règles s'appliquent.
+
+**Ne pas reposer de règle sur `user.geo`.** Elle donnerait l'illusion d'une
+protection.
+
+**Ce qui marche** est côté client, dans `scrub()` : poser une adresse explicite
+et non routable au lieu d'effacer le champ. Sentry n'essaie alors plus de
+deviner. `0.0.0.0` est identique pour toutes les installations, donc rien
+d'identifiant n'est réintroduit en échange.
+
+C'est contre-intuitif et ça vaut d'être retenu : **effacer une donnée peut en
+révéler une autre**, quand l'effacement rend la main à celui qui sait deviner.
 
 `app_id` reste envoyé dans les deux régimes : c'est l'**UUID du binaire**,
 identique pour toutes les installations d'un même build, et la symbolication en


### PR DESCRIPTION
Corrige le dernier point ouvert de #498.

## Effacer l'adresse IP était le problème, pas la solution

`scrub()` faisait `event.user?.ipAddress = nil`, puis — sans consentement —
`event.user = nil`. Deux effacements qui rendent précisément la main au serveur :
quand la charge ne porte aucune adresse, Sentry prend celle de la connexion et en
dérive un pays **et une ville**.

Les rapports anonymes portaient donc `FR, Paris, France`.

## Aucune règle de scrubbing ne pouvait le corriger

Cinq événements de contrôle, envoyés au projet le 2026-09-10 :

| envoi | `user.geo` |
|---|---|
| aucune IP dans la charge | `FR, France` |
| aucune IP + règle `[Remove][Anything]` sur `$user.geo` | `FR, France` |
| aucune IP + règle sur `user.geo` (chemin, sans `$`) | `FR, Paris, France` |
| **`user.ip_address: "0.0.0.0"`** | **aucun bloc `user`** |
| **`user.ip_address: "127.0.0.1"`** | **aucun bloc `user`** |

Le troisième essai lève l'objection évidente — *et si le pipeline ne tournait
pas ?* Sur ce même événement, `extra.password` et `extra.api_key` revenaient
`[Filtered]`. Le scrubbing marchait, les règles étaient actives, et elles ne
matchaient pas : **la géolocalisation est calculée après l'étape de nettoyage**,
donc le champ n'existe pas encore quand les règles s'appliquent.

## Le correctif

`scrub()` pose `0.0.0.0` au lieu d'effacer, dans les **deux régimes** — le
consentement porte sur le rattachement au compte, jamais sur la localisation.

Sans consentement, le bloc `user` n'est plus supprimé mais **vidé** : il ne reste
que l'adresse factice. Un `nil` pur rendrait la main à Sentry.

`0.0.0.0` est identique pour toutes les installations : rien d'identifiant n'est
réintroduit en échange.

## Ce que ça évite

Une modification de la politique de confidentialité. La 2.4 redevient exacte
telle quelle — « sans aucun identifiant — ni compte, ni identifiant
d'installation, ni adresse IP ».

La PR qui annonçait la collecte (ArboreTeam/Arbore_SiteVitrine#6) et son miroir
in-app (#508) sont fermées : annoncer une collecte qui n'a plus lieu serait faux
dans l'autre sens.

## Vérification

14 tests verts sur `SentryAnonymisationTests`, dont quatre nouveaux — y compris
un qui vérifie que l'adresse est **la même d'un événement à l'autre**, parce
qu'une valeur qui varierait redeviendrait un identifiant.

**Éprouvé par neutralisation** : remettre l'ancien comportement fait échouer deux
tests.

Ce que ces tests ne prouvent pas, et qu'il faudra vérifier sur un vrai événement
après le prochain build : que Sentry se comporte avec la charge du SDK comme avec
celle de mes envois bruts. Le raisonnement dit oui — c'est la charge qui compte,
pas son émetteur — mais c'est un raisonnement.

## Doc

`docs/*/operations/observability.md` recommandait la règle de scrubbing. Elle
dit maintenant qu'elle a été essayée et qu'elle ne marche pas, tableau de mesures
à l'appui, pour que personne ne la repose. FR et EN à parité.

## À faire côté Sentry

Supprimer les deux règles `$user.geo` et `user.geo`. Elles ne font rien, et une
règle qui a l'air de protéger induit en erreur.

Refs #498
