### PR TITLE
fix(ios): géolocalisation coupée à la source et Sentry muet sous XCTest — promotion vers main

### DIFF
--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -26,11 +26,30 @@ enum SentryManager {
     /// Vrai si l'utilisateur a consenti au partage des données de diagnostic.
     static var hasConsent: Bool { UserDefaults.standard.bool(forKey: consentKey) }
 
-    /// Vrai si le crash reporting tourne — DSN présent suffit désormais (#469).
+    /// Vrai si le processus courant est piloté par XCTest.
+    ///
+    /// Depuis #469, un DSN suffit à démarrer le SDK. Or les tests instancient
+    /// `AppDelegate`, donc toute machine dont le `Secrets.xcconfig` porte un DSN
+    /// émettait à chaque exécution de la suite — et le lancement du runner
+    /// XCTest est assez lent pour déclencher le détecteur d'app hangs. Résultat
+    /// dans Sentry : un « App Hanging for at least 2000 ms » dont la pile est
+    /// celle de `_XCTestMain`, indiscernable d'un gel chez un testeur tant qu'on
+    /// ne l'a pas lue (#506).
+    ///
+    /// Un test ne doit pas pouvoir écrire dans l'observabilité de production.
+    ///
+    /// La variable est posée par le harnais XCTest lui-même : elle est absente
+    /// de l'app livrée, et sa lecture ne coûte rien.
+    static var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
+    /// Vrai si le crash reporting tourne — DSN présent suffit désormais (#469),
+    /// sauf sous XCTest (#506).
     ///
     /// L'opt-in ne conditionne plus la COLLECTE, mais l'IDENTIFICATION. Voir
     /// `start()` pour ce que cela change concrètement.
-    static var isEnabled: Bool { isConfigured }
+    static var isEnabled: Bool { isConfigured && !isRunningTests }
 
     /// Démarre Sentry dès qu'un DSN est configuré. Appelée au tout début de
     /// `AppDelegate.didFinishLaunchingWithOptions`, AVANT `FirebaseApp.configure()`,
@@ -65,6 +84,13 @@ enum SentryManager {
     /// réglage Sentry « Prevent Storing of IP Addresses » doit être activé côté
     /// projet — le SDK n'envoie pas l'IP, mais l'ingest la voit passer.
     static func start() {
+        guard !isRunningTests else {
+            #if DEBUG
+            print("ℹ️ Sentry désactivé (exécution sous XCTest — cf. #506).")
+            #endif
+            return
+        }
+
         guard isConfigured else {
             #if DEBUG
             print("ℹ️ Sentry désactivé (aucun DSN dans Secrets.xcconfig).")

--- a/ArboreUi/ArboreUi/Observability/SentryManager.swift
+++ b/ArboreUi/ArboreUi/Observability/SentryManager.swift
@@ -158,8 +158,23 @@ enum SentryManager {
     /// `app_id` est délibérément CONSERVÉ : vérifié contre le dSYM téléversé,
     /// c'est l'UUID du binaire, identique pour tous les porteurs d'un même
     /// build. Le retirer casserait la symbolication sans rien gagner.
+    /// Adresse non routable posée à la place de celle de l'utilisateur.
+    ///
+    /// Effacer l'adresse IP ne suffisait pas : quand la charge n'en porte
+    /// aucune, Sentry prend celle de la connexion et en dérive un pays et une
+    /// ville, qui atterrissent dans `user.geo`. Ça se produisait **même sur les
+    /// rapports anonymes**, et aucune règle de scrubbing ne peut l'empêcher —
+    /// la géolocalisation est calculée après l'étape de nettoyage (#498).
+    ///
+    /// Poser une adresse explicite coupe la déduction à la source : Sentry
+    /// n'essaie plus de deviner. Mesuré — un événement portant cette valeur
+    /// revient sans aucun bloc `user`.
+    ///
+    /// `0.0.0.0` est identique pour toutes les installations : rien
+    /// d'identifiant n'est réintroduit en échange.
+    private static let adresseAnonyme = "0.0.0.0"
+
     static func scrub(_ event: Event, consenti: Bool) -> Event {
-        event.user?.ipAddress = nil
         event.user?.email = nil
         event.user?.username = nil
         event.user?.name = nil
@@ -167,9 +182,19 @@ enum SentryManager {
         event.serverName = nil
         event.request = nil
 
+        // Vaut pour les deux régimes : le consentement porte sur le
+        // rattachement au compte, jamais sur la localisation.
+        event.user?.ipAddress = adresseAnonyme
+
         guard !consenti else { return event }
 
-        event.user = nil
+        // Sans consentement, il ne reste de l'utilisateur que l'adresse
+        // factice. Un `nil` pur rendrait la main à Sentry, qui regarderait
+        // alors la connexion.
+        let anonyme = Sentry.User()
+        anonyme.ipAddress = adresseAnonyme
+        event.user = anonyme
+
         if var contexts = event.context, var app = contexts["app"] {
             app.removeValue(forKey: "device_app_hash")
             contexts["app"] = app

--- a/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
+++ b/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
@@ -43,9 +43,55 @@ final class SentryAnonymisationTests: XCTestCase {
     // MARK: - Sans consentement : l'anonymat
 
     /// L'invariant que la politique publique promet.
-    func testSansConsentementAucunUtilisateurNeSubsiste() {
+    ///
+    /// Le bloc `user` n'est plus supprimé mais vidé : il ne porte qu'une adresse
+    /// factice. Un `nil` pur rendrait la main à Sentry, qui regarderait alors
+    /// l'adresse de la connexion et en dériverait une ville (#498). Ce qui
+    /// compte n'est pas que `user` soit absent — c'est qu'il ne désigne
+    /// personne.
+    func testSansConsentementAucunIdentifiantNeSubsiste() {
         let e = SentryManager.scrub(evenement(avecUtilisateur: "firebase-uid-123"), consenti: false)
-        XCTAssertNil(e.user, "Aucun identifiant de compte ne doit subsister")
+
+        XCTAssertNil(e.user?.userId, "Aucun identifiant de compte ne doit subsister")
+        XCTAssertNil(e.user?.email)
+        XCTAssertNil(e.user?.username)
+        XCTAssertNil(e.user?.name)
+        XCTAssertNil(e.user?.data)
+    }
+
+    // MARK: - L'adresse IP (#498)
+
+    /// Effacer l'IP ne suffisait pas : sans adresse dans la charge, Sentry
+    /// prenait celle de la connexion et en dérivait `user.geo` — pays ET ville,
+    /// y compris sur les rapports anonymes. Aucune règle de scrubbing ne peut
+    /// l'atteindre, la géolocalisation étant calculée après le nettoyage.
+    ///
+    /// Poser une adresse explicite coupe la déduction. Remettre `nil` ici fait
+    /// échouer le test, et rouvre la fuite.
+    func testSansConsentementLAdresseEstRemplaceeEtNonEffacee() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: false)
+
+        XCTAssertEqual(e.user?.ipAddress, "0.0.0.0",
+                       "Une adresse absente laisse Sentry lire celle de la connexion "
+                       + "et en déduire une ville")
+    }
+
+    /// Le consentement porte sur le rattachement au compte, jamais sur la
+    /// localisation : l'adresse est remplacée dans les deux régimes.
+    func testAvecConsentementLAdresseEstAussiRemplacee() {
+        let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: true)
+
+        XCTAssertEqual(e.user?.ipAddress, "0.0.0.0")
+        XCTAssertEqual(e.user?.userId, "uid", "Le compte, lui, reste rattaché")
+    }
+
+    /// L'adresse posée doit être la même partout : une valeur qui varierait
+    /// redeviendrait un identifiant.
+    func testLAdresseAnonymeEstConstanteEntreDeuxEvenements() {
+        let a = SentryManager.scrub(evenement(avecUtilisateur: "uid-a"), consenti: false)
+        let b = SentryManager.scrub(evenement(avecUtilisateur: "uid-b"), consenti: false)
+
+        XCTAssertEqual(a.user?.ipAddress, b.user?.ipAddress)
     }
 
     /// La régression de #498 : `user = nil` ne suffisait pas.
@@ -77,9 +123,10 @@ final class SentryAnonymisationTests: XCTestCase {
     }
 
     /// Même consenti, l'identité directe ne part jamais — minimisation RGPD.
-    func testMemeConsentiNiIPNiEmailNePartent() {
+    /// L'adresse réelle non plus : elle est remplacée, cf. la section suivante.
+    func testMemeConsentiNiEmailNiNomNePartent() {
         let e = SentryManager.scrub(evenement(avecUtilisateur: "uid"), consenti: true)
-        XCTAssertNil(e.user?.ipAddress)
+        XCTAssertNotEqual(e.user?.ipAddress, "92.184.105.12", "L'adresse réelle ne doit jamais partir")
         XCTAssertNil(e.user?.email)
         XCTAssertNil(e.user?.name)
         XCTAssertNil(e.user?.username)

--- a/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
+++ b/ArboreUi/ArboreUiTests/SentryAnonymisationTests.swift
@@ -103,6 +103,24 @@ final class SentryAnonymisationTests: XCTestCase {
         XCTAssertNotNil(SentryManager.filtrer(c, consenti: true))
     }
 
+    // MARK: - Muet sous XCTest (#506)
+
+    /// Ce test s'exécute sous XCTest, donc il vérifie la détection dans le seul
+    /// contexte où elle compte. Casser le mécanisme le fait échouer.
+    func testLaPresenceDuHarnaisDeTestEstDetectee() {
+        XCTAssertTrue(SentryManager.isRunningTests,
+                      "Le harnais XCTest pose XCTestConfigurationFilePath : ne pas le voir, "
+                      + "c'est réémettre de faux plantages depuis la suite de tests")
+    }
+
+    /// L'invariant réel : un test ne doit pas pouvoir écrire dans
+    /// l'observabilité de production, DSN configuré ou non.
+    func testLeSDKResteEteintPendantLesTests() {
+        XCTAssertFalse(SentryManager.isEnabled,
+                       "Un DSN présent dans Secrets.xcconfig ne doit pas suffire à faire "
+                       + "émettre la suite de tests (#506)")
+    }
+
     /// Les autres fils d'Ariane — navigation, cycle de vie — ne portent pas
     /// d'identifiant et restent utiles au diagnostic.
     func testLesAutresFilsDArianePassentDansLesDeuxCas() {

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -69,6 +69,7 @@ regimes coexist, and consent picks which one applies:
 |---|---|---|
 | `user` (Firebase UID) | dropped | kept |
 | `device_app_hash` | **removed** (#498) | kept |
+| IP address | **replaced with `0.0.0.0`** | **replaced with `0.0.0.0`** |
 | network breadcrumbs | discarded | kept |
 | `tracesSampleRate` | `0` | `0.1` |
 | `attachViewHierarchy` | no | yes |
@@ -80,12 +81,41 @@ The logic lives in two pure functions, `scrub(_:consenti:)` and
 nested closure, which is what made #498 invisible (#496). Nine tests cover it,
 one of them proven by neutralisation.
 
-> ⚠️ **What is still not anonymous: geolocation.** Sentry derives a city from
-> the IP address **after** ingestion. The "Prevent Storing of IP Addresses"
-> setting removes the address, not the position derived from it, and no client
-> code can reach it. It needs either an *Advanced Data Scrubbing* rule on
-> `$user.geo` under `Settings → Security & Privacy`, or an explicit mention on
-> `arbore.app/privacy`. Tracked in #498.
+### Geolocation, and why scrubbing cannot touch it
+
+Sentry derives a country **and a city** from the IP address and puts them in
+`user.geo`. This happened even on anonymous reports.
+
+The "Prevent Storing of IP Addresses" setting is not enough: it removes the
+address, not the position derived from it.
+
+**Scrubbing rules are not enough either.** Measured on 2026-09-10, five control
+events:
+
+| what was sent | `user.geo` |
+|---|---|
+| no IP in the payload | `FR, France` |
+| no IP + `[Remove][Anything]` rule on `$user.geo` | `FR, France` |
+| no IP + rule on `user.geo` (path, no `$`) | `FR, Paris, France` |
+| `user.ip_address: "0.0.0.0"` | **no `user` block at all** |
+| `user.ip_address: "127.0.0.1"` | **no `user` block at all** |
+
+The third run settles the obvious objection — that the pipeline was not running:
+on that very event, `extra.password` and `extra.api_key` came back `[Filtered]`.
+Scrubbing worked, the rules were active, and they did not match. Geolocation is
+computed **after** the scrubbing stage: the field does not exist yet when the
+rules run.
+
+**Do not add a rule on `user.geo` again.** It would give the illusion of
+protection.
+
+**What works** is on the client, in `scrub()`: set an explicit non-routable
+address instead of clearing the field. Sentry then stops guessing. `0.0.0.0` is
+identical across every installation, so nothing identifying is reintroduced in
+exchange.
+
+It is counter-intuitive and worth remembering: **erasing one piece of data can
+reveal another**, when the erasure hands control back to whoever can guess.
 
 `app_id` is still sent under both regimes: it is the **binary's UUID**, identical
 across every installation of a given build, and symbolication depends on it. It

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -11,19 +11,37 @@ Crash and performance reporting for Arbore. **iOS**, **web** and the **Go/Gin ba
 
 ---
 
-## Measured state — 2026-09-08
+## Measured state — 2026-09-10
 
 Read from the Sentry organization, not inferred from configuration. Re-measure
 rather than trust: these figures age.
 
-| project | SDK | traffic over 90 days |
+| project | SDK | state |
 |---|---|---|
-| `arbore-frontend` (iOS) | ✅ | **nothing at all** |
-| `frontend-web-arbore` | ✅ | 192,800 spans, 0 errors |
-| `arbore-backend` | ❌ absent from `go.mod` | empty |
+| `arbore-frontend` (iOS) | ✅ | **reporting since build 29** (anonymous regime, #495) |
+| `frontend-web-arbore` | ✅ | 192,800 spans |
+| `arbore-backend` | ✅ since #388 | panics, 5xx and startup failures |
 
-**Zero errors across all three projects.** That is not a sign of health, it is
-the measurement of what is not wired up — see the two sections below.
+### What the instrumentation found on day one
+
+The 2026-09-08 reading showed "zero errors across all three projects". That was
+not a sign of health, it was the measurement of what was not wired up. Two days
+later the first real events delivered three defects no code review had caught:
+
+| event | defect | issue |
+|---|---|---|
+| `App Hanging: 2000 ms` | plant traits recomputed on every call, on the main thread | #499 |
+| first anonymous event | `device_app_hash` was leaving the device without consent | #498 |
+| — | wizard questions skippable by swiping, found validating the same build | #500 |
+
+The second one is the one to remember: **the anonymisation had been declared
+sound after a code review, and the public privacy policy asserted it the next
+day.** A real event contradicted both. A review cannot see what an SDK adds by
+itself.
+
+Hence the rule that now applies to this project: **verify against a real event
+after every build**, and only write into the policy what has been observed
+leaving the device.
 
 A Sentry organization `arbore` also exists, **empty**. It must not be used as a
 destination by mistake: everything lives in `epi-apps`.
@@ -39,16 +57,43 @@ destination by mistake: everything lives in `epi-apps`.
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
 | dSYM upload | `fastlane/Fastfile` → `beta` lane |
 
-`SentryManager` is **disabled until a DSN is configured _and_ the user has explicitly opted in** to diagnostics sharing (the `privacy_shareData` toggle in the privacy settings, **off by default** — GDPR opt-in, #226). Without secrets or consent, the app builds and runs identically (handy for contributors and CI). `start()` is a no-op until consent is given; toggling consent starts/stops the SDK at runtime via `updateConsent(granted:uid:)`. The user context is the **Firebase UID only** (no email or name) and tracks auth state through a single `addStateDidChangeListener` in `AppDelegate`.
+`SentryManager` is **disabled until a DSN is configured**. Without secrets, the
+app builds and runs identically (handy for contributors and CI).
 
-Options set: `environment` (`debug` / `production`, see the next section), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (privacy), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus a `beforeSend` hook that strips IP / email / name / request body from every event (keeping only the UID pseudonym).
+It no longer **depends on consent to start**, however (#469, #495). The
+reasoning: a crash could only be observed on devices whose owners had enabled a
+setting they were never offered, which amounted to observing nothing. So two
+regimes coexist, and consent picks which one applies:
 
-> ⚠️ **Consequence worth knowing: iOS reports nothing.** Zero events in 90 days
-> (measured 2026-09-08). The mechanism works — it is consent that is never
-> given, because it is never offered. The whole chain, DSN and dSYM upload
-> included, is in place and has no effect. A launch crash on a tester's device
-> is today indistinguishable from a tester who does not open the app. Open
-> decision in #469.
+| | without consent | with consent |
+|---|---|---|
+| `user` (Firebase UID) | dropped | kept |
+| `device_app_hash` | **removed** (#498) | kept |
+| network breadcrumbs | discarded | kept |
+| `tracesSampleRate` | `0` | `0.1` |
+| `attachViewHierarchy` | no | yes |
+
+In both regimes: no IP, no email, no name, no request body.
+
+The logic lives in two pure functions, `scrub(_:consenti:)` and
+`filtrer(_:consenti:)`, precisely so it can be tested — it used to sit inside a
+nested closure, which is what made #498 invisible (#496). Nine tests cover it,
+one of them proven by neutralisation.
+
+> ⚠️ **What is still not anonymous: geolocation.** Sentry derives a city from
+> the IP address **after** ingestion. The "Prevent Storing of IP Addresses"
+> setting removes the address, not the position derived from it, and no client
+> code can reach it. It needs either an *Advanced Data Scrubbing* rule on
+> `$user.geo` under `Settings → Security & Privacy`, or an explicit mention on
+> `arbore.app/privacy`. Tracked in #498.
+
+`app_id` is still sent under both regimes: it is the **binary's UUID**, identical
+across every installation of a given build, and symbolication depends on it. It
+designates nobody — unlike `device_app_hash`, which is per-installation.
+
+Other options set: `environment` (`debug` / `production`, see the next section),
+`releaseName = version+build`, `dist = build`, `attachScreenshot = false`
+(privacy), `sendDefaultPii = false`.
 
 ### iOS setup (one-shot)
 
@@ -80,6 +125,11 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug` and with the Firebase UID.
 4. For symbolicated **release** crashes, ship a `fastlane beta` build with the token above, then trigger a crash on the TestFlight build.
 
+**And the check that actually matters**: after every shipped build, open a real
+event and read its raw JSON — `user`, the `app` context, the breadcrumbs. That
+reading, not CI, is what found #498. Tests guarantee the code removes what it
+was told to remove; they will never tell you nothing else remains.
+
 ## ⚠️ Environment vocabulary is not unified
 
 The three components do not tag their events the same way. This is a known
@@ -109,8 +159,9 @@ which backend it targets. The defect is that `AppConfig.environment` does not
 look at it — it keys off `#if DEBUG`, which `Dev` inherits anyway. **Wrong
 criterion, not missing information.**
 
-No effect today, iOS reporting nothing (see above), but it is a trap armed for
-the day it does.
+That trap is now **fully armed**: since build 29, iOS reports. An event coming
+from a `Dev` build is today indistinguishable from one coming from a `Debug`
+build, even though they target two different backends.
 
 ---
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -11,19 +11,38 @@ Reporting de crashs et de performance pour Arbore. **iOS**, **web** et **backend
 
 ---
 
-## État mesuré — 2026-09-08
+## État mesuré — 2026-09-10
 
 Relevé dans l'organisation Sentry, pas déduit de la configuration. À refaire
 plutôt qu'à croire : ces chiffres vieillissent.
 
-| projet | SDK | trafic sur 90 jours |
+| projet | SDK | état |
 |---|---|---|
-| `arbore-frontend` (iOS) | ✅ | **rien** |
-| `frontend-web-arbore` | ✅ | 192 800 spans, 0 erreur |
-| `arbore-backend` | ❌ absent de `go.mod` | vide |
+| `arbore-frontend` (iOS) | ✅ | **remonte depuis le build 29** (régime anonyme, #495) |
+| `frontend-web-arbore` | ✅ | 192 800 spans |
+| `arbore-backend` | ✅ depuis #388 | panics, 5xx et échecs de démarrage |
 
-**Zéro erreur pour les trois projets.** Ce n'est pas un signe de bonne santé,
-c'est la mesure de ce qui n'est pas branché — voir les deux sections suivantes.
+### Ce que l'instrumentation a trouvé dès le premier jour
+
+Le relevé du 2026-09-08 affichait « zéro erreur pour les trois projets ». Ce
+n'était pas un signe de bonne santé, c'était la mesure de ce qui n'était pas
+branché. Deux jours plus tard, les premiers événements réels ont livré trois
+défauts qu'aucune relecture n'avait vus :
+
+| événement | défaut | issue |
+|---|---|---|
+| `App Hanging: 2000 ms` | traits de plante recalculés à chaque appel, sur le fil principal | #499 |
+| premier événement anonyme | `device_app_hash` quittait l'appareil sans consentement | #498 |
+| — | questions du wizard sautables au doigt, trouvé en validant le même build | #500 |
+
+Le second mérite d'être retenu : **l'anonymisation avait été déclarée conforme
+après relecture, et la politique publique l'avait affirmée le lendemain.** C'est
+l'événement réel qui a démenti les deux. Une relecture ne voit pas ce qu'un SDK
+ajoute lui-même.
+
+D'où la règle qui vaut maintenant pour ce projet : **vérifier sur un événement
+réel après chaque build**, et n'écrire dans la politique que ce qui a été
+observé sortir de l'appareil.
 
 Une organisation Sentry `arbore` existe aussi, **vide**. Elle ne doit pas servir
 de destination par erreur : tout vit dans `epi-apps`.
@@ -39,16 +58,45 @@ de destination par erreur : tout vit dans `epi-apps`.
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
 | Upload dSYM | `fastlane/Fastfile` → lane `beta` |
 
-`SentryManager` est **désactivé tant qu'un DSN n'est pas configuré _et_ que l'utilisateur n'a pas explicitement opté** pour le partage de diagnostics (toggle `privacy_shareData` dans les réglages de confidentialité, **off par défaut** — opt-in RGPD, #226). Sans secrets ni consentement, l'app se build et tourne à l'identique (pratique pour les contributeurs et la CI). `start()` est un no-op jusqu'au consentement ; basculer le consentement démarre/arrête le SDK à chaud via `updateConsent(granted:uid:)`. Le contexte utilisateur est l'**UID Firebase uniquement** (ni email ni nom) et suit l'état d'auth via un unique `addStateDidChangeListener` dans `AppDelegate`.
+`SentryManager` est **désactivé tant qu'un DSN n'est pas configuré**. Sans
+secrets, l'app se build et tourne à l'identique (pratique pour les contributeurs
+et la CI).
 
-Options posées : `environment` (`debug` / `production`, cf. la section suivante), `releaseName = version+build`, `dist = build`, `tracesSampleRate = 0.1`, `attachScreenshot = false` (vie privée), `attachViewHierarchy = true`, `sendDefaultPii = false`, plus un hook `beforeSend` qui retire IP / email / nom / corps de requête de chaque événement (ne conserve que le pseudonyme UID).
+Il ne dépend en revanche **plus du consentement pour démarrer** (#469, #495).
+Le raisonnement : un crash ne pouvait être observé que chez les utilisateurs
+ayant activé un réglage qu'on ne leur proposait jamais, ce qui revenait à ne
+rien observer. Deux régimes coexistent donc, et le consentement choisit lequel :
 
-> ⚠️ **Conséquence à connaître : l'iOS ne remonte rien.** Zéro événement en
-> 90 jours (mesuré le 2026-09-08). Le mécanisme fonctionne — c'est le
-> consentement qui n'est jamais donné, faute d'être proposé. Toute la chaîne,
-> DSN et upload dSYM compris, est en place et sans effet. Un crash au lancement
-> chez un testeur est aujourd'hui indiscernable d'un testeur qui n'ouvre pas
-> l'app. Arbitrage ouvert dans #469.
+| | sans consentement | avec consentement |
+|---|---|---|
+| `user` (UID Firebase) | supprimé | conservé |
+| `device_app_hash` | **retiré** (#498) | conservé |
+| fils d'Ariane réseau | écartés | conservés |
+| `tracesSampleRate` | `0` | `0.1` |
+| `attachViewHierarchy` | non | oui |
+
+Dans les deux régimes : ni IP, ni email, ni nom, ni corps de requête.
+
+La logique vit dans deux fonctions pures, `scrub(_:consenti:)` et
+`filtrer(_:consenti:)`, précisément pour être testable — elle était auparavant
+enfouie dans une closure imbriquée, et c'est ce qui avait rendu #498 invisible
+(#496). Neuf tests la couvrent, dont un éprouvé par neutralisation.
+
+> ⚠️ **Ce qui n'est toujours pas anonyme : la géolocalisation.** Sentry déduit
+> une ville de l'adresse IP **après** ingestion. Le réglage « Prevent Storing of
+> IP Addresses » supprime l'adresse, pas la position qui en a été tirée, et
+> aucun code client ne peut l'atteindre. Il faut soit une règle *Advanced Data
+> Scrubbing* sur `$user.geo` dans `Settings → Security & Privacy`, soit
+> l'annoncer sur `arbore.app/privacy`. Suivi dans #498.
+
+`app_id` reste envoyé dans les deux régimes : c'est l'**UUID du binaire**,
+identique pour toutes les installations d'un même build, et la symbolication en
+dépend. Il ne désigne personne — contrairement à `device_app_hash`, qui est
+propre à l'installation.
+
+Autres options posées : `environment` (`debug` / `production`, cf. la section
+suivante), `releaseName = version+build`, `dist = build`, `attachScreenshot =
+false` (vie privée), `sendDefaultPii = false`.
 
 ### Setup iOS (one-shot)
 
@@ -80,6 +128,12 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug` et avec l'UID Firebase.
 4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
 
+**Et la vérification qui compte vraiment** : après chaque build livré, ouvrir un
+événement réel et lire son JSON brut — `user`, le contexte `app`, les fils
+d'Ariane. C'est cette lecture, et non la CI, qui a trouvé #498. Les tests
+garantissent que le code retire ce qu'on lui a demandé de retirer ; ils ne
+diront jamais qu'il ne reste rien d'autre.
+
 ## ⚠️ Le vocabulaire des environnements n'est pas unifié
 
 Les trois composants n'étiquettent pas leurs événements de la même façon. C'est
@@ -109,8 +163,9 @@ configuration : l'app sait parfaitement quel backend elle vise. Le défaut est
 que `AppConfig.environment` ne le regarde pas — elle se fonde sur `#if DEBUG`,
 que `Dev` hérite de toute façon. **Mauvais critère, pas information manquante.**
 
-Sans effet aujourd'hui, l'iOS ne remontant rien (voir plus haut), mais c'est un
-piège armé pour le jour où il remontera.
+Ce piège est désormais **armé pour de bon** : depuis le build 29, l'iOS remonte.
+Un événement venu d'un build `Dev` est aujourd'hui indiscernable d'un événement
+venu d'un build `Debug`, alors qu'ils visent deux backends différents.
 
 ---
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -71,6 +71,7 @@ rien observer. Deux régimes coexistent donc, et le consentement choisit lequel 
 |---|---|---|
 | `user` (UID Firebase) | supprimé | conservé |
 | `device_app_hash` | **retiré** (#498) | conservé |
+| adresse IP | **remplacée par `0.0.0.0`** | **remplacée par `0.0.0.0`** |
 | fils d'Ariane réseau | écartés | conservés |
 | `tracesSampleRate` | `0` | `0.1` |
 | `attachViewHierarchy` | non | oui |
@@ -82,12 +83,41 @@ La logique vit dans deux fonctions pures, `scrub(_:consenti:)` et
 enfouie dans une closure imbriquée, et c'est ce qui avait rendu #498 invisible
 (#496). Neuf tests la couvrent, dont un éprouvé par neutralisation.
 
-> ⚠️ **Ce qui n'est toujours pas anonyme : la géolocalisation.** Sentry déduit
-> une ville de l'adresse IP **après** ingestion. Le réglage « Prevent Storing of
-> IP Addresses » supprime l'adresse, pas la position qui en a été tirée, et
-> aucun code client ne peut l'atteindre. Il faut soit une règle *Advanced Data
-> Scrubbing* sur `$user.geo` dans `Settings → Security & Privacy`, soit
-> l'annoncer sur `arbore.app/privacy`. Suivi dans #498.
+### La géolocalisation, et pourquoi le scrubbing n'y peut rien
+
+Sentry dérive un pays **et une ville** de l'adresse IP, et les pose dans
+`user.geo`. Ça se produisait y compris sur les rapports anonymes.
+
+Le réglage « Prevent Storing of IP Addresses » ne suffit pas : il supprime
+l'adresse, pas la position qui en a été tirée.
+
+**Les règles de scrubbing non plus.** Mesuré le 2026-09-10, série de cinq
+événements de contrôle :
+
+| envoi | `user.geo` |
+|---|---|
+| aucune IP dans la charge | `FR, France` |
+| aucune IP + règle `[Remove][Anything]` sur `$user.geo` | `FR, France` |
+| aucune IP + règle sur `user.geo` (chemin, sans `$`) | `FR, Paris, France` |
+| `user.ip_address: "0.0.0.0"` | **aucun bloc `user`** |
+| `user.ip_address: "127.0.0.1"` | **aucun bloc `user`** |
+
+Le troisième essai lève l'objection évidente — le pipeline ne tournerait pas :
+sur ce même événement, `extra.password` et `extra.api_key` revenaient
+`[Filtered]`. Le scrubbing marchait, les règles étaient actives, et elles ne
+matchaient pas. La géolocalisation est calculée **après** l'étape de nettoyage :
+le champ n'existe pas encore quand les règles s'appliquent.
+
+**Ne pas reposer de règle sur `user.geo`.** Elle donnerait l'illusion d'une
+protection.
+
+**Ce qui marche** est côté client, dans `scrub()` : poser une adresse explicite
+et non routable au lieu d'effacer le champ. Sentry n'essaie alors plus de
+deviner. `0.0.0.0` est identique pour toutes les installations, donc rien
+d'identifiant n'est réintroduit en échange.
+
+C'est contre-intuitif et ça vaut d'être retenu : **effacer une donnée peut en
+révéler une autre**, quand l'effacement rend la main à celui qui sait deviner.
 
 `app_id` reste envoyé dans les deux régimes : c'est l'**UUID du binaire**,
 identique pour toutes les installations d'un même build, et la symbolication en


### PR DESCRIPTION
Promotion de `dev` (`7875f37`) vers `main`, pour porter le build 31.

Trois commits, tous iOS ou documentation. **Aucun changement backend ni web** —
rien à redéployer côté serveur.

## #509 — La géolocalisation

`scrub()` **effaçait** l'adresse IP. C'était le défaut, pas la protection : quand
la charge d'un événement n'en porte aucune, Sentry prend celle de la connexion et
en dérive un pays **et une ville**. Les rapports anonymes portaient
`FR, Paris, France`.

Aucune règle de scrubbing ne pouvait le corriger — mesuré sur cinq événements de
contrôle. La géolocalisation est calculée **après** l'étape de nettoyage, donc le
champ n'existe pas encore quand les règles s'appliquent. Le test décisif l'a
prouvé : sur un même événement, `extra.password` revenait `[Filtered]` tandis que
`user.geo` survivait à deux règles actives.

Le correctif pose `0.0.0.0` au lieu d'effacer, dans les deux régimes.

| | build 30 | build 31 |
|---|---|---|
| `user.geo` sans consentement | `FR, Paris, France` | absent |
| `user.geo` avec consentement | `FR, Paris, France` | absent |
| adresse IP réelle | jamais envoyée | jamais envoyée |

**Aucune modification de la politique de confidentialité.** `arbore.app/privacy`
reste en 2.4 et redevient exacte sans qu'on y touche.

## #507 — Sentry muet sous XCTest

`ARBORE-FRONTEND-5` était un faux « App Hanging » : la pile était celle du runner
XCTest qui démarre. Depuis #469, un DSN suffit à démarrer le SDK, donc toute
machine de dev émettait à chaque exécution de la suite. La CI n'était pas
concernée.

## #505 — Documentation

La doc décrivait un régime iOS qui n'existe plus depuis #495. Elle porte
maintenant les deux régimes, la raison de conserver `app_id`, et le tableau des
cinq mesures sur la géolocalisation — pour que personne ne repose une règle de
scrubbing qui ne peut pas fonctionner.

## Vérification

CI verte sur les trois PR, `ios_ui` compris.

14 tests sur `SentryAnonymisationTests`, dont un qui vérifie que l'adresse posée
est **identique d'un événement à l'autre** : une valeur qui varierait
redeviendrait un identifiant. Éprouvé par neutralisation — l'ancien comportement
en fait échouer deux.

## Ce qui reste après ce build

Vérifier sur un **événement réel** que le SDK produit bien la même charge que mes
envois bruts. C'est un raisonnement solide, pas une observation — et c'est le
genre de raisonnement qui a créé #498. L'issue reste ouverte jusque-là.

Refs #498, #506
