### PR TITLE
fix(fastlane): dSYM avant livraison — et les suites documentaires du 10 septembre

### DIFF
--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -32,6 +32,8 @@ later the first real events delivered three defects no code review had caught:
 |---|---|---|
 | `App Hanging: 2000 ms` | plant traits recomputed on every call, on the main thread | #499 |
 | first anonymous event | `device_app_hash` was leaving the device without consent | #498 |
+| the same one, read closer | `user.geo` carried country **and city**, on an anonymous report | #498 |
+| `App Hanging` with culprit `YourApp.$main` | it was an XCTest runner, not a user | #506 |
 | — | wizard questions skippable by swiping, found validating the same build | #500 |
 
 The second one is the one to remember: **the anonymisation had been declared
@@ -152,8 +154,14 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 
 1. Fill in the DSN in `Secrets.xcconfig`, run a **Debug** build.
 2. Profile → **Debug Tools → "Send Sentry test event"** (visible in DEBUG only).
-3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug` and with the Firebase UID.
+3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug`. **Without consent it carries no `user` at all** — the Firebase UID is attached only if "Link diagnostics to my account" is on.
 4. For symbolicated **release** crashes, ship a `fastlane beta` build with the token above, then trigger a crash on the TestFlight build.
+
+> ℹ️ **Tests emit nothing.** `start()` returns immediately under XCTest (#506).
+> Before that fix, any machine whose `Secrets.xcconfig` carried a DSN sent a fake
+> "App Hanging" on every run of the suite — the stack was the runner starting up.
+> If a test event seems missing, that is expected: use the debug button above,
+> not `xcodebuild test`.
 
 **And the check that actually matters**: after every shipped build, open a real
 event and read its raw JSON — `user`, the `app` context, the breadcrumbs. That

--- a/docs/en/operations/testflight-deploy.md
+++ b/docs/en/operations/testflight-deploy.md
@@ -185,23 +185,32 @@ Useful to confirm the previous upload was properly registered on the ASC side be
 | `Build number 42 already exists` | Race condition with another upload in progress | Wait for processing to finish, check `current_build`, retry |
 | `App Store Connect timeout` | Abnormally long Apple processing | Check the status on [Apple System Status](https://www.apple.com/support/systemstatus/), retry later |
 | Diverging `Code signing entitlements` | Xcode capabilities changed without updating ASC | Toggle the capability in Xcode, build again |
-| `Could not set changelog: SSL_connect ... unexpected eof` | Network drop to Apple **after** the upload | The binary is shipped — confirm with `current_build`. **But upload the dSYMs by hand**, see below |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Network drop to Apple **after** the binary upload | No longer fails the lane since #512: the binary is shipped and the dSYMs already went out. Set the changelog by hand in App Store Connect |
 
-### ⚠️ A lane failing after the upload leaves a build without its symbols
+### The lane's ordering, and why it changed
 
-The `beta` lane runs: archive → `upload_to_testflight` → changelog → dSYMs to
-Sentry. A failure at the changelog step — which happened on 2026-09-10 for
-build 31, an SSL drop on Apple's side 36 minutes after a successful upload —
-**stops the lane before the dSYM upload**.
+`beta` runs: bump → archive → **dSYMs to Sentry** → `upload_to_testflight`.
 
-The build is then in testers' hands, and its crashes come back with unreadable
-stack traces.
+Symbols go out **before** the binary. A build must never reach a tester without
+the means to read its crashes.
 
-The Fastfile's `begin/rescue` covers the opposite case (a dSYM upload failing
-after a shipped build must not mark the deploy as failed). It does not cover
-this one.
+That was not the case before 2026-09-10. The order was archive → upload →
+changelog → dSYMs, and on build 31 an SSL drop to Apple during the changelog step
+stopped the lane **36 minutes after a successful upload** — that is, before the
+symbols were sent. The build was in testers' hands, its crashes bound for
+unreadable stacks.
 
-Recovery:
+Two guardrails follow:
+
+- **dSYMs first.** If delivery then fails, we will have uploaded symbols for a
+  build that does not exist: a few orphaned megabytes, no harm done;
+- **a failing changelog no longer fails the lane.** It is cosmetic. The failure
+  is reported and the lane carries on — but only for that error: a failure to
+  upload the binary stays fatal, otherwise the lane would announce a delivery
+  that never happened.
+
+If the dSYM upload fails anyway, the lane says so loudly and continues: shipping
+without symbols beats not shipping. Recovery:
 
 ```bash
 export SENTRY_AUTH_TOKEN=$(grep -m1 -E '^\s*token\s*=' .sentryclirc | sed 's/^[^=]*=[[:space:]]*//')

--- a/docs/en/operations/testflight-deploy.md
+++ b/docs/en/operations/testflight-deploy.md
@@ -185,7 +185,7 @@ Useful to confirm the previous upload was properly registered on the ASC side be
 | `Build number 42 already exists` | Race condition with another upload in progress | Wait for processing to finish, check `current_build`, retry |
 | `App Store Connect timeout` | Abnormally long Apple processing | Check the status on [Apple System Status](https://www.apple.com/support/systemstatus/), retry later |
 | Diverging `Code signing entitlements` | Xcode capabilities changed without updating ASC | Toggle the capability in Xcode, build again |
-| `Could not set changelog: SSL_connect ... unexpected eof` | Network drop to Apple **after** the binary upload | No longer fails the lane since #512: the binary is shipped and the dSYMs already went out. Set the changelog by hand in App Store Connect |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Network drop to Apple **after** the binary upload | No longer fails the lane since #511: the binary is shipped and the dSYMs already went out. Set the changelog by hand in App Store Connect |
 
 ### The lane's ordering, and why it changed
 

--- a/docs/en/operations/testflight-deploy.md
+++ b/docs/en/operations/testflight-deploy.md
@@ -185,6 +185,32 @@ Useful to confirm the previous upload was properly registered on the ASC side be
 | `Build number 42 already exists` | Race condition with another upload in progress | Wait for processing to finish, check `current_build`, retry |
 | `App Store Connect timeout` | Abnormally long Apple processing | Check the status on [Apple System Status](https://www.apple.com/support/systemstatus/), retry later |
 | Diverging `Code signing entitlements` | Xcode capabilities changed without updating ASC | Toggle the capability in Xcode, build again |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Network drop to Apple **after** the upload | The binary is shipped — confirm with `current_build`. **But upload the dSYMs by hand**, see below |
+
+### ⚠️ A lane failing after the upload leaves a build without its symbols
+
+The `beta` lane runs: archive → `upload_to_testflight` → changelog → dSYMs to
+Sentry. A failure at the changelog step — which happened on 2026-09-10 for
+build 31, an SSL drop on Apple's side 36 minutes after a successful upload —
+**stops the lane before the dSYM upload**.
+
+The build is then in testers' hands, and its crashes come back with unreadable
+stack traces.
+
+The Fastfile's `begin/rescue` covers the opposite case (a dSYM upload failing
+after a shipped build must not mark the deploy as failed). It does not cover
+this one.
+
+Recovery:
+
+```bash
+export SENTRY_AUTH_TOKEN=$(grep -m1 -E '^\s*token\s*=' .sentryclirc | sed 's/^[^=]*=[[:space:]]*//')
+sentry-cli debug-files upload -o epi-apps -p arbore-frontend ./fastlane/builds/
+```
+
+After any lane failure, **check the two things separately**: is the build on
+TestFlight (`bundle exec fastlane current_build`), and are its symbols in Sentry
+(`Settings → Debug Files`).
 
 ### Detailed logs
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -33,6 +33,8 @@ défauts qu'aucune relecture n'avait vus :
 |---|---|---|
 | `App Hanging: 2000 ms` | traits de plante recalculés à chaque appel, sur le fil principal | #499 |
 | premier événement anonyme | `device_app_hash` quittait l'appareil sans consentement | #498 |
+| le même, relu de plus près | `user.geo` portait pays **et ville**, sur un rapport anonyme | #498 |
+| `App Hanging` au culprit `YourApp.$main` | c'était un runner XCTest, pas un utilisateur | #506 |
 | — | questions du wizard sautables au doigt, trouvé en validant le même build | #500 |
 
 Le second mérite d'être retenu : **l'anonymisation avait été déclarée conforme
@@ -155,8 +157,14 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 
 1. Renseigner le DSN dans `Secrets.xcconfig`, lancer un build **Debug**.
 2. Profil → **Debug Tools → « Send Sentry test event »** (visible en DEBUG uniquement).
-3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug` et avec l'UID Firebase.
+3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug`. **Sans consentement il ne porte aucun `user`** — l'UID Firebase n'y est joint que si « Rattacher les diagnostics à mon compte » est activé.
 4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
+
+> ℹ️ **Les tests n'émettent rien.** `start()` sort immédiatement sous XCTest
+> (#506). Avant ce correctif, toute machine dont le `Secrets.xcconfig` portait un
+> DSN envoyait un faux « App Hanging » à chaque exécution de la suite — la pile
+> était celle du runner qui démarre. Si un événement de test vous manque, c'est
+> normal : utilisez le bouton de debug ci-dessus, pas `xcodebuild test`.
 
 **Et la vérification qui compte vraiment** : après chaque build livré, ouvrir un
 événement réel et lire son JSON brut — `user`, le contexte `app`, les fils

--- a/docs/fr/operations/testflight-deploy.md
+++ b/docs/fr/operations/testflight-deploy.md
@@ -186,6 +186,32 @@ Utile pour confirmer que l'upload précédent a bien été enregistré côté AS
 | `Build number 42 already exists` | Race condition avec un autre upload en cours | Attendre la fin du processing, vérifier `current_build`, relancer |
 | `App Store Connect timeout` | Processing Apple anormalement long | Vérifier le statut sur [Apple System Status](https://www.apple.com/support/systemstatus/), relancer plus tard |
 | `Code signing entitlements` divergent | Capabilities Xcode modifiées sans MAJ ASC | Activer/désactiver la capability dans Xcode, builder à nouveau |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Coupure réseau vers Apple **après** l'upload | Le binaire est livré — vérifier avec `current_build`. **Mais téléverser les dSYM à la main**, voir ci-dessous |
+
+### ⚠️ Une lane qui échoue après l'upload laisse un build sans ses symboles
+
+L'ordre de la lane `beta` est : archive → `upload_to_testflight` → changelog →
+dSYM vers Sentry. Un échec au changelog — arrivé le 2026-09-10 sur le build 31,
+coupure SSL côté Apple 36 minutes après un upload réussi — **arrête la lane avant
+l'upload des dSYM**.
+
+Le build est alors chez les testeurs, et ses plantages remontent avec des piles
+d'appel illisibles.
+
+Le `begin/rescue` du Fastfile protège le cas inverse (un dSYM qui échoue après un
+build livré ne doit pas marquer le déploiement comme raté). Il ne couvre pas
+celui-ci.
+
+Rattrapage :
+
+```bash
+export SENTRY_AUTH_TOKEN=$(grep -m1 -E '^\s*token\s*=' .sentryclirc | sed 's/^[^=]*=[[:space:]]*//')
+sentry-cli debug-files upload -o epi-apps -p arbore-frontend ./fastlane/builds/
+```
+
+Après un échec de lane, **toujours vérifier deux choses séparément** : le build
+est-il sur TestFlight (`bundle exec fastlane current_build`), et ses symboles
+sont-ils dans Sentry (`Settings → Debug Files`).
 
 ### Logs détaillés
 

--- a/docs/fr/operations/testflight-deploy.md
+++ b/docs/fr/operations/testflight-deploy.md
@@ -186,23 +186,33 @@ Utile pour confirmer que l'upload précédent a bien été enregistré côté AS
 | `Build number 42 already exists` | Race condition avec un autre upload en cours | Attendre la fin du processing, vérifier `current_build`, relancer |
 | `App Store Connect timeout` | Processing Apple anormalement long | Vérifier le statut sur [Apple System Status](https://www.apple.com/support/systemstatus/), relancer plus tard |
 | `Code signing entitlements` divergent | Capabilities Xcode modifiées sans MAJ ASC | Activer/désactiver la capability dans Xcode, builder à nouveau |
-| `Could not set changelog: SSL_connect ... unexpected eof` | Coupure réseau vers Apple **après** l'upload | Le binaire est livré — vérifier avec `current_build`. **Mais téléverser les dSYM à la main**, voir ci-dessous |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Coupure réseau vers Apple **après** l'upload du binaire | N'échoue plus la lane depuis #512 : le binaire est livré et les dSYM sont déjà partis. Le changelog se pose à la main depuis App Store Connect |
 
-### ⚠️ Une lane qui échoue après l'upload laisse un build sans ses symboles
+### L'ordre de la lane, et pourquoi il a changé
 
-L'ordre de la lane `beta` est : archive → `upload_to_testflight` → changelog →
-dSYM vers Sentry. Un échec au changelog — arrivé le 2026-09-10 sur le build 31,
-coupure SSL côté Apple 36 minutes après un upload réussi — **arrête la lane avant
-l'upload des dSYM**.
+`beta` enchaîne : bump → archive → **dSYM vers Sentry** → `upload_to_testflight`.
 
-Le build est alors chez les testeurs, et ses plantages remontent avec des piles
-d'appel illisibles.
+Les symboles partent **avant** le binaire. Un build ne doit jamais atteindre un
+testeur sans de quoi lire ses plantages.
 
-Le `begin/rescue` du Fastfile protège le cas inverse (un dSYM qui échoue après un
-build livré ne doit pas marquer le déploiement comme raté). Il ne couvre pas
-celui-ci.
+Ce n'était pas le cas avant le 2026-09-10. L'ordre était archive → upload →
+changelog → dSYM, et sur le build 31 une coupure SSL vers Apple pendant la pose
+du changelog a arrêté la lane **36 minutes après un upload réussi** — donc avant
+l'envoi des symboles. Le build était chez les testeurs, ses plantages promis à
+des piles illisibles.
 
-Rattrapage :
+Deux garde-fous en découlent :
+
+- **les dSYM d'abord.** Si la livraison échoue ensuite, on aura téléversé les
+  symboles d'un build qui n'existe pas : quelques mégaoctets orphelins, sans
+  conséquence ;
+- **un changelog qui échoue n'échoue plus la lane.** Il est cosmétique. Le
+  rattrapage est signalé et la lane continue — mais seulement pour cette
+  erreur-là : un échec d'upload du binaire reste fatal, sans quoi la lane
+  annoncerait une livraison qui n'a pas eu lieu.
+
+Si l'upload des dSYM échoue malgré tout, la lane le dit fort et continue :
+livrer sans symboles vaut mieux que ne pas livrer. Rattrapage :
 
 ```bash
 export SENTRY_AUTH_TOKEN=$(grep -m1 -E '^\s*token\s*=' .sentryclirc | sed 's/^[^=]*=[[:space:]]*//')

--- a/docs/fr/operations/testflight-deploy.md
+++ b/docs/fr/operations/testflight-deploy.md
@@ -186,7 +186,7 @@ Utile pour confirmer que l'upload précédent a bien été enregistré côté AS
 | `Build number 42 already exists` | Race condition avec un autre upload en cours | Attendre la fin du processing, vérifier `current_build`, relancer |
 | `App Store Connect timeout` | Processing Apple anormalement long | Vérifier le statut sur [Apple System Status](https://www.apple.com/support/systemstatus/), relancer plus tard |
 | `Code signing entitlements` divergent | Capabilities Xcode modifiées sans MAJ ASC | Activer/désactiver la capability dans Xcode, builder à nouveau |
-| `Could not set changelog: SSL_connect ... unexpected eof` | Coupure réseau vers Apple **après** l'upload du binaire | N'échoue plus la lane depuis #512 : le binaire est livré et les dSYM sont déjà partis. Le changelog se pose à la main depuis App Store Connect |
+| `Could not set changelog: SSL_connect ... unexpected eof` | Coupure réseau vers Apple **après** l'upload du binaire | N'échoue plus la lane depuis #511 : le binaire est livré et les dSYM sont déjà partis. Le changelog se pose à la main depuis App Store Connect |
 
 ### L'ordre de la lane, et pourquoi il a changé
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,12 @@
 # Fastfile — automatisation TestFlight pour Arbore iOS
 #
 # Lane principale : `fastlane beta`
-#   Bump le build number à `latest_testflight + 1`, archive et upload sur
-#   TestFlight, distribue automatiquement au groupe interne « Internal QA ».
+#   Bump le build number à `latest_testflight + 1`, archive, téléverse les dSYM
+#   chez Sentry, puis upload sur TestFlight et distribue automatiquement au
+#   groupe interne « Internal QA ».
+#
+#   L'ordre compte : les symboles partent AVANT le binaire, pour qu'aucun build
+#   n'atteigne un testeur sans de quoi lire ses plantages (#498).
 #
 # Prérequis (one-shot, cf. docs/operations/testflight-deploy.md) :
 #   1. App Store Connect API Key (rôle App Manager) → fichier `.p8`
@@ -95,30 +99,29 @@ platform :ios do
       xcargs: "-allowProvisioningUpdates"
     )
 
-    # Internal-only deploy : on ne soumet PAS pour Beta App Review et on
-    # ne passe pas de `groups` (qui pousserait fastlane à appeler
-    # post_beta_app_review_submission, qui exige une "Beta App Description"
-    # qu'on n'a pas renseignée pour Arbore — réservée à la distribution
-    # externe). Le groupe « Internal QA » avec « Enable automatic
-    # distribution » coché côté ASC récupère la build automatiquement
-    # une fois le processing terminé.
-    upload_to_testflight(
-      api_key_path: AUTH_KEY,
-      ipa: "./fastlane/builds/Arbore.ipa",
-      distribute_external: false,
-      skip_submission: true,
-      skip_waiting_for_build_processing: false,
-      changelog: "Build interne automatique (lane: beta)."
-    )
-
-    # --- Sentry : upload des dSYM pour symboliser les crashes (#205) ---
+    # --- Sentry : upload des dSYM AVANT la livraison (#205, ordre revu #498) ---
+    #
+    # Les dSYM partaient autrefois APRÈS `upload_to_testflight`. Le 2026-09-10,
+    # sur le build 31, une coupure SSL vers Apple pendant la pose du changelog a
+    # arrêté la lane 36 minutes après un upload réussi — donc AVANT cet envoi.
+    # Le build était chez les testeurs, et ses plantages promis à des piles
+    # d'appel illisibles.
+    #
+    # L'ordre est donc inversé : un binaire ne doit jamais atteindre un testeur
+    # avant que ses symboles soient chez Sentry. Le dSYM est disponible dès la
+    # fin de `build_app`, rien n'obligeait à attendre.
+    #
+    # Si la livraison échoue ensuite, on aura téléversé les symboles d'un build
+    # qui n'existe pas : quelques mégaoctets orphelins, sans conséquence. C'est
+    # le bon sens de l'échange.
+    #
     # Skippé proprement si non configuré, pour ne pas casser la lane chez
     # quelqu'un sans Sentry. Nécessite `sentry-cli`
     # (brew install getsentry/tools/sentry-cli) + un token : SENTRY_AUTH_TOKEN
     # ou un .sentryclirc. org/projet sont déjà câblés (epi-apps/arbore-frontend).
-    # Le build est DÉJÀ sur TestFlight à ce stade : un échec d'upload dSYM
-    # (réseau, sleep macOS pendant le transfert…) ne doit PAS marquer le
-    # déploiement comme raté. On log et on continue ; relançable à la main.
+    #
+    # L'échec reste non bloquant : livrer un build sans symboles vaut mieux que
+    # ne pas livrer. Mais on le dit fort, parce que c'est une dette immédiate.
     begin
       upload_dsyms_to_sentry(
         version: version,
@@ -126,8 +129,41 @@ platform :ios do
         dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH]
       )
     rescue => e
-      UI.important("⚠️ Upload dSYM Sentry échoué (build déjà livré sur TestFlight) : #{e.message}")
-      UI.important("   Relance : sentry-cli debug-files upload -o #{SENTRY_ORG} -p #{SENTRY_PROJECT} ./fastlane/builds/Arbore.app.dSYM.zip")
+      UI.important("⚠️ Upload dSYM Sentry échoué : #{e.message}")
+      UI.important("   Le build va être livré SANS symboles — les plantages remonteront illisibles.")
+      UI.important("   Rattrapage : sentry-cli debug-files upload -o #{SENTRY_ORG} -p #{SENTRY_PROJECT} ./fastlane/builds/")
+    end
+
+    # Internal-only deploy : on ne soumet PAS pour Beta App Review et on
+    # ne passe pas de `groups` (qui pousserait fastlane à appeler
+    # post_beta_app_review_submission, qui exige une "Beta App Description"
+    # qu'on n'a pas renseignée pour Arbore — réservée à la distribution
+    # externe). Le groupe « Internal QA » avec « Enable automatic
+    # distribution » coché côté ASC récupère la build automatiquement
+    # une fois le processing terminé.
+    #
+    # Le `changelog` est posé par un appel séparé APRÈS l'upload du binaire.
+    # C'est là qu'a échoué le build 31, et c'est purement cosmétique : on ne
+    # laisse pas un texte d'accompagnement faire échouer une livraison qui a
+    # abouti. L'échec est signalé, la lane continue.
+    begin
+      upload_to_testflight(
+        api_key_path: AUTH_KEY,
+        ipa: "./fastlane/builds/Arbore.ipa",
+        distribute_external: false,
+        skip_submission: true,
+        skip_waiting_for_build_processing: false,
+        changelog: "Build interne automatique (lane: beta)."
+      )
+    rescue => e
+      # Ne rattraper QUE l'échec du changelog : un échec d'upload du binaire
+      # doit rester fatal, sans quoi la lane annoncerait une livraison qui n'a
+      # pas eu lieu.
+      raise e unless e.message.to_s.include?("Could not set changelog")
+
+      UI.important("⚠️ Changelog non posé : #{e.message}")
+      UI.important("   Le BINAIRE est bien livré — vérifier avec `bundle exec fastlane current_build`.")
+      UI.important("   Le changelog est cosmétique ; il se pose à la main depuis App Store Connect.")
     end
 
     UI.success("✅ Build #{latest + 1} déployée sur TestFlight → groupe #{INTERNAL_GROUP}")


### PR DESCRIPTION
Deux choses : un correctif de la chaîne de livraison, et les écarts de
documentation relevés dans la journée.

## Le correctif — `fastlane/Fastfile`

L'ordre de la lane faisait dépendre les symboles d'une étape cosmétique.

Sur le build 31, aujourd'hui :

```
18:46:45  Successfully uploaded the new binary to App Store Connect
19:22:17  ❌ Could not set changelog: SSL_connect ... unexpected eof
```

Une coupure SSL vers Apple pendant la pose du changelog a arrêté la lane
**36 minutes après un upload réussi**. Le binaire était déjà chez les testeurs ;
l'envoi des dSYM, qui venait après, n'a jamais eu lieu. Un plantage sur ce build
serait remonté avec une pile illisible.

**Les dSYM partent désormais avant le binaire.**

```
avant :  bump → archive → upload → changelog → dSYM
après :  bump → archive → dSYM → upload (+ changelog)
```

Ils sont disponibles dès la fin de `build_app` ; rien n'obligeait à attendre. Si
la livraison échoue ensuite, on aura téléversé les symboles d'un build qui
n'existe pas — quelques mégaoctets orphelins. L'échange est évident dans ce
sens-là.

**Un changelog qui échoue n'échoue plus la lane.** Le `rescue` ne rattrape que
cette erreur et relaie toutes les autres :

```ruby
raise e unless e.message.to_s.include?("Could not set changelog")
```

Un échec d'upload du binaire doit rester fatal, sans quoi la lane annoncerait une
livraison qui n'a pas eu lieu.

Le message d'échec des dSYM change aussi de ton. Il disait « build déjà livré sur
TestFlight », ce qui minimisait. Il dit maintenant que le build partira **sans
symboles** et que les plantages seront illisibles.

`ruby -c fastlane/Fastfile` → Syntax OK.

## Les écarts de documentation

**`observability.md`** — « Vérifier (iOS) » promettait l'UID Firebase sur
l'événement de test ; faux depuis #495, où sans consentement l'événement ne porte
**aucun** `user`. Et rien ne disait que les tests n'émettent plus depuis #506 :
quelqu'un qui cherche son événement après un `xcodebuild test` conclurait à une
panne.

Le tableau des trouvailles gagne deux lignes :

| événement | défaut | issue |
|---|---|---|
| le premier événement, relu de plus près | `user.geo` portait pays **et ville**, sur un rapport anonyme | #498 |
| `App Hanging` au culprit `YourApp.$main` | c'était un runner XCTest, pas un utilisateur | #506 |

**`testflight-deploy.md`** — décrit le nouvel ordre, la raison du changement, et
la règle qui reste vraie : après un échec de lane, vérifier **séparément** que le
build est sur TestFlight et que ses symboles sont dans Sentry.

FR et EN à parité.

## Ce qui n'est pas couvert

Le build 31 est déjà livré avec l'ancien ordre. Ses dSYM ont été téléversés à la
main ce soir — vérifié, `UPLOADED 0b694216-dd02-3184-becc-2c9b40c2ed35`. Le
correctif vaut pour les suivants.

Refs #498, #506, #469
