### PR TITLE
feat(data): renseigner care.difficulty sur les 123 fiches du catalogue

### DIFF
--- a/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
+++ b/ArboreUi/ArboreUi/Models/WizardPlantFilter.swift
@@ -182,14 +182,19 @@ struct WizardPlantFilter {
         // Résolution partagée avec le filtre du catalogue (#485) : `care.difficulty`
         // quand il existe, repli sur `flags.easyCare` sinon.
         //
-        // `nil` = entretien inconnu. On n'exclut pas : 26 des 124 fiches n'ont
-        // ni difficulté ni flags, et les masquer sur une donnée manquante
-        // reviendrait à affirmer qu'elles ne conviennent pas.
+        // `nil` = entretien inconnu. On n'exclut pas : masquer une fiche sur une
+        // donnée manquante reviendrait à affirmer qu'elle ne convient pas.
+        //
+        // Le cas est devenu rare — 123 des 124 fiches portent désormais une
+        // difficulté (#485). La seule sans est un LIVRE aspiré par erreur du
+        // catalogue botanic, qu'aucune difficulté ne saurait décrire.
         guard let actual = plant.careDifficulty(locale: locale) else { return true }
 
-        // ⚠️ « Très facile » et « Facile » donnent le même résultat tant que la
-        // source est `flags.easyCare`, qui est binaire. La distinction
-        // n'apparaîtra qu'une fois `care.difficulty` peuplé (#485).
+        // « Très facile » et « Facile » donnent toujours le même résultat, mais
+        // pour une autre raison qu'avant : le barème n'a que trois niveaux, et
+        // les deux premiers crans de l'interface visent le même. Ce n'est plus
+        // une limite de la donnée, c'est le vocabulaire de l'interface qui est
+        // plus fin que celui du barème.
         if maintL.contains("facile") || maintL == "veryeasy" || maintL == "easy" {
             return actual == .easy
         }

--- a/ArboreUi/ArboreUi/Views/FilterView.swift
+++ b/ArboreUi/ArboreUi/Views/FilterView.swift
@@ -128,9 +128,10 @@ struct FilterView: View {
     /// exigeantes, mais exactement les fiches SANS donnée — un sous-ensemble
     /// arbitraire présenté comme une réponse.
     ///
-    /// Aujourd'hui la seule source est `flags.easyCare`, qui est binaire : le
-    /// niveau intermédiaire disparaît donc de lui-même. Il réapparaîtra sans
-    /// changement de code le jour où des fiches porteront `care.difficulty`.
+    /// Ce jour est arrivé : les 123 fiches portent une difficulté depuis #485,
+    /// dont 21 intermédiaires. Le niveau apparaît donc de lui-même, sans qu'une
+    /// ligne ait changé ici — c'était l'intérêt de dériver les options de la
+    /// donnée plutôt que de les coder en dur.
     var difficultyOptions: [String] {
         let niveaux = Set(plants.compactMap { $0.careDifficulty(locale: locale) })
 

--- a/scripts/assign-care-difficulty.py
+++ b/scripts/assign-care-difficulty.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Renseigne `translations.<lang>.care.difficulty` sur les 124 fiches. (#485)
+
+## Le défaut corrigé
+
+`care.difficulty` n'existait sur aucune fiche. Le filtre du catalogue vidait donc
+la liste, et le wizard se rabattait sur `flags.easyCare` — un booléen, alors que
+l'interface propose trois niveaux. Le cran « intermédiaire » ne pouvait rien
+renvoyer.
+
+## Ce que « difficulté » veut dire ici, et ce qu'elle ne dit pas
+
+Elle mesure **l'effort d'entretien courant**, pas l'adéquation au lieu.
+
+La distinction est le cœur du barème. Une lavande exige un sol drainant — c'est
+une condition de SITE, déjà portée par `botanicalProfile.drainage` et exploitée
+par le moteur de compatibilité. La compter aussi comme une difficulté la
+pénaliserait deux fois : une fois pour ne pas convenir à un sol lourd, une fois
+pour être « exigeante ». Or plantée au bon endroit, elle ne demande rien.
+
+Ce que la difficulté mesure, c'est ce que la plante réclame **une fois bien
+placée** : rythme d'arrosage serré, humidité que l'air d'un logement ne fournit
+pas, sensibilité aux ravageurs, intolérance à l'écart.
+
+## Les trois niveaux
+
+  facile        Supporte la négligence. Arrosage irrégulier, plage de lumière
+                large, aucune exigence d'humidité. Un débutant la garde en vie.
+
+  intermédiaire Une chose doit être faite juste, régulièrement — un rythme
+                d'arrosage, un niveau de lumière — mais un oubli ne tue pas.
+
+  exigeant      Réclame des conditions qu'un logement ou un jardin ordinaire ne
+                fournit pas spontanément, ou meurt d'une seule erreur.
+
+## Le vocabulaire n'est pas libre
+
+`Plant.careDifficulty(locale:)` reconnaît la difficulté par mots-clés, et le
+build 31 est DÉJÀ chez les testeurs. Les valeurs écrites doivent donc être
+comprises par ce binaire-là : élargir la liste côté code n'aiderait pas les
+installations existantes.
+
+Vérifié caractère par caractère : « Difficult » et « Demanding » ne sont PAS
+reconnus (les mots-clés sont « difficile », « dificil », « difícil », « hard »).
+D'où « Hard » en anglais.
+
+La valeur est aussi affichée telle quelle dans `PlantDetailView` : elle doit être
+lisible, pas seulement reconnue.
+
+## Provenance des verdicts
+
+La majorité relève d'un consensus horticole que rien ne conteste — un
+Zamioculcas supporte l'abandon, un Croton perd ses feuilles au moindre écart.
+
+Les cas discutables ont été vérifiés auprès de la RHS et du Missouri Botanical
+Garden, et portent la mention `verifie=` avec ce qui a été retenu. Le buis en est
+l'exemple : arbuste facile il y a vingt ans, la RHS écrit aujourd'hui que la
+pyrale et le dépérissement « peuvent le rendre impossible à cultiver dans
+certaines régions ».
+"""
+
+from __future__ import annotations
+import argparse, json, re, sys
+
+LIBELLES = {
+    "facile":        {"fr": "Facile",        "en": "Easy",     "es": "Fácil",     "de": "Einfach"},
+    "intermediaire": {"fr": "Intermédiaire", "en": "Moderate", "es": "Intermedio","de": "Mittel"},
+    "exigeant":      {"fr": "Exigeant",      "en": "Hard",     "es": "Difícil",   "de": "Anspruchsvoll"},
+}
+
+# taxon (premier mot du nom, minuscule) -> (niveau, justification)
+VERDICTS: dict[str, tuple[str, str]] = {
+    # --- Supporte la négligence -------------------------------------------
+    "zamioculcas":  ("facile", "rhizomes tubéreux : survit à des semaines d'oubli et à la faible lumière"),
+    "sansevieria":  ("facile", "succulente à port dressé, arrosage mensuel toléré, indifférente à l'humidité"),
+    "pothos":       ("facile", "bouture facile, tolère la faible lumière et l'arrosage irrégulier"),
+    "scindapsus":   ("facile", "même tolérance que le pothos dont il est proche"),
+    "chlorophytum": ("facile", "plante de débutant par excellence, repart de ses stolons"),
+    "aglaonema":    ("facile", "feuillage d'ombre, aucune exigence d'humidité"),
+    "aglaonéma":    ("facile", "même taxon que l'aglaonema, orthographe accentuée du catalogue"),
+    "dracaena":     ("facile", "tige lignifiée, réserve d'eau, tolère l'ombre et l'oubli"),
+    "haworthia":    ("facile", "succulente compacte, arrosage espacé, lumière moyenne suffisante"),
+    "echeveria":    ("facile", "succulente de rosette, ne demande que du soleil et peu d'eau"),
+    "crassula":     ("facile", "arbre de jade : réserve d'eau dans les feuilles, très tolérant"),
+    "sedum":        ("facile", "orpin rustique, supporte sécheresse, gel et sol pauvre"),
+    "kalanchoe":    ("facile", "succulente fleurie, arrosage espacé"),
+    "kalanchoé":    ("facile", "même taxon, orthographe accentuée du catalogue"),
+    "cactus":       ("facile", "arrosage toutes les 2-3 semaines, l'oubli lui convient mieux que l'excès"),
+    "composition":  ("facile", "composition de cactées : mêmes exigences que ses composants"),
+    "agave":        ("facile", "succulente architecturale, sécheresse et plein soleil"),
+    "beaucarnea":   ("facile", "pied d'éléphant : le caudex stocke l'eau, arrosage très espacé"),
+    "ceropegia":    ("facile", "chaîne des cœurs, tubercules de réserve, tolère l'oubli"),
+    "yucca":        ("facile", "tronc ligneux, sécheresse et plein soleil, rustique en extérieur"),
+    "philodendron": ("facile", "aroïdée grimpante tolérante à l'ombre et à l'arrosage irrégulier"),
+    "monstera":     ("facile", "vigoureuse, tolère la lumière indirecte et un arrosage hebdomadaire"),
+    "syngonium":    ("facile", "aroïdée de croissance rapide, peu exigeante"),
+    "tradescantia": ("facile", "misère : se bouture dans un verre d'eau, repart de rien"),
+    "peperomia":    ("facile", "feuilles épaisses semi-succulentes, arrosage espacé"),
+    "pilea":        ("facile", "plante à monnaie chinoise, arrosage hebdomadaire, lumière indirecte"),
+    "pilea-peperomia": ("facile", "duo de deux genres également faciles"),
+    "asparagus":    ("facile", "racines tubéreuses de réserve, repart même après dessèchement"),
+    "chamaedorea":  ("facile", "palmier de montagne : le seul qui prospère en lumière faible"),
+    "kentia":       ("facile", "palmier de salon réputé pour sa tolérance à l'ombre et à l'oubli"),
+    "schefflera":   ("facile", "arbre parapluie, robuste, tolère une taille sévère"),
+    "spathiphyllum":("facile", "signale sa soif en s'affaissant puis se relève : erreur réversible"),
+    "dieffenbachia":("facile", "feuillage épais, tolère la lumière moyenne"),
+    "ficus":        ("facile", "caoutchouc : robuste, seule la lumière compte vraiment"),
+    "hoya":         ("facile", "feuilles cireuses de réserve, arrosage espacé, aime être à l'étroit"),
+    "aucuba":       ("facile", "arbuste d'ombre rustique, indifférent au sol et à la sécheresse"),
+    "festuca":      ("facile", "graminée bleue de sol sec et pauvre, aucun entretien"),
+    "stipa":        ("facile", "cheveux d'ange : graminée de sol sec, un peignage annuel suffit"),
+    "miscanthus":   ("facile", "graminée vivace robuste, une taille par an"),
+    "achillea":     ("facile", "vivace de sol pauvre, résiste à la sécheresse"),
+    "echinacea":    ("facile", "vivace de prairie, rustique et sobre"),
+    "salvia":       ("facile", "sauge des bois : vivace rustique, une taille après floraison"),
+    "gaura":        ("facile", "vivace légère, tolère sécheresse et sol pauvre"),
+    "phormium":     ("facile", "lin de Nouvelle-Zélande, persistant robuste, aucun soin courant"),
+    "ophiopogon":   ("facile", "couvre-sol persistant, indifférent, aucun entretien"),
+    "fargesia":     ("facile", "bambou non traçant : pas de rhizomes à contenir, arrosage en pot"),
+    "nandina":      ("facile", "bambou sacré, arbuste rustique sans ravageur notable"),
+    "cupressus":    ("facile", "cyprès méditerranéen, sec et rustique une fois installé"),
+    "pelargonium":  ("facile", "géranium de balcon : supporte la sécheresse, refleurit sans soin"),
+    "washingtonia": ("facile", "palmier vigoureux, sécheresse et plein soleil"),
+    "palmier":      ("facile", "Trachycarpus fortunei : le palmier le plus rustique, aucun soin courant"),
+    "fougère":      ("facile", "fougère vivace d'extérieur : à l'ombre fraîche, elle se passe de soin"),
+    "lavandula":    ("facile", "verifie=RHS « long-lived and hardy », sobre une fois installée ; "
+                               "son exigence de drainage est une condition de site, portée par botanicalProfile.drainage"),
+    "olea":         ("facile", "olivier : sobre et lent ; le gel est une contrainte de site, pas d'entretien"),
+    "begonia":      ("facile", "bégonias de massif (Semperflorens, Dragon Wing, Boliviensis) : annuels "
+                               "de plein air, floraison continue sans intervention"),
+
+    # --- Une chose à faire juste, régulièrement ---------------------------
+    "anthurium":    ("intermediaire", "fleurit et garde son feuillage si l'humidité et la lumière restent stables"),
+    "phalaenopsis": ("intermediaire", "orchidée la plus tolérante, mais l'arrosage par trempage et le "
+                                      "drainage ne pardonnent pas l'excès"),
+    "pachira":      ("intermediaire", "verifie=Missouri Bot. Garden « moderate but even moisture » ; "
+                                      "l'excès d'eau jaunit et fait tomber les feuilles basses"),
+    "areca":        ("intermediaire", "brunit du bout des feuilles en air sec et attire l'araignée rouge"),
+    "livistona":    ("intermediaire", "palmier lent exigeant lumière vive et arrosage régulier"),
+    "cordyline":    ("intermediaire", "sensible à l'eau calcaire et à l'air sec, brunit facilement"),
+    "strelitzia":   ("intermediaire", "oiseau de paradis : lumière vive indispensable, floraison lente à venir"),
+    "hydrangea":    ("intermediaire", "hortensia : très gourmand en eau, flétrit en un jour de chaleur "
+                                      "(arrosage relevé à 2-3 jours dans les données du catalogue)"),
+    "acer":         ("intermediaire", "érable du Japon : feuillage brûlé par le soleil direct et le vent, "
+                                      "demande un sol frais en permanence"),
+    "hosta":        ("intermediaire", "facile en soi, mais les limaces imposent une surveillance de printemps"),
+    "rhododendron":("intermediaire", "azalée : sol acide et frais en continu, souffre dès qu'il sèche"),
+    "dahlia":       ("intermediaire", "arrosage soutenu, tuteurage, et arrachage des tubercules hors climat doux"),
+    "alcea":        ("intermediaire", "rose trémière : la rouille est quasi systématique et demande un suivi"),
+    "bougainvillea":("intermediaire", "floraison conditionnée à un stress hydrique maîtrisé et beaucoup de lumière"),
+    "buxus":        ("exigeant", "verifie=RHS : pyrale du buis et dépérissement « peuvent le rendre "
+                                 "impossible à cultiver dans certaines régions » — surveillance et "
+                                 "traitements deviennent la norme, pas l'exception"),
+
+    # --- Réclame ce qu'un logement ne fournit pas -------------------------
+    "calathea":     ("exigeant", "verifie=RHS : « high humidity at all times », difficile à tenir en hiver ; "
+                                 "les feuilles s'enroulent et brunissent en air sec"),
+    "calathéa":     ("exigeant", "même taxon, orthographe accentuée du catalogue"),
+    "maranta":      ("exigeant", "verifie=RHS : mêmes exigences d'humidité constante que le Calathea"),
+    "alocasia":     ("exigeant", "dormance hivernale déroutante, araignée rouge, humidité élevée requise"),
+    "oreilles":     ("exigeant", "Alocasia Calidora : même taxon, nom vernaculaire du catalogue"),
+    "croton":       ("exigeant", "défolie au moindre changement de lieu, de température ou d'arrosage"),
+    "nephrolepis":  ("exigeant", "fougère de Boston : brunit dès que l'air sèche, réclame une humidité soutenue"),
+    "dicksonia":    ("exigeant", "fougère arborescente : stipe à humidifier, protection hivernale obligatoire"),
+}
+
+# Exceptions par fiche : quand le genre n'est pas homogène.
+#
+# Le verdict porte sur le taxon, ce qui suffit presque partout — un Sedum reste
+# un Sedum. Mais certains genres abritent des espèces d'exigence différente, et
+# les confondre trahirait l'utilisateur dans les deux sens.
+OVERRIDES: dict[str, tuple[str, str]] = {
+    "hoya linearis": ("intermediaire",
+                      "feuilles fines et pendantes, sans la réserve d'eau cireuse des autres Hoya : "
+                      "elle brunit en air sec et ne pardonne pas l'oubli, contrairement à H. bella"),
+}
+
+
+# Fiches à ignorer, avec la raison.
+IGNOREES = {
+    "plantes": "« Plantes Succulentes Faciles à Vivre 222 pages Éditions Eugen ULMER » "
+               "n'est pas une plante mais un LIVRE, aspiré par erreur du catalogue botanic (#489)",
+}
+
+
+def taxon(nom: str) -> str:
+    return re.sub(r"[«»'\"]", " ", nom).strip().split()[0].lower()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plants", required=True, help="export JSON de la collection plants")
+    ap.add_argument("--out", help="fichier d'opérations ; défaut : résumé seul")
+    a = ap.parse_args()
+
+    plants = json.load(open(a.plants, encoding="utf-8"))
+    ops, ignorees, inconnues = [], [], []
+
+    for p in plants:
+        t = taxon(p["name"])
+        if t in IGNOREES:
+            ignorees.append((p["name"], IGNOREES[t]))
+            continue
+        nom_bas = p["name"].lower()
+        exception = next((v for k, v in OVERRIDES.items() if k in nom_bas), None)
+        if exception:
+            niveau, pourquoi = exception
+        elif t in VERDICTS:
+            niveau, pourquoi = VERDICTS[t]
+        else:
+            inconnues.append(p["name"])
+            continue
+        ops.append({
+            "_id": p["_id"], "name": p["name"],
+            "niveau": niveau, "pourquoi": pourquoi,
+            "libelles": LIBELLES[niveau],
+        })
+
+    par_niveau = {n: sum(1 for o in ops if o["niveau"] == n) for n in LIBELLES}
+    print(f"  fiches            : {len(plants)}", file=sys.stderr)
+    print(f"  verdicts          : {len(ops)}", file=sys.stderr)
+    for n, c in par_niveau.items():
+        print(f"    {n:<14}: {c}", file=sys.stderr)
+    print(f"  ignorées          : {len(ignorees)}", file=sys.stderr)
+    for nom, raison in ignorees:
+        print(f"    · {nom}\n      {raison}", file=sys.stderr)
+    if inconnues:
+        print(f"  SANS VERDICT      : {len(inconnues)}", file=sys.stderr)
+        for nom in inconnues:
+            print(f"    · {nom}", file=sys.stderr)
+
+    if a.out:
+        with open(a.out, "w", encoding="utf-8") as f:
+            json.dump(ops, f, ensure_ascii=False, indent=1)
+        print(f"  → {a.out}", file=sys.stderr)
+
+    return 1 if inconnues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Corrige #485. **La donnée est déjà écrite en production** — cette PR porte le
script qui l'a produite, et corrige deux commentaires devenus faux.

## Ce que « difficulté » mesure, et ce qu'elle ne dit pas

L'effort d'**entretien courant**, pas l'adéquation au lieu.

Cette distinction est venue de la recherche, pas d'une intuition. La RHS décrit
*Lavandula angustifolia* comme « long-lived and hardy » : son exigence de
drainage est une condition de **site**, déjà portée par
`botanicalProfile.drainage` et exploitée par le moteur de compatibilité.

La compter aussi comme une difficulté la pénaliserait **deux fois** — une fois
pour ne pas convenir à un sol lourd, une fois pour être « exigeante » — alors que
bien plantée, elle ne demande rien.

## Le barème

| niveau | ce qu'il veut dire |
|---|---|
| Facile | supporte la négligence : arrosage irrégulier, plage de lumière large, aucune exigence d'humidité |
| Intermédiaire | une chose doit être faite juste et régulièrement, mais un oubli ne tue pas |
| Exigeant | réclame ce qu'un logement ordinaire ne fournit pas, ou meurt d'une seule erreur |

## Les verdicts — 79 taxons

**88 faciles, 21 intermédiaires, 14 exigeants.**

La plupart relèvent d'un consensus qui ne se discute pas. Les cas contestables
ont été vérifiés à la source et portent la mention `verifie=` :

| taxon | verdict | ce qui a été retenu |
|---|---|---|
| *Buxus sempervirens* | **exigeant** | RHS : pyrale et dépérissement « peuvent le rendre impossible à cultiver dans certaines régions » |
| *Calathea*, *Maranta* | **exigeants** | RHS : « high humidity at all times », difficile à tenir en hiver |
| *Pachira aquatica* | intermédiaire | Missouri Bot. Garden : « moderate but even moisture » |
| *Lavandula angustifolia* | **facile** | RHS : « long-lived and hardy » — cf. plus haut |

Le buis mérite un mot : c'était l'arbuste facile par excellence il y a vingt ans.
Le classer sur une réputation d'époque aurait été une erreur de fond.

Une exception par fiche là où le genre n'est pas homogène : *Hoya linearis*, aux
feuilles fines sans réserve cireuse, est classée au-dessus des autres *Hoya*.

## Deux pièges évités

**Une fiche n'est pas une plante.** « Plantes Succulentes Faciles à Vivre
222 pages Éditions Eugen ULMER » est un **livre**, aspiré par erreur du catalogue
botanic. Le script le signale au lieu de lui inventer une difficulté — d'où
123 verdicts et non 124.

**97 fiches sur 124 n'ont que `en,fr`.** Écrire `es` et `de` sur celles-là aurait
créé des traductions partielles. Or `PlantTranslation` déclare `description` et
`plantType` **non optionnels** : le décodage de la fiche entière aurait échoué
côté app. Le script n'écrit que dans les langues déjà présentes — vérifié après
coup, **0 traduction partielle créée**.

C'était un bug majeur à un `$set` près.

## Le vocabulaire n'était pas libre

`careDifficulty(locale:)` reconnaît la difficulté par mots-clés, et **le build 31
est déjà chez les testeurs** : élargir la liste côté code n'aiderait pas les
installations existantes.

Vérifié caractère par caractère — « Difficult » et « Demanding » ne sont **pas**
reconnus (les mots-clés sont `difficile`, `dificil`, `difícil`, `hard`). D'où
« Hard » en anglais, qui est aussi affiché tel quel dans `PlantDetailView`.

## Application

Simulation d'abord, puis écriture, puis relecture :

```
fr 123/124   en 123   es 27   de 27
Facile 88 · Intermédiaire 21 · Exigeant 14
traductions partielles créées : 0
```

Le backend déployé (`3f145e9`) porte déjà `CareInfo.Difficulty` : **aucun
redéploiement n'est nécessaire**, la donnée est servie depuis maintenant.

## Ce que ça ne règle pas

**71 % du catalogue reste « Facile ».** Le filtre exclut donc 35 fiches sur 123,
là où il en excluait 22 avant.

C'est une amélioration modeste, et je ne l'ai pas gonflée : un catalogue
constitué à 98 fiches d'un site de jardinerie **est** majoritairement composé de
plantes de débutant. Durcir les verdicts pour rendre le filtre plus sélectif
aurait été mentir pour flatter une interface.

Si le filtre paraît encore lâche, ce qui manque est de la **diversité de
catalogue**, pas de la sévérité de notation.

## Vérification

285 tests, 0 échec.

Refs #485, #489
