### PR TITLE
fix(ios): décoder les traductions langue par langue, pour qu'une langue fautive ne fasse plus disparaître la plante

### DIFF
--- a/ArboreUi/ArboreUi/Models/Plant.swift
+++ b/ArboreUi/ArboreUi/Models/Plant.swift
@@ -45,8 +45,7 @@ struct Plant: Identifiable, Codable {
 
         self.modelURL = try container.decodeIfPresent(String.self, forKey: .modelURL)
 
-        self.translations = try container.decodeIfPresent([String: PlantTranslation].self, forKey: .translations)
-            ?? [:]
+        self.translations = Plant.traductionsUtilisables(dans: container)
 
         self.generated = try container.decodeIfPresent(Bool.self, forKey: .generated)
         self.upAxis = try container.decodeIfPresent(String.self, forKey: .upAxis)
@@ -55,6 +54,75 @@ struct Plant: Identifiable, Codable {
         self.flags = try container.decodeIfPresent(PlantFlags.self, forKey: .flags)
         self.botanicalProfile = try container.decodeIfPresent(PlantBotanicalProfile.self, forKey: .botanicalProfile)
         self.hasHeavy = try container.decodeIfPresent(Bool.self, forKey: .hasHeavy)
+    }
+
+    /// Clé dynamique : le bloc `translations` est indexé par code de langue,
+    /// et rien ne borne l'ensemble des langues à l'avance.
+    private struct CodeDeLangue: CodingKey {
+        let stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int? { nil }
+        init?(intValue: Int) { nil }
+    }
+
+    /// Décode `translations` **langue par langue**, en écartant celles qui ne
+    /// tiennent pas — issue #489.
+    ///
+    /// ## Le défaut que ce garde-fou corrige
+    ///
+    /// `PlantTranslation` déclare `description` et `plantType` NON optionnels.
+    /// Décoder le bloc d'un seul coup — `decodeIfPresent([String: PlantTranslation])` —
+    /// fait donc échouer TOUT le dictionnaire dès qu'une seule langue est
+    /// partielle. Et comme cette erreur remonte l'`init(from:)`, ce n'est pas la
+    /// traduction fautive qui est perdue : c'est **la plante entière**, qui
+    /// disparaît du catalogue.
+    ///
+    /// Un `$set` maladroit sur `translations.de` d'une seule fiche suffisait à
+    /// l'effacer de l'app. Les scripts d'écriture se gardent de le faire, mais
+    /// la discipline d'un script ne protège pas d'une commande tapée à la main
+    /// dans `mongosh` un soir de correctif.
+    ///
+    /// Ici, une langue illisible ne coûte que cette langue. Les appelants
+    /// retombent tous sur `en` (`PlantDetailView.translation(for:)`,
+    /// `ManageGardenView.preferredTranslation(for:)`), donc le lecteur voit une
+    /// fiche complète dans une autre langue — au lieu de rien du tout.
+    ///
+    /// ## Ce que ce garde-fou ne fait délibérément PAS
+    ///
+    /// Il ne juge pas le contenu. Une traduction dont `description` est vide est
+    /// conservée, alors qu'elle affichera peu de chose.
+    ///
+    /// La tentation était forte de l'écarter au profit du repli sur `en`, plus
+    /// complet. C'est une erreur : un bloc de langue ne porte pas que de la
+    /// prose, il porte aussi des données structurées que le catalogue consomme —
+    /// `care.difficulty` en tête, dont `careDifficulty(locale:)` dépend pour
+    /// filtrer. Jeter la langue entière parce que son texte est vide reviendrait
+    /// à jeter sa difficulté avec, et à faire disparaître la plante des filtres
+    /// pour régler un problème d'affichage.
+    ///
+    /// Un décodeur ne détruit pas de la donnée valide pour arranger une vue. La
+    /// complétude est vérifiée en amont par les scripts d'écriture, qui voient
+    /// la source ; le repli sur un champ vide se règle à la lecture, là où le
+    /// contexte existe.
+    private static func traductionsUtilisables(
+        dans container: KeyedDecodingContainer<CodingKeys>
+    ) -> [String: PlantTranslation] {
+        guard let bloc = try? container.nestedContainer(keyedBy: CodeDeLangue.self,
+                                                        forKey: .translations) else {
+            return [:]
+        }
+
+        var retenues: [String: PlantTranslation] = [:]
+        for cle in bloc.allKeys {
+            guard let traduction = try? bloc.decode(PlantTranslation.self, forKey: cle) else {
+                #if DEBUG
+                print("⚠️ Plant: traduction « \(cle.stringValue) » illisible — langue ignorée, la fiche est conservée")
+                #endif
+                continue
+            }
+            retenues[cle.stringValue] = traduction
+        }
+        return retenues
     }
 
     // ✅ Helper pour reconstruire une plante minimale au moment du restore

--- a/ArboreUi/ArboreUiTests/PlantTranslationDecodingTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantTranslationDecodingTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import ArboreUi
+
+// PlantTranslationDecodingTests.swift — issue #489.
+//
+// Ces tests couvrent un défaut qui n'a jamais été observé en production, et
+// c'est précisément la raison de les écrire : il ne se serait pas manifesté par
+// un affichage dégradé, mais par la disparition pure et simple d'une plante du
+// catalogue. Un symptôme qu'on attribue à un problème de réseau, pas à une
+// donnée.
+//
+// Le mécanisme. `PlantTranslation` déclare `description` et `plantType` NON
+// optionnels. Tant que `translations` était décodé d'un bloc, une seule langue
+// partielle faisait échouer le dictionnaire entier, l'erreur remontait
+// l'`init(from:)`, et la fiche devenait indécodable. Écrire `translations.de`
+// sans `plantType` sur une fiche revenait donc à l'effacer de l'app — dans
+// TOUTES les langues, y compris celles qui allaient bien.
+//
+// Les trois scripts d'écriture du catalogue vérifient la complétude avant
+// d'écrire. Mais cette discipline vit dans les scripts, pas dans le modèle : un
+// `$set` tapé à la main dans `mongosh` ne la connaît pas. Ces tests déplacent la
+// garantie là où elle tient toute seule.
+
+final class PlantTranslationDecodingTests: XCTestCase {
+
+    // MARK: - Fabrique
+
+    /// Décode une plante à partir du seul bloc `translations`, le reste étant
+    /// le minimum viable. Le chemin testé est le chemin réel : celui du JSON.
+    private func plante(traductions: String) throws -> Plant {
+        let json = """
+        {
+            "id": "test-plant",
+            "name": "Plante de test",
+            "type": "interieur",
+            "imageURLs": [],
+            "description": "Description racine",
+            "translations": \(traductions)
+        }
+        """
+        return try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+    }
+
+    private let complete = #"{"description": "Une description complète.", "plantType": "Plante d'intérieur"}"#
+
+    // MARK: - L'invariant principal
+
+    /// La régression de #489, dans sa forme la plus directe.
+    ///
+    /// `de` n'a pas de `plantType`. Avant le garde-fou, ce seul manque faisait
+    /// disparaître la plante. Désormais il ne coûte que l'allemand.
+    func testUneLangueIncompleteNeFaitPasDisparaitreLaPlante() throws {
+        let p = try plante(traductions: #"""
+        {
+            "fr": \#(complete),
+            "en": \#(complete),
+            "de": {"description": "Eine Beschreibung ohne Typ."}
+        }
+        """#)
+
+        XCTAssertEqual(p.name, "Plante de test", "La fiche doit survivre à une traduction fautive")
+        XCTAssertNotNil(p.translations["fr"], "Les langues saines ne doivent pas être emportées")
+        XCTAssertNotNil(p.translations["en"])
+        XCTAssertNil(p.translations["de"], "La langue incomplète est la seule perte")
+    }
+
+    /// Le repli est ce qui rend la perte acceptable : sans `de`, l'appelant
+    /// trouve `en`. Si ce test échoue, écarter la langue ne suffit plus.
+    func testLeRepliSurAnglaisResteDisponibleApresRejet() throws {
+        let p = try plante(traductions: #"""
+        {
+            "en": \#(complete),
+            "de": {"plantType": "Zimmerpflanze"}
+        }
+        """#)
+
+        let vue = p.translations["de"] ?? p.translations["en"]
+        XCTAssertEqual(vue?.description, "Une description complète.",
+                       "Le lecteur germanophone doit voir une fiche anglaise complète, pas rien")
+        XCTAssertEqual(vue?.plantType, "Plante d'intérieur")
+    }
+
+    /// Une traduction au texte vide est CONSERVÉE, et ce choix mérite d'être
+    /// défendu : l'écarter au profit du repli sur `en` paraissait plus utile au
+    /// lecteur, et c'est un piège.
+    ///
+    /// Un bloc de langue ne porte pas que de la prose. Il porte aussi
+    /// `care.difficulty`, dont dépend le filtrage du catalogue. Jeter la langue
+    /// parce que sa description est blanche jetterait sa difficulté avec, et
+    /// ferait disparaître la plante des filtres pour régler un problème
+    /// d'affichage — le bug de #485, réintroduit par le correctif de #489.
+    ///
+    /// Un décodeur ne détruit pas de la donnée valide pour arranger une vue.
+    func testUneTraductionAuTexteVideEstConserveePourSesDonneesStructurees() throws {
+        let p = try plante(traductions: #"""
+        {
+            "en": \#(complete),
+            "es": {
+                "description": "   ",
+                "plantType": "",
+                "care": {"difficulty": "Fácil", "weekly": [], "monthly": [], "yearly": [], "extraTips": []}
+            }
+        }
+        """#)
+
+        let es = try XCTUnwrap(p.translations["es"],
+                               "La langue doit survivre : sa difficulté est exploitable même sans texte")
+        XCTAssertEqual(es.care?.difficulty, "Fácil")
+    }
+
+    /// La conséquence directe sur le catalogue : la difficulté reste lisible.
+    /// C'est ce test qui relie le garde-fou de #489 au filtre de #485.
+    func testUneDifficulteResteLisibleMalgreUnTexteVide() throws {
+        let p = try plante(traductions: #"""
+        {"fr": {"description": "", "plantType": "", "care": {"difficulty": "Exigeant"}}}
+        """#)
+
+        XCTAssertEqual(p.careDifficulty(locale: "fr"), .demanding,
+                       "Le filtre du catalogue ne doit rien perdre au passage du décodage par langue")
+    }
+
+    // MARK: - Ce qui doit continuer de passer
+
+    /// Le garde-fou ne doit rien coûter au cas nominal : les 124 fiches du
+    /// catalogue portent quatre langues complètes.
+    func testLesQuatreLanguesCompletesSontToutesRetenues() throws {
+        let p = try plante(traductions: #"""
+        {
+            "fr": \#(complete),
+            "en": \#(complete),
+            "es": \#(complete),
+            "de": \#(complete)
+        }
+        """#)
+
+        XCTAssertEqual(Set(p.translations.keys), ["fr", "en", "es", "de"])
+    }
+
+    /// Les sections optionnelles vides ne sont pas un défaut : une fiche
+    /// succincte reste une fiche. Le garde-fou ne juge que `description` et
+    /// `plantType`.
+    func testUneTraductionSansSectionsFacultativesEstRetenue() throws {
+        let p = try plante(traductions: #"""
+        {"fr": \#(complete)}
+        """#)
+
+        let t = try XCTUnwrap(p.translations["fr"])
+        XCTAssertEqual(t.description, "Une description complète.")
+        XCTAssertNil(t.sun, "Les sections facultatives absentes restent absentes, sans rejet")
+        XCTAssertNil(t.care)
+    }
+
+    /// Les sections riches doivent continuer de se décoder normalement — le
+    /// passage par un conteneur dynamique ne doit rien perdre en chemin.
+    func testLesSectionsRichesSurviventAuDecodageParLangue() throws {
+        let p = try plante(traductions: #"""
+        {
+            "fr": {
+                "description": "Une description complète.",
+                "plantType": "Plante d'intérieur",
+                "care": {"difficulty": "Facile", "weekly": ["Arroser"], "monthly": [], "yearly": [], "extraTips": []},
+                "sun": {"lightType": "Lumière vive indirecte", "tips": ["Tourner le pot"]}
+            }
+        }
+        """#)
+
+        let t = try XCTUnwrap(p.translations["fr"])
+        XCTAssertEqual(t.care?.difficulty, "Facile")
+        XCTAssertEqual(t.care?.weekly, ["Arroser"])
+        XCTAssertEqual(t.sun?.lightType, "Lumière vive indirecte")
+        XCTAssertEqual(t.sun?.tips, ["Tourner le pot"])
+    }
+
+    // MARK: - Formes dégénérées du bloc lui-même
+
+    /// `translations` absent : cas des fiches legacy.
+    func testUnBlocAbsentDonneUnDictionnaireVide() throws {
+        let json = """
+        {"id": "x", "name": "Sans traduction", "type": "interieur", "imageURLs": [], "description": "d"}
+        """
+        let p = try JSONDecoder().decode(Plant.self, from: Data(json.utf8))
+        XCTAssertTrue(p.translations.isEmpty)
+    }
+
+    /// `translations` du mauvais type ne doit pas non plus emporter la fiche.
+    func testUnBlocMalFormeNEmportePasLaFiche() throws {
+        let p = try plante(traductions: #""une chaîne au lieu d'un objet""#)
+        XCTAssertEqual(p.name, "Plante de test")
+        XCTAssertTrue(p.translations.isEmpty)
+    }
+
+    /// Toutes les langues fautives : la plante reste au catalogue, sans
+    /// traduction. C'est le pire cas, et il reste préférable à sa disparition.
+    func testToutesLesLanguesFautivesLaissentLaPlanteAuCatalogue() throws {
+        let p = try plante(traductions: #"""
+        {
+            "fr": {"description": "Sans type."},
+            "en": {"plantType": "Sans description."}
+        }
+        """#)
+
+        XCTAssertEqual(p.name, "Plante de test")
+        XCTAssertTrue(p.translations.isEmpty)
+    }
+}


### PR DESCRIPTION
`PlantTranslation` déclare `description` et `plantType` NON optionnels, et `translations` était décodé d'un bloc. Une seule langue partielle faisait donc échouer tout le dictionnaire, l'erreur remontait l'`init(from:)`, et ce n'était pas la traduction fautive qui était perdue : c'était **la fiche entière**.

Écrire `translations.de` sans `plantType` sur une plante revenait à l'effacer de l'app — dans toutes les langues, y compris celles qui allaient bien. Le symptôme aurait été une plante absente du catalogue, qu'on attribue à un problème de réseau plutôt qu'à une donnée.

Désormais une langue illisible ne coûte que cette langue. Les appelants retombent tous sur `en` (`PlantDetailView.translation(for:)`, `ManageGardenView.preferredTranslation(for:)`), donc le lecteur voit une fiche complète dans une autre langue au lieu de ne rien voir.

## Pourquoi le modèle et pas seulement les scripts

Les trois scripts d'écriture du catalogue vérifient déjà la complétude avant d'écrire, et c'est ce qui a évité l'accident deux fois (#513, #514). Mais cette discipline vit dans les scripts : un `$set` tapé à la main dans `mongosh` un soir de correctif ne la connaît pas. La garantie est déplacée là où elle tient seule.

## Un garde-fou que j'ai écrit puis retiré

La première version écartait aussi les traductions au texte vide, pour leur préférer le repli sur `en`, plus complet. **Onze tests de #485 sont tombés, et ils avaient raison** : un bloc de langue ne porte pas que de la prose, il porte `care.difficulty`, dont dépend le filtrage du catalogue. Jeter la langue parce que sa description est blanche jetait sa difficulté avec — soit le bug de #485 réintroduit par le correctif de #489.

Un décodeur ne détruit pas de la donnée valide pour arranger une vue. La règle retenue est donc la plus étroite : on garde tout ce qui se décode. Deux tests consignent ce choix, pour qu'il ne soit pas « resserré » plus tard sans voir le prix.

## `SetDefaults()` n'est pas le filet qu'il paraît être

`ArboreBackend/setdefault.go` remplit `description` et `plantType` dans les quatre langues, ce qui ressemble à une protection côté serveur. Elle n'est appelée **nulle part** — vérifié sur tout le paquet.

Et il ne faut pas la brancher pour autant : elle écrirait « Aucune information détaillée disponible » là où le repli donnait de l'anglais complet. Ce serait un recul, pas un filet. Consigné dans #489 plutôt que corrigé à la hâte.

## Vérifications

Les 10 nouveaux tests passent. **Sans le garde-fou, 4 échouent** — la disparition de la fiche, le bloc mal typé, le cas où toutes les langues sont fautives, et la perte du repli. Les 6 autres couvrent ce qui ne doit rien coûter au cas nominal.

| suite | tests | échecs |
|---|---|---|
| `PlantTranslationDecodingTests` | 10 | 0 |
| `PlantCareDifficultyTests` | 14 | 0 |
| `PlantCatalogContextTests` | 13 | 0 |
| `PlantCatalogTraitsCacheTests` | 4 | 0 |
| `PlantPlacementCompatibilityTests` | 5 | 0 |
| `ModelCacheManagerTests` | 10 | 0 |
| **total** | **56** | **0** |

Aucun changement de donnée : les 124 fiches portent déjà quatre langues complètes (#514). Ce correctif porte sur ce qui se passerait si ce n'était plus le cas.

Avance #489.