### PR TITLE
docs(stockage): corriger l'état de la production, qui sert depuis R2 et non le disque

### DIFF
--- a/docs/en/operations/asset-storage.md
+++ b/docs/en/operations/asset-storage.md
@@ -19,9 +19,13 @@ what the `StorageProvider` abstraction buys
 
 | `STORAGE_PROVIDER` | Use | Specificity |
 |---|---|---|
-| `filesystem` | default, and current production state | serves from `MODELS_HOST_PATH` |
-| `r2` / `s3` | intended production | no egress fees with R2 |
+| `filesystem` | default, and the **dev environment** | serves from `MODELS_HOST_PATH` |
+| `r2` / `s3` | **production** | no egress fees with R2 |
 | `minio` | local development | `STORAGE_S3_USE_SSL=false` |
+
+Production therefore serves its models from R2, and dev from disk — deliberately:
+giving dev the bucket credentials would have meant a dev age key opens write
+access to production storage.
 
 The full variable inventory, with one example per store, is in
 [`ops/secrets/env.template`](../../../ops/secrets/env.template).
@@ -76,6 +80,15 @@ Strip the `https://` and anything after the host: the library wants the bare
 host.
 
 ## Migrating to R2 — order matters
+
+> **Done.** Production has moved to R2. This section stays to document the
+> procedure — in case it must be redone against another bucket, or to explain
+> why the order is what it is.
+>
+> Measured on 2026-09-11: `arbore-prod-backend` logs
+> `📦 Stockage des assets : s3(…eu.r2.cloudflarestorage.com)+garde` at startup,
+> and the `arbore-assets` bucket holds 370 objects for 4.5 GiB.
+> `arbore-dev-backend` logs `filesystem`.
 
 The reverse order would have production serving from an empty bucket: every
 model 404, immediately.

--- a/docs/fr/operations/stockage-assets.md
+++ b/docs/fr/operations/stockage-assets.md
@@ -19,9 +19,13 @@ champs — c'est ce qu'achète l'abstraction `StorageProvider`
 
 | `STORAGE_PROVIDER` | Usage | Particularité |
 |---|---|---|
-| `filesystem` | défaut, et état actuel de la production | sert depuis `MODELS_HOST_PATH` |
-| `r2` / `s3` | production visée | aucun frais de sortie chez R2 |
+| `filesystem` | défaut, et **environnement de dev** | sert depuis `MODELS_HOST_PATH` |
+| `r2` / `s3` | **production** | aucun frais de sortie chez R2 |
 | `minio` | développement local | `STORAGE_S3_USE_SSL=false` |
+
+La production sert donc ses modèles depuis R2, et le dev depuis le disque —
+c'est délibéré : donner au dev les identifiants du seau aurait signifié qu'une
+clé age de dev ouvre l'écriture sur le stockage de production.
 
 L'inventaire complet des variables, avec un exemple par support, est dans
 [`ops/secrets/env.template`](../../../ops/secrets/env.template).
@@ -76,6 +80,15 @@ Retirer le `https://` et tout ce qui suit l'hôte : la bibliothèque veut l'hôt
 seul.
 
 ## Migrer vers R2 — l'ordre importe
+
+> **Fait.** La production est passée sur R2, et cette section reste pour
+> documenter la marche à suivre — au cas où il faudrait recommencer sur un autre
+> seau, ou comprendre pourquoi l'ordre est celui-là.
+>
+> État mesuré le 2026-09-11 : `arbore-prod-backend` journalise au démarrage
+> `📦 Stockage des assets : s3(…eu.r2.cloudflarestorage.com)+garde`, et le seau
+> `arbore-assets` porte 370 objets pour 4,5 Gio. `arbore-dev-backend`
+> journalise `filesystem`.
 
 L'ordre inverse ferait servir la production depuis un seau vide : tous les
 modèles en 404, immédiatement.


### PR DESCRIPTION
La table des supports annonçait `filesystem` comme « état actuel de la production » et R2 comme « production visée ». C'était vrai à l'écriture, ça ne l'est plus : la migration a eu lieu et personne n'est revenu corriger la page.

Défaut signalé par l'utilisateur, qui se souvenait de la vraie répartition mieux que la documentation.

## Mesuré, pas déduit du dépôt

```
arbore-prod-backend : 📦 Stockage des assets : s3(…eu.r2.cloudflarestorage.com)+garde
arbore-dev-backend  : 🛡️  Garde stockage (filesystem)
```

Le seau `arbore-assets` porte 370 objets pour 4,5 Gio.

| `STORAGE_PROVIDER` | avant (doc) | réel |
|---|---|---|
| production | `filesystem` | **`r2`** |
| dev | — | `filesystem` |

## Ce qui est conservé

La section « Migrer vers R2 — l'ordre importe » reste, marquée comme faite. Elle garde sa valeur : l'ordre des étapes y est expliqué — poser les identifiants avant de basculer le drapeau, sans quoi la production servirait depuis un seau vide — et il faudra le rejouer si le seau change un jour.

## Ce qui est ajouté

La répartition est consignée comme un **choix**, pas comme un retard de migration : le dev sert depuis le disque parce que lui donner les identifiants du seau aurait signifié qu'une clé age de dev ouvre l'écriture sur le stockage de production. Sans cette phrase, un lecteur pressé « corrige » le dev en le branchant sur R2.

FR et EN mis à jour à parité.