### PR TITLE
fix(ios): décoder les vignettes hors du thread principal, qui gelait le catalogue

### DIFF
--- a/ArboreUi/ArboreUi/Thumbnail/PlantThumbnailCache.swift
+++ b/ArboreUi/ArboreUi/Thumbnail/PlantThumbnailCache.swift
@@ -1,4 +1,5 @@
 import UIKit
+import ImageIO
 
 struct PlantThumbnailCache {
 
@@ -27,6 +28,92 @@ struct PlantThumbnailCache {
         blue: 186.0 / 255.0,
         alpha: 1
     )
+
+    // MARK: - Décodage hors du thread principal
+
+    /// Images déjà décodées, prêtes à dessiner.
+    ///
+    /// `UIImage(contentsOfFile:)` et `UIImage(data:)` sont **paresseux** : ils ne
+    /// décompressent rien. La décompression a lieu au premier dessin, donc dans
+    /// le commit Core Animation — sur le thread principal. Charger le fichier
+    /// dans un `Task.detached` déporte la lecture, pas le décodage, et donne
+    /// l'illusion d'un travail mis de côté.
+    ///
+    /// C'est ce qui a produit le gel de 2 s relevé par Sentry en parcourant le
+    /// catalogue (`ARBORE-FRONTEND-A`, build 32) : la pile s'arrêtait dans
+    /// `CA::Layer::layout_and_display_if_needed`, sans aucune frame applicative.
+    ///
+    /// Les vignettes pèsent 720 × 900 px pour ~500 Ko, la grille en montre cinq
+    /// à la fois et le catalogue en compte 123.
+    private static let decodees: NSCache<NSString, UIImage> = {
+        let c = NSCache<NSString, UIImage>()
+        // Une vignette décodée occupe 576 × 720 × 4 ≈ 1,7 Mo. Un plafond de
+        // 40 Mio en garde une vingtaine — bien plus que la grille n'en montre,
+        // et sans retenir les 123 fiches en mémoire.
+        c.totalCostLimit = 40 * 1024 * 1024
+        return c
+    }()
+
+    /// Verdicts de `isLegacyThumbnail` déjà rendus, par fichier.
+    ///
+    /// Ce contrôle enchaîne quatre balayages de pixels, et chacun force un
+    /// décodage complet de l'image. Il était rejoué à **chaque** apparition de
+    /// carte alors que son résultat ne dépend que du fichier, lequel ne change
+    /// pas sous la même clé de version.
+    private static let verdicts = NSCache<NSString, NSNumber>()
+
+    /// Côté le plus long, en pixels, d'une vignette préparée pour l'affichage.
+    ///
+    /// La carte mesure environ 173 × 220 pt ; à l'échelle 3 il faut donc
+    /// 519 × 660 px. Une source de 720 × 900 ramenée à 576 × 720 couvre ce
+    /// besoin avec ~11 % de marge, tout en divisant par 1,6 le nombre de pixels
+    /// à décoder. Descendre plus bas se verrait sur les écrans les plus denses.
+    private static let cotePrepare: CGFloat = 720
+
+    private static func cle(_ plantID: String) -> NSString {
+        "\(plantID)_\(version)" as NSString
+    }
+
+    private static func cout(_ image: UIImage) -> Int {
+        guard let cg = image.cgImage else { return 0 }
+        return cg.bytesPerRow * cg.height
+    }
+
+    /// Décode et redimensionne en une passe, **là où on l'appelle**.
+    ///
+    /// `kCGImageSourceShouldCacheImmediately` est le drapeau qui compte : sans
+    /// lui, ImageIO reste paresseux comme `UIImage(data:)` et le coût retombe
+    /// dans le rendu. Avec lui, le travail est fait ici — donc hors du thread
+    /// principal si l'appelant s'y trouve.
+    static func imagePreteAAfficher(source: CGImageSource) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: cotePrepare
+        ]
+        guard let cg = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+        return UIImage(cgImage: cg)
+    }
+
+    /// Variante pour des octets fraîchement téléchargés.
+    ///
+    /// Le repli sur `UIImage(data:)` couvre le cas où ImageIO refuse le format :
+    /// mieux vaut une image paresseuse qu'une carte vide.
+    static func imagePreteAAfficher(data: Data) -> UIImage? {
+        guard let src = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return UIImage(data: data)
+        }
+        return imagePreteAAfficher(source: src) ?? UIImage(data: data)
+    }
+
+    /// Vide les caches mémoire. Utile après une régénération de vignettes.
+    static func viderCachesMemoire() {
+        decodees.removeAllObjects()
+        verdicts.removeAllObjects()
+    }
 
     static func url(for plantID: String) -> URL {
         directory.appendingPathComponent("\(plantID)_\(version).png")
@@ -67,17 +154,43 @@ struct PlantThumbnailCache {
         return Set(ids).sorted()
     }
 
+    /// Rend une vignette **déjà décodée**, en ne payant lecture, contrôle et
+    /// décompression qu'une fois par fichier.
+    ///
+    /// L'ordre importe : le contrôle d'ancienneté porte sur l'image d'origine,
+    /// pas sur la version réduite. Ses heuristiques échantillonnent des pixels à
+    /// des positions précises — les juger sur une image redimensionnée
+    /// changerait leur verdict, et une vignette légitime finirait effacée.
     static func load(for plantID: String) -> UIImage? {
-        let fileURL = url(for: plantID)
-        guard let image = UIImage(contentsOfFile: fileURL.path) else { return nil }
+        let k = cle(plantID)
+        if let deja = decodees.object(forKey: k) { return deja }
 
-        if isLegacyThumbnail(image) {
+        let fileURL = url(for: plantID)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+
+        let estAncienne: Bool
+        if let memorise = verdicts.object(forKey: k) {
+            estAncienne = memorise.boolValue
+        } else {
+            guard let originale = UIImage(contentsOfFile: fileURL.path) else { return nil }
+            estAncienne = isLegacyThumbnail(originale)
+            verdicts.setObject(NSNumber(value: estAncienne), forKey: k)
+        }
+
+        if estAncienne {
             try? FileManager.default.removeItem(at: fileURL)
+            verdicts.removeObject(forKey: k)
             print("🧹 Ancien thumbnail supprimé:", fileURL.path)
             return nil
         }
 
-        return image
+        guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
+              let prete = imagePreteAAfficher(source: source) else {
+            return nil
+        }
+
+        decodees.setObject(prete, forKey: k, cost: cout(prete))
+        return prete
     }
 
     @discardableResult
@@ -90,6 +203,24 @@ struct PlantThumbnailCache {
         let path = url(for: plantID)
         try? data.write(to: path)
         print("✅ PNG écrit:", path.path)
+
+        // Le fichier vient de changer sous cette clé : les deux mémoires qui en
+        // dépendent doivent partir avec lui, sinon un `load` suivant servirait
+        // l'ancienne image ou l'ancien verdict.
+        //
+        // On réamorce dans la foulée plutôt que de laisser le prochain `load`
+        // repayer lecture et décodage : `save` tourne déjà hors du thread
+        // principal, c'est le bon endroit pour le faire. Le marqueur vient
+        // d'être posé, donc le verdict est connu sans le calculer.
+        let k = cle(plantID)
+        decodees.removeObject(forKey: k)
+        verdicts.setObject(NSNumber(value: false), forKey: k)
+        if let source = CGImageSourceCreateWithData(data as CFData, nil),
+           let prete = imagePreteAAfficher(source: source) {
+            decodees.setObject(prete, forKey: k, cost: cout(prete))
+            return prete
+        }
+
         return cachedImage
     }
 

--- a/ArboreUi/ArboreUi/Views/PlantCard.swift
+++ b/ArboreUi/ArboreUi/Views/PlantCard.swift
@@ -122,7 +122,7 @@ struct PlantCard: View {
         // to the dedicated debug/admin screen used before uploading PNGs.
         if let rawURL = plant.imageURLs.first(where: { !$0.isEmpty }),
            let url = URL(string: rawURL),
-           let image = await downloadImage(from: url) {
+           let image = await downloadPreparedImage(from: url) {
             await MainActor.run {
                 fetchedImage = image
                 didFailLoading = false
@@ -132,6 +132,28 @@ struct PlantCard: View {
 
         await MainActor.run {
             didFailLoading = true
+        }
+    }
+
+    /// Variante du téléchargement qui décode **ici**, pour les images affichées
+    /// directement sans passer par `PlantThumbnailCache.save`.
+    ///
+    /// `downloadImage` doit rendre l'image d'origine : son résultat alimente le
+    /// contrôle d'ancienneté, dont les heuristiques échantillonnent des pixels,
+    /// et l'écriture disque, qui ne doit pas figer une version réduite. Ce
+    /// chemin-ci n'a aucune de ces deux contraintes.
+    private func downloadPreparedImage(from url: URL) async -> UIImage? {
+        do {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .returnCacheDataElseLoad
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                return nil
+            }
+            return PlantThumbnailCache.imagePreteAAfficher(data: data)
+        } catch {
+            return nil
         }
     }
 
@@ -151,17 +173,22 @@ struct PlantCard: View {
     }
 
     private func displayAndCache(_ image: UIImage) async {
-        await MainActor.run {
-            fetchedImage = image
-            didFailLoading = false
-        }
-
+        // L'image d'origine n'est PAS affichée telle quelle. `UIImage(data:)`
+        // est paresseux : la poser ici ferait décompresser 720 × 900 px dans le
+        // passage de rendu, sur le thread principal — ce que ce correctif
+        // supprime partout ailleurs.
+        //
+        // `save` écrit le PNG puis rend la version déjà décodée. La carte reste
+        // sur son indicateur de chargement le temps de cet aller-retour, ce qui
+        // est à la fois plus court et plus honnête qu'une image posée d'avance
+        // au prix d'un gel.
         let cachedImage = await Task.detached(priority: .utility) {
             PlantThumbnailCache.save(image, plantID: plant.id)
         }.value
 
         await MainActor.run {
             cachedThumbnail = cachedImage
+            didFailLoading = false
         }
     }
 

--- a/ArboreUi/ArboreUiTests/PlantThumbnailDecodingTests.swift
+++ b/ArboreUi/ArboreUiTests/PlantThumbnailDecodingTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+import UIKit
+@testable import ArboreUi
+
+// PlantThumbnailDecodingTests.swift — gel du catalogue (ARBORE-FRONTEND-A).
+//
+// Le premier événement réel du build 32 : App Hang ≥ 2 s en parcourant le
+// catalogue, sur un iPhone 17 Pro, en production. La pile s'arrêtait dans
+// `CA::Layer::layout_and_display_if_needed` → `ScrollViewContentFrame`, sans
+// aucune frame applicative — le thread principal était bloqué DANS le rendu.
+//
+// La cause n'était pas une fonction lente, c'était une absente.
+// `UIImage(contentsOfFile:)` et `UIImage(data:)` ne décompressent rien : ils
+// rendent une image paresseuse dont le décodage a lieu au premier dessin, donc
+// sur le thread principal. Le code chargeait consciencieusement le fichier dans
+// un `Task.detached` — ce qui déporte la lecture, pas le décodage.
+//
+// S'y ajoutait `isLegacyThumbnail`, quatre balayages de pixels forçant chacun un
+// décodage complet, rejoués à CHAQUE apparition de carte alors que leur verdict
+// ne dépend que du fichier. Soit environ cinq décodages d'un PNG 720 × 900 par
+// vignette affichée, pour une grille qui en montre cinq à la fois.
+//
+// Ces tests gardent les trois propriétés qui font tenir le correctif. Aucun ne
+// mesure un temps : une assertion de durée passerait ou échouerait selon la
+// machine. Ils vérifient à la place ce qui CAUSE la durée — que l'image est
+// décodée d'avance, qu'elle est réduite, et qu'elle n'est calculée qu'une fois.
+
+final class PlantThumbnailDecodingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PlantThumbnailCache.viderCachesMemoire()
+    }
+
+    override func tearDown() {
+        PlantThumbnailCache.viderCachesMemoire()
+        super.tearDown()
+    }
+
+    // MARK: - Fabrique
+
+    /// Un PNG de la taille réelle des vignettes servies : 720 × 900.
+    ///
+    /// Le fond gris uniforme 0.72 n'est pas décoratif : c'est la seule forme
+    /// que `isLegacyThumbnail` accepte sans réserve, et celle qu'emploient déjà
+    /// `PlantThumbnailRenderingTests`. Une première version de cette fabrique
+    /// dessinait un bloc coloré sur fond blanc — soit exactement ce que
+    /// `hasLegacyWhiteWallDarkFloor` est fait pour détecter, et la vignette se
+    /// faisait condamner. Le détecteur avait raison ; c'est la fabrique qui
+    /// mentait.
+    ///
+    /// Ces tests portent sur le cycle du cache, pas sur le détecteur — lequel a
+    /// ses propres tests.
+    private func pngDeVignette(width: CGFloat = 720, height: CGFloat = 900) throws -> Data {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        let image = UIGraphicsImageRenderer(size: CGSize(width: width, height: height),
+                                            format: format).image { ctx in
+            UIColor(white: 0.72, alpha: 1).setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+        return try XCTUnwrap(image.pngData())
+    }
+
+    // MARK: - L'invariant central : l'image arrive décodée
+
+    /// La régression, dans sa forme la plus directe.
+    ///
+    /// `CGImage` non nul ne suffit pas à prouver le décodage — une image
+    /// paresseuse en expose un aussi. Ce qui le prouve, c'est de pouvoir lire
+    /// les octets : `dataProvider.data` force le décodage s'il n'a pas eu lieu,
+    /// et le fait de le faire ICI, dans le test, est précisément ce que le
+    /// correctif garantit qu'on peut faire hors du thread principal.
+    func testUneImagePrepareeExposeSesPixelsSansAttendreLeRendu() throws {
+        let data = try pngDeVignette()
+        let image = try XCTUnwrap(PlantThumbnailCache.imagePreteAAfficher(data: data))
+        let cg = try XCTUnwrap(image.cgImage)
+
+        XCTAssertNotNil(cg.dataProvider?.data,
+                        "Les pixels doivent être disponibles sans passer par un dessin")
+        XCTAssertGreaterThan(cg.width, 0)
+        XCTAssertGreaterThan(cg.height, 0)
+    }
+
+    /// Le second bénéfice : moins de pixels à décoder, puis à dessiner.
+    ///
+    /// La carte mesure ~173 × 220 pt, soit 519 × 660 px à l'échelle 3. Réduire
+    /// 720 × 900 à 576 × 720 couvre ce besoin avec de la marge.
+    func testUneVignetteEstReduiteAuxBesoinsDeLaCarte() throws {
+        let data = try pngDeVignette()
+        let image = try XCTUnwrap(PlantThumbnailCache.imagePreteAAfficher(data: data))
+        let cg = try XCTUnwrap(image.cgImage)
+
+        XCTAssertLessThanOrEqual(max(cg.width, cg.height), 720,
+                                 "Le côté le plus long doit être ramené à la taille d'affichage")
+        XCTAssertGreaterThanOrEqual(cg.height, 660,
+                                    "…mais pas en dessous de ce qu'un écran à l'échelle 3 demande")
+        XCTAssertLessThan(cg.width * cg.height, 720 * 900,
+                          "Il doit rester moins de pixels à décoder qu'à l'origine")
+    }
+
+    /// Une image plus petite que la cible ne doit pas être agrandie : on
+    /// gagnerait des pixels à décoder au lieu d'en perdre.
+    func testUnePetiteVignetteNEstPasAgrandie() throws {
+        let data = try pngDeVignette(width: 300, height: 375)
+        let image = try XCTUnwrap(PlantThumbnailCache.imagePreteAAfficher(data: data))
+        let cg = try XCTUnwrap(image.cgImage)
+
+        XCTAssertLessThanOrEqual(max(cg.width, cg.height), 375)
+    }
+
+    /// Des octets illisibles ne doivent pas faire tomber l'appelant.
+    func testDesOctetsInvalidesRendentNilPlutotQueDePlanter() {
+        let poubelle = Data([0x00, 0x01, 0x02, 0x03])
+        XCTAssertNil(PlantThumbnailCache.imagePreteAAfficher(data: poubelle))
+    }
+
+    // MARK: - La mémoire : ne payer qu'une fois
+
+    /// Le cœur du correctif côté défilement. Une carte qui réapparaît ne doit
+    /// ni relire le fichier, ni le revalider, ni le redécoder.
+    ///
+    /// L'identité de l'objet est la preuve : un second `load` qui rendrait une
+    /// instance différente aurait refait le travail.
+    func testUneSecondeLectureRendLaMemeInstanceSansRefaireLeTravail() throws {
+        let id = "test-memoire-\(UUID().uuidString)"
+        let data = try pngDeVignette()
+        let originale = try XCTUnwrap(UIImage(data: data))
+        PlantThumbnailCache.save(originale, plantID: id)
+        defer { try? FileManager.default.removeItem(at: PlantThumbnailCache.url(for: id)) }
+
+        let premiere = try XCTUnwrap(PlantThumbnailCache.load(for: id))
+        let seconde = try XCTUnwrap(PlantThumbnailCache.load(for: id))
+
+        XCTAssertTrue(premiere === seconde,
+                      "Le second appel doit servir l'instance déjà décodée")
+    }
+
+    /// `save` réécrit le fichier sous la même clé : la mémoire doit suivre,
+    /// sans quoi un `load` ultérieur servirait l'image précédente.
+    func testUneReecritureRemplaceLImageEnMemoire() throws {
+        let id = "test-reecriture-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(at: PlantThumbnailCache.url(for: id)) }
+
+        let premiere = try XCTUnwrap(UIImage(data: try pngDeVignette()))
+        PlantThumbnailCache.save(premiere, plantID: id)
+        let avant = try XCTUnwrap(PlantThumbnailCache.load(for: id))
+
+        // Une taille franchement différente, et sous le plafond de réduction :
+        // deux images qui plafonnent toutes deux à 720 se ressembleraient une
+        // fois préparées, et le test ne prouverait rien.
+        let seconde = try XCTUnwrap(UIImage(data: try pngDeVignette(width: 320, height: 400)))
+        PlantThumbnailCache.save(seconde, plantID: id)
+        let apres = try XCTUnwrap(PlantThumbnailCache.load(for: id))
+
+        XCTAssertFalse(avant === apres, "La mémoire doit être invalidée par la réécriture")
+        XCTAssertNotEqual(avant.cgImage?.height, apres.cgImage?.height,
+                          "C'est bien la nouvelle image qui est servie")
+    }
+
+    /// Ce que `save` rend doit être directement affichable : c'est ce que la
+    /// carte pose dans sa vue, sans repasser par un décodage.
+    func testCeQueSaveRendEstDejaDecode() throws {
+        let id = "test-save-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(at: PlantThumbnailCache.url(for: id)) }
+
+        let originale = try XCTUnwrap(UIImage(data: try pngDeVignette()))
+        let rendue = PlantThumbnailCache.save(originale, plantID: id)
+
+        let cg = try XCTUnwrap(rendue.cgImage)
+        XCTAssertNotNil(cg.dataProvider?.data)
+        XCTAssertLessThanOrEqual(max(cg.width, cg.height), 720)
+    }
+
+    // MARK: - Ce que la réduction ne doit PAS toucher
+
+    /// Le piège que ce correctif a failli introduire.
+    ///
+    /// `isLegacyThumbnail` échantillonne des pixels et efface le fichier quand
+    /// il conclut à une vignette périmée. Le juger sur une image redimensionnée
+    /// ferait basculer ses seuils de luminosité, et des vignettes légitimes
+    /// finiraient supprimées. Le contrôle porte donc sur l'ORIGINALE, et seul
+    /// l'affichage reçoit la version réduite.
+    ///
+    /// Ce test le vérifie par sa conséquence : une vignette correctement
+    /// marquée survit à un aller-retour complet par le cache.
+    func testUneVignetteLegitimeSurvitAuCycleComplet() throws {
+        let id = "test-survie-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(at: PlantThumbnailCache.url(for: id)) }
+
+        let originale = try XCTUnwrap(UIImage(data: try pngDeVignette()))
+        PlantThumbnailCache.save(originale, plantID: id)
+        PlantThumbnailCache.viderCachesMemoire()   // forcer la relecture disque
+
+        XCTAssertNotNil(PlantThumbnailCache.load(for: id),
+                        "Le contrôle d'ancienneté ne doit pas condamner une vignette valide")
+        XCTAssertTrue(FileManager.default.fileExists(at: PlantThumbnailCache.url(for: id)),
+                      "…ni effacer son fichier")
+    }
+
+    /// Un identifiant sans fichier reste sans image, et ne doit rien peupler.
+    func testUnIdentifiantSansFichierRendNil() {
+        XCTAssertNil(PlantThumbnailCache.load(for: "absent-\(UUID().uuidString)"))
+    }
+}
+
+private extension FileManager {
+    func fileExists(at url: URL) -> Bool { fileExists(atPath: url.path) }
+}


### PR DESCRIPTION
Le premier événement réel du build 32 : **App Hang ≥ 2 s en parcourant le catalogue**, sur un iPhone 17 Pro, en production ([ARBORE-FRONTEND-A](https://epi-apps.sentry.io/issues/ARBORE-FRONTEND-A)).

La pile s'arrêtait dans `CA::Layer::layout_and_display_if_needed` → `_UIHostingView.layoutSubviews` → `ScrollViewContentFrame`, **sans aucune frame applicative sous `main`**. Le thread principal était bloqué *dans* le rendu.

## Ce que j'ai écarté avant d'accuser

| suspect | verdict |
|---|---|
| #512 (difficulté) | diff filtré des commentaires : **zéro ligne de code** modifiée |
| filtre du catalogue | `contains` sur deux champs courts, une seule langue lue |
| garde-fou de décodage (#515) | tourne au chargement, pas au défilement |

## La cause n'était pas une fonction lente, c'était une absente

`UIImage(contentsOfFile:)` et `UIImage(data:)` ne décompressent rien : ils rendent une image **paresseuse** dont le décodage a lieu au premier dessin, donc dans le commit Core Animation. Le code chargeait consciencieusement le fichier dans un `Task.detached` — ce qui déporte la lecture, **pas le décodage**. Le travail coûteux restait sur le thread principal, à un endroit où rien ne le désignait.

S'y ajoutait `isLegacyThumbnail` : quatre balayages de pixels forçant chacun un décodage complet, **rejoués à chaque apparition de carte** alors que leur verdict ne dépend que du fichier.

Soit environ **cinq décodages d'un PNG 720 × 900 par vignette affichée**, pour une grille qui en montre cinq à la fois et un catalogue qui en compte 123.

Mesuré côté serveur : 124 vignettes, **60 Mio** au total, ~500 Ko et **720 × 900 px** chacune.

## Le correctif

`CGImageSourceCreateThumbnailAtIndex` avec `kCGImageSourceShouldCacheImmediately` décode et redimensionne en une passe, **là où on l'appelle** — donc hors du thread principal. Sans ce drapeau, ImageIO reste paresseux comme `UIImage(data:)` et le coût retombe dans le rendu.

Deux caches mémoire s'y ajoutent : les images déjà décodées (plafonnées à 40 Mio, une vingtaine — bien plus que la grille n'en montre, sans retenir les 123 fiches) et les verdicts d'ancienneté déjà rendus.

La réduction à 720 px de côté suit la carte : ~173 × 220 pt, soit 519 × 660 px à l'échelle 3. Une source de 720 × 900 ramenée à 576 × 720 couvre ce besoin avec 11 % de marge, en divisant par 1,6 le nombre de pixels à décoder.

## Un piège que ce correctif a failli introduire

Première version : réduire l'image **avant** le contrôle d'ancienneté. Ce contrôle échantillonne des pixels et **efface le fichier** quand il conclut au périmé. `hasCurrentDesignMarker` échantillonne en relatif et aurait survécu — mais les trois autres heuristiques jugent des seuils de luminosité qu'un rééchantillonnage peut faire basculer. Et `save` aurait figé sur disque la version réduite, dégradant le cache définitivement.

Le contrôle porte donc sur l'**originale**, et seul l'affichage reçoit la version préparée. `downloadImage` garde sa sémantique pour cette raison ; le repli sur la photo botanic, qui ne passe ni par le contrôle ni par l'écriture, utilise une variante préparée.

## Vérifications

**304 tests, 0 échec.** 9 nouveaux.

Un seul échoue si l'on retire la mémoïsation — les huit autres portent sur des fonctions que ce correctif *ajoute* et ne compileraient pas contre l'ancienne version. Je le dis plutôt que d'annoncer « 9 échouent sans le correctif », qui serait faux.

Aucune assertion de durée : elles passeraient ou échoueraient selon la machine. Les tests vérifient ce qui **cause** la durée — que l'image est décodée d'avance, qu'elle est réduite, et qu'elle n'est calculée qu'une fois.

Une première fabrique de test dessinait un bloc coloré sur fond blanc et se faisait condamner par le détecteur : c'est exactement ce que `hasLegacyWhiteWallDarkFloor` cherche. Le détecteur avait raison, la fabrique mentait.

## Pas de livraison

**Aucun build TestFlight n'accompagne cette PR**, à la demande : passage devant un jury cet après-midi, et le build 32 déjà installé ne doit pas bouger. Le correctif attend une livraison ultérieure.