### PR TITLE
feat(fastlane): la bêta publique automatisée, et la doc alignée sur les lanes — promotion vers main

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -35,7 +35,7 @@ The documentation is split into complementary views. Depending on what you are l
 | Web tests (Vitest) | [`testing/web.md`](testing/web.md) |
 | Observability (Sentry iOS + web) | [`operations/observability.md`](operations/observability.md) |
 | Botanical data audit | [`operations/botanical-data-audit.md`](operations/botanical-data-audit.md) |
-| TestFlight deployment (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
+| TestFlight deployment, internal and public beta (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
 | Prod/dev environments (targeting dev from Xcode) | [`operations/environments.md`](operations/environments.md) |
 | VPS provisioning (Docker · nginx · Mongo) | [`operations/vps-bootstrap.md`](operations/vps-bootstrap.md) |
 | 3D asset storage (R2 · S3 · MinIO) | [`operations/asset-storage.md`](operations/asset-storage.md) |

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -57,7 +57,7 @@ destination by mistake: everything lives in `epi-apps`.
 | Config / DSN assembly | `ArboreUi/ArboreUi/Config/AppConfig.swift` |
 | Secrets (gitignored) | `ArboreUi/Secrets.xcconfig` (+ `.example`) |
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
-| dSYM upload | `fastlane/Fastfile` → `beta` lane |
+| dSYM upload | `fastlane/Fastfile` → `beta` and `public_beta` lanes |
 
 `SentryManager` is **disabled until a DSN is configured**. Without secrets, the
 app builds and runs identically (handy for contributors and CI).
@@ -140,7 +140,19 @@ SENTRY_DSN_PROJECT_ID = <project id>
 
 Leave empty to keep Sentry disabled.
 
-**2. dSYM symbolication (fastlane).** The `beta` lane uploads the dSYMs after the TestFlight upload. Org/project are already wired in the Fastfile (`epi-apps` / `arbore-frontend`); all that remains is to provide an auth token. Without a token, the lane logs a skip and continues.
+**2. dSYM symbolication (fastlane).** The `beta` and `public_beta` lanes send the dSYMs **before** the TestFlight upload. Org/project are already wired in the Fastfile (`epi-apps` / `arbore-frontend`); all that remains is to provide an auth token. Without a token, the lane logs a skip and continues.
+
+> The order was reversed on 2026-09-10 (#511), and it is not a detail. On build
+> 31, an SSL cut towards Apple during the changelog step stopped the lane 36
+> minutes after a successful upload, therefore before the symbols were sent: the
+> binary was with the testers and its crashes promised to be unreadable call
+> stacks. A binary must never reach a tester before its symbols are at Sentry.
+> The dSYM is available as soon as `build_app` finishes; nothing required
+> waiting.
+>
+> If delivery then fails, we will have uploaded symbols for a build that does
+> not exist: a few orphan megabytes, without consequence. That is the right side
+> of the trade.
 
 ```bash
 brew install getsentry/tools/sentry-cli
@@ -155,7 +167,7 @@ Create the token at `sentry.io → Settings → Auth Tokens` (scopes `project:re
 1. Fill in the DSN in `Secrets.xcconfig`, run a **Debug** build.
 2. Profile → **Debug Tools → "Send Sentry test event"** (visible in DEBUG only).
 3. The event shows up in `sentry.io → arbore-frontend → Issues` within seconds, tagged `environment: debug`. **Without consent it carries no `user` at all** — the Firebase UID is attached only if "Link diagnostics to my account" is on.
-4. For symbolicated **release** crashes, ship a `fastlane beta` build with the token above, then trigger a crash on the TestFlight build.
+4. For symbolicated **release** crashes, ship a `fastlane beta` (or `public_beta`) build with the token above, then trigger a crash on the TestFlight build.
 
 > ℹ️ **Tests emit nothing.** `start()` returns immediately under XCTest (#506).
 > Before that fix, any machine whose `Secrets.xcconfig` carried a DSN sent a fake

--- a/docs/en/operations/testflight-deploy.md
+++ b/docs/en/operations/testflight-deploy.md
@@ -161,6 +161,100 @@ The command:
 
 Total: 10-40 min depending on Apple processing.
 
+### Ship to the public beta
+
+```bash
+bundle exec fastlane public_beta \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+```
+
+All four languages are **required**. The lane refuses to start if one is
+missing, and also refuses a path that points at no file.
+
+Same flow as `beta`, with three differences that matter.
+
+| | `beta` | `public_beta` |
+|---|---|---|
+| group | Internal QA (3 testers) | Bêta privée (10 testers, public link) |
+| Apple review | none | Beta App Review |
+| delay before testers get it | after processing | after approval, hours to a day |
+
+The build **reaches nobody** until Apple approves it. Do not confuse "shipped"
+with "received": `current_build` will show the number long before anyone can
+install it.
+
+### Release notes
+
+They live in `fastlane/changelogs/<locale>.txt`, one per language the app
+serves: `fr-FR`, `en-US`, `es-ES`, `de-DE`. Version-controlled, so they get
+reviewed like everything else.
+
+Neither an environment variable nor generated from the git log: a tester has no
+use for commit subjects, and text you reread is text you write better.
+
+#### The four paths are named by hand
+
+`fastlane/changelogs/` is a convention, **not a default**. No lane reads that
+directory on its own.
+
+That is the point. A lane that went looking there would publish the previous
+release's notes the day someone forgets to update them, silently, and the text
+would stay readable by testers until the next build. Having to name the four
+files forces you to look at them.
+
+For the same reason, a path pointing at no file is an **error**, never literal
+text: accepting both would publish `notes/33-de.txt` on the smallest typo.
+
+```bash
+bundle exec fastlane verifier_notes \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+
+bundle exec fastlane notes build:33 \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+```
+
+Relative paths resolve from the **repo root**, not from `fastlane/` where
+fastlane chdirs at startup. Absolute paths work too.
+
+`public_beta` runs this check **before archiving**. Failing on a turn of phrase
+after two and a half minutes of compilation would be a gratuitous punishment.
+
+#### What the check rejects
+
+- a missing or empty file, in any of the four languages;
+- more than 4,000 characters (the App Store Connect limit);
+- a **long dash** (`—` or `–`): it is not typed by accident, and its presence
+  marks text produced elsewhere;
+- a list of turns of phrase that keep coming back, per language: "nous sommes
+  ravis", "we're excited", "sumérgete", "wir freuen uns", "feel free to",
+  "seamless", "unlock"…
+
+The lane **refuses to ship** rather than let it through. That is deliberate: a
+badly written note stays readable by ten people until the next build, whereas a
+failed lane costs thirty seconds.
+
+> The phrase list is not a guarantee of style. It catches what repeats; it does
+> not replace a proofread. The lane therefore prints the first line of each
+> language before sending.
+
+#### How to write these notes
+
+One line per change, present tense, saying what changes for the user rather than
+what changed in the code. "The catalog no longer freezes when you scroll
+quickly" rather than "optimised thumbnail decoding".
+
+End with what you want tested first: that is the only part testers actually
+follow.
+
 ### Check the latest build on TestFlight
 
 ```bash

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -35,7 +35,7 @@ La documentation est découpée en vues complémentaires. Selon l'information re
 | Tests Web (Vitest) | [`testing/web.md`](testing/web.md) |
 | Observabilité (Sentry iOS + web) | [`operations/observability.md`](operations/observability.md) |
 | Audit des données botaniques | [`operations/botanical-data-audit.md`](operations/botanical-data-audit.md) |
-| Déploiement TestFlight (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
+| Déploiement TestFlight, interne et bêta publique (fastlane) | [`operations/testflight-deploy.md`](operations/testflight-deploy.md) |
 | Environnements prod/dev (viser le dev depuis Xcode) | [`operations/environnements.md`](operations/environnements.md) |
 | Provisionnement VPS (Docker · nginx · Mongo) | [`operations/vps-bootstrap.md`](operations/vps-bootstrap.md) |
 | Stockage des assets 3D (R2 · S3 · MinIO) | [`operations/stockage-assets.md`](operations/stockage-assets.md) |

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -58,7 +58,7 @@ de destination par erreur : tout vit dans `epi-apps`.
 | Config / assemblage DSN | `ArboreUi/ArboreUi/Config/AppConfig.swift` |
 | Secrets (gitignorés) | `ArboreUi/Secrets.xcconfig` (+ `.example`) |
 | Privacy manifest | `ArboreUi/ArboreUi/PrivacyInfo.xcprivacy` (CrashData + OtherDiagnosticData) |
-| Upload dSYM | `fastlane/Fastfile` → lane `beta` |
+| Upload dSYM | `fastlane/Fastfile` → lanes `beta` et `public_beta` |
 
 `SentryManager` est **désactivé tant qu'un DSN n'est pas configuré**. Sans
 secrets, l'app se build et tourne à l'identique (pratique pour les contributeurs
@@ -143,7 +143,19 @@ SENTRY_DSN_PROJECT_ID = <project id>
 
 Laisser vide pour garder Sentry désactivé.
 
-**2. Symbolication dSYM (fastlane).** La lane `beta` uploade les dSYM après l'upload TestFlight. Org/projet sont déjà câblés dans le Fastfile (`epi-apps` / `arbore-frontend`) ; il ne reste qu'à fournir un token d'auth. Sans token, la lane log un skip et continue.
+**2. Symbolication dSYM (fastlane).** Les lanes `beta` et `public_beta` envoient les dSYM **avant** l'upload TestFlight. Org/projet sont déjà câblés dans le Fastfile (`epi-apps` / `arbore-frontend`) ; il ne reste qu'à fournir un token d'auth. Sans token, la lane log un skip et continue.
+
+> L'ordre a été inversé le 2026-09-10 (#511), et ce n'est pas un détail. Sur le
+> build 31, une coupure SSL vers Apple pendant la pose du changelog a arrêté la
+> lane 36 minutes après un upload réussi, donc avant l'envoi des symboles : le
+> binaire était chez les testeurs et ses plantages promis à des piles d'appel
+> illisibles. Un binaire ne doit jamais atteindre un testeur avant que ses
+> symboles soient chez Sentry. Le dSYM est disponible dès la fin de `build_app`,
+> rien n'obligeait à attendre.
+>
+> Si la livraison échoue ensuite, on aura téléversé les symboles d'un build qui
+> n'existe pas : quelques mégaoctets orphelins, sans conséquence. C'est le bon
+> sens de l'échange.
 
 ```bash
 brew install getsentry/tools/sentry-cli
@@ -158,7 +170,7 @@ Créer le token sur `sentry.io → Settings → Auth Tokens` (scopes `project:re
 1. Renseigner le DSN dans `Secrets.xcconfig`, lancer un build **Debug**.
 2. Profil → **Debug Tools → « Send Sentry test event »** (visible en DEBUG uniquement).
 3. L'événement apparaît dans `sentry.io → arbore-frontend → Issues` en quelques secondes, tagué `environment: debug`. **Sans consentement il ne porte aucun `user`** — l'UID Firebase n'y est joint que si « Rattacher les diagnostics à mon compte » est activé.
-4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
+4. Pour des crashs **release** symbolisés, livrer un build `fastlane beta` (ou `public_beta`) avec le token ci-dessus, puis déclencher un crash sur le build TestFlight.
 
 > ℹ️ **Les tests n'émettent rien.** `start()` sort immédiatement sous XCTest
 > (#506). Avant ce correctif, toute machine dont le `Secrets.xcconfig` portait un

--- a/docs/fr/operations/testflight-deploy.md
+++ b/docs/fr/operations/testflight-deploy.md
@@ -162,6 +162,103 @@ La commande :
 
 Total : 10-40 min selon le processing Apple.
 
+### Livrer à la bêta publique
+
+```bash
+bundle exec fastlane public_beta \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+```
+
+Les quatre langues sont **obligatoires**. La lane refuse de démarrer s'il en
+manque une, et refuse aussi un chemin qui ne désigne aucun fichier.
+
+Même déroulé que `beta`, avec trois différences qui comptent.
+
+| | `beta` | `public_beta` |
+|---|---|---|
+| groupe | Internal QA (3 testeurs) | Bêta privée (10 testeurs, lien public) |
+| revue Apple | aucune | Beta App Review |
+| délai avant réception | après le processing | après approbation, de quelques heures à un jour |
+
+La build **n'atteint personne** tant qu'Apple n'a pas approuvé. Ne pas confondre
+« livrée » et « reçue » : `current_build` affichera le numéro bien avant que
+quiconque puisse l'installer.
+
+### Les notes de version
+
+Elles vivent dans `fastlane/changelogs/<locale>.txt`, une par langue desservie :
+`fr-FR`, `en-US`, `es-ES`, `de-DE`. Versionnées, donc relues en revue comme le
+reste.
+
+Ni variable d'environnement, ni génération depuis le journal git : un testeur
+n'a rien à faire de sujets de commit, et un texte qu'on relit est un texte qu'on
+écrit mieux.
+
+#### Les quatre chemins se nomment à la main
+
+`fastlane/changelogs/` est une convention, **pas un défaut**. Aucune lane ne lit
+ce dossier toute seule.
+
+C'est le point important. Une lane qui irait y chercher les fichiers publierait
+les notes de la version précédente le jour où l'on oublie de les mettre à jour,
+sans rien signaler, et le texte resterait lisible par les testeurs jusqu'à la
+build suivante. Devoir nommer les quatre fichiers force à les regarder.
+
+Pour la même raison, un chemin qui ne désigne aucun fichier est une **faute**,
+jamais un texte littéral : accepter les deux ferait publier
+`notes/33-de.txt` à la moindre faute de frappe.
+
+```bash
+bundle exec fastlane verifier_notes \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+
+bundle exec fastlane notes build:33 \
+  fr:fastlane/changelogs/fr-FR.txt \
+  en:fastlane/changelogs/en-US.txt \
+  es:fastlane/changelogs/es-ES.txt \
+  de:fastlane/changelogs/de-DE.txt
+```
+
+Les chemins relatifs se résolvent depuis la **racine du dépôt**, pas depuis
+`fastlane/` où fastlane se place au démarrage. Les chemins absolus marchent
+aussi.
+
+`public_beta` lance ce contrôle **avant l'archive**. Échouer sur une tournure
+après deux minutes et demie de compilation serait une punition gratuite.
+
+#### Ce que le contrôle refuse
+
+- un fichier absent ou vide, dans l'une des quatre langues ;
+- plus de 4 000 caractères (la limite d'App Store Connect) ;
+- un **tiret long** (`—` ou `–`) : il ne se tape pas au clavier par accident, sa
+  présence signe un texte produit ailleurs ;
+- une liste de tournures qui reviennent toujours, par langue : « nous sommes
+  ravis », « we're excited », « sumérgete », « wir freuen uns », « n'hésitez
+  pas », « seamless », « unlock »…
+
+La lane **refuse de livrer** plutôt que de laisser passer. C'est délibéré : une
+note mal écrite reste lisible par dix personnes jusqu'à la build suivante, alors
+qu'un échec de lane coûte trente secondes.
+
+> La liste de tournures n'est pas une garantie de style. Elle attrape ce qui se
+> répète, elle ne remplace pas une relecture. La lane affiche donc la première
+> ligne de chaque langue avant d'envoyer.
+
+#### Comment écrire ces notes
+
+Une ligne par changement, au présent, en disant ce qui change pour l'utilisateur
+et non ce qui a changé dans le code. « Le catalogue ne se fige plus quand on le
+fait défiler vite » plutôt que « optimisation du décodage des vignettes ».
+
+Terminer par ce qu'on veut voir testé en priorité : c'est la seule partie que les
+testeurs suivent vraiment.
+
 ### Vérifier le dernier build sur TestFlight
 
 ```bash

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,8 +15,20 @@
 #   4. Xcode automatic signing activé sur la machine qui déploie
 #
 # Usage :
-#   bundle exec fastlane beta            # déploie une nouvelle build interne
+#   bundle exec fastlane beta            # build interne (3 testeurs, immédiat)
+#   bundle exec fastlane public_beta     # build externe (« Bêta privée », via Apple)
+#   bundle exec fastlane verifier_notes  # contrôle les notes sans rien livrer
+#   bundle exec fastlane notes build:33  # republie les notes d'une build en ligne
 #   bundle exec fastlane current_build   # affiche le dernier build_number sur TestFlight
+#
+# Interne ou externe, la différence n'est pas cosmétique :
+#
+#   `beta`        → groupe « Internal QA », distribution immédiate après le
+#                   processing, aucune revue Apple.
+#   `public_beta` → groupe « Bêta privée », lien public TestFlight, soumission à
+#                   la Beta App Review. La build n'atteint personne tant
+#                   qu'Apple n'a pas approuvé, ce qui prend de quelques heures
+#                   à un jour.
 
 WORKSPACE = "ArboreUi/ArboreUi.xcworkspace"
 SCHEME    = "ArboreUi"
@@ -26,6 +38,31 @@ SCHEME    = "ArboreUi"
 # relatif chercherait `fastlane/fastlane/AuthKey.json`).
 AUTH_KEY  = File.expand_path("AuthKey.json", __dir__)
 INTERNAL_GROUP = "Internal QA"
+# Groupe EXTERNE, celui du lien public TestFlight. Distribuer ici expose la
+# build à des gens qui ne sont pas dans l'équipe, et passe par la Beta App
+# Review d'Apple.
+EXTERNAL_GROUP = "Bêta privée"
+APP_IDENTIFIER = "com.arboreteam.arbore"
+
+# Les quatre locales que l'app dessert, et les seules déclarées côté ASC.
+# Un testeur dont l'iPhone est dans une autre langue lit la locale par défaut.
+BETA_LOCALES = ["fr-FR", "en-US", "es-ES", "de-DE"].freeze
+DEFAULT_LOCALE = "fr-FR"
+# Option courte attendue sur la ligne de commande → locale App Store Connect.
+# `fastlane public_beta fr:… en:… es:… de:…`
+OPTIONS_LOCALES = {
+  fr: "fr-FR",
+  en: "en-US",
+  es: "es-ES",
+  de: "de-DE"
+}.freeze
+# Emplacement conventionnel des fichiers. Ce n'est PAS un défaut : la lane ne
+# lit jamais ce dossier toute seule (cf. `lire_et_verifier_notes`).
+CHANGELOG_DIR = File.expand_path("changelogs", __dir__)
+# Racine du dépôt. fastlane se place dans `fastlane/` au démarrage : un chemin
+# relatif tapé depuis la racine y désignerait `fastlane/fastlane/…`. On résout
+# donc d'abord depuis la racine, qui est là où l'on lance la commande.
+REPO_ROOT = File.expand_path("..", __dir__)
 
 # Sentry (#205) — org/projet ne sont pas des secrets, donc valeurs par défaut.
 # Overridables par variable d'env. Le token, lui, reste hors-repo : variable
@@ -167,6 +204,252 @@ platform :ios do
     end
 
     UI.success("✅ Build #{latest + 1} déployée sur TestFlight → groupe #{INTERNAL_GROUP}")
+  end
+
+  # ─── Notes de version ───────────────────────────────────────────────────
+  #
+  # Les notes vivent dans `fastlane/changelogs/<locale>.txt`, versionnées, une
+  # par langue desservie. Pas dans une variable d'environnement ni dérivées du
+  # journal git : un testeur ne veut pas lire des sujets de commit, et un texte
+  # qu'on relit en revue est un texte qu'on écrit mieux.
+  #
+  # Le contrôle ci-dessous REFUSE la livraison plutôt que de laisser passer.
+  # C'est délibéré : une note publiée mal écrite reste lisible par dix personnes
+  # jusqu'à la build suivante, alors qu'un échec de lane coûte trente secondes.
+
+  # Tournures bannies, par langue. La liste n'est pas une garantie de style,
+  # c'est un filet contre les formules qui reviennent toujours. Elle attrape ce
+  # qui se répète ; elle ne remplace pas une relecture.
+  TOURNURES_BANNIES = {
+    "fr-FR" => [
+      "nous sommes ravis", "nous sommes heureux", "n'hésitez pas",
+      "plongez dans", "révolutionn", "et ce n'est pas tout",
+      "toujours plus", "au service de", "une expérience unique"
+    ],
+    "en-US" => [
+      "we're excited", "we are excited", "we're thrilled", "we are thrilled",
+      "dive into", "seamless", "unlock", "elevate your", "game-chang",
+      "supercharge", "and that's not all", "feel free to", "take your"
+    ],
+    "es-ES" => [
+      "nos complace", "estamos encantados", "no dudes en", "sumérgete",
+      "revolucion", "lleva tu", "y eso no es todo"
+    ],
+    "de-DE" => [
+      "wir freuen uns", "zögern sie nicht", "tauchen sie ein",
+      "revolutionär", "heben sie", "und das ist noch nicht alles"
+    ]
+  }.freeze
+
+  # La limite d'App Store Connect sur le champ « What to Test ».
+  LIMITE_NOTES = 4000
+
+  desc "Vérifie des notes de version sans rien livrer."
+  desc "Usage : fastlane verifier_notes fr:… en:… es:… de:… (chemins de fichiers)"
+  lane :verifier_notes do |options|
+    notes = lire_et_verifier_notes(options)
+    UI.success("✅ Les #{notes.size - 1} langues passent le contrôle.")
+  end
+
+  # Résout un chemin donné sur la ligne de commande.
+  #
+  # fastlane fait `chdir` dans `fastlane/` au démarrage. Un chemin relatif tapé
+  # depuis la racine du dépôt — ce que tout le monde fait — y chercherait
+  # `fastlane/fastlane/changelogs/…`. Le piège a été rencontré, pas anticipé :
+  # c'est le même que celui déjà documenté pour `AuthKey.json`.
+  #
+  # On essaie donc la racine d'abord, puis le dossier courant. Un chemin absolu
+  # est pris tel quel.
+  def resoudre_chemin(brut)
+    return File.expand_path(brut) if brut.start_with?("/")
+
+    depuis_racine = File.expand_path(brut, REPO_ROOT)
+    return depuis_racine if File.file?(depuis_racine)
+
+    depuis_courant = File.expand_path(brut)
+    return depuis_courant if File.file?(depuis_courant)
+
+    # Aucun des deux n'existe : rendre celui depuis la racine, pour que le
+    # message d'erreur montre le chemin auquel l'utilisateur pensait.
+    depuis_racine
+  end
+
+  # Le message d'aide, rendu une fois plutôt que recopié dans chaque lane.
+  def usage_notes(commande)
+    "Les quatre langues doivent être nommées explicitement :\n\n" \
+    "  bundle exec fastlane #{commande} \\\n" \
+    "    fr:fastlane/changelogs/fr-FR.txt \\\n" \
+    "    en:fastlane/changelogs/en-US.txt \\\n" \
+    "    es:fastlane/changelogs/es-ES.txt \\\n" \
+    "    de:fastlane/changelogs/de-DE.txt"
+  end
+
+  # Lit les quatre fichiers NOMMÉS SUR LA LIGNE DE COMMANDE, les contrôle, et
+  # rend la structure attendue par `upload_to_testflight`.
+  #
+  # Aucun chemin par défaut, volontairement. Une lane qui lirait
+  # `fastlane/changelogs/` toute seule publierait les notes de la version
+  # précédente le jour où l'on oublie de les mettre à jour — sans rien signaler,
+  # et le texte resterait lisible par dix testeurs jusqu'à la build suivante.
+  # Devoir nommer les quatre fichiers force à les regarder.
+  #
+  # Un chemin qui ne désigne aucun fichier est une FAUTE, jamais un texte
+  # littéral : accepter les deux ferait publier « notes/33-fr.txt » à la moindre
+  # faute de frappe.
+  def lire_et_verifier_notes(options)
+    options ||= {}
+    fautes = []
+    textes = {}
+
+    manquantes = OPTIONS_LOCALES.keys.reject { |k| options[k].to_s.strip != "" }
+    unless manquantes.empty?
+      UI.user_error!(
+        "Langues non fournies : #{manquantes.join(', ')}\n\n" +
+        usage_notes("<lane>")
+      )
+    end
+
+    OPTIONS_LOCALES.each do |option, locale|
+      chemin = resoudre_chemin(options[option].to_s.strip)
+      unless File.file?(chemin)
+        fautes << "#{locale} (#{option}:) : aucun fichier à #{chemin}"
+        next
+      end
+
+      texte = File.read(chemin).strip
+      if texte.empty?
+        fautes << "#{locale} : fichier vide (#{chemin})"
+        next
+      end
+
+      if texte.length > LIMITE_NOTES
+        fautes << "#{locale} : #{texte.length} caractères, la limite ASC est #{LIMITE_NOTES}"
+      end
+
+      # Le tiret cadratin et le tiret demi-cadratin. Ils ne se tapent pas au
+      # clavier par accident ; leur présence signe un texte produit ailleurs.
+      if texte.include?("—") || texte.include?("–")
+        fautes << "#{locale} : contient un tiret long (— ou –). Utiliser deux-points, parenthèses ou point."
+      end
+
+      bannies = (TOURNURES_BANNIES[locale] || []).select { |t| texte.downcase.include?(t) }
+      bannies.each { |t| fautes << "#{locale} : tournure bannie « #{t} »" }
+
+      textes[locale] = texte
+    end
+
+    unless fautes.empty?
+      UI.user_error!(
+        "Notes de version refusées :\n" +
+        fautes.map { |f| "  · #{f}" }.join("\n")
+      )
+    end
+
+    # On montre ce qui part. Un contrôle automatique attrape des tournures, pas
+    # un contresens : la dernière relecture est humaine.
+    UI.message("Notes de version qui seront publiées :")
+    BETA_LOCALES.each do |locale|
+      UI.message("  [#{locale}] #{textes[locale].lines.first.to_s.strip}")
+    end
+
+    infos = {}
+    textes.each { |locale, texte| infos[locale] = { whats_new: texte } }
+    infos["default"] = { whats_new: textes[DEFAULT_LOCALE] }
+    infos
+  end
+
+  desc "Build + upload TestFlight + distribution au groupe EXTERNE « Bêta privée »."
+  desc "Soumet à la Beta App Review d'Apple et publie des notes dans les 4 langues."
+  desc "Usage : fastlane public_beta fr:… en:… es:… de:… (chemins de fichiers)"
+  lane :public_beta do |options|
+    # Le contrôle des notes passe AVANT l'archive. Échouer sur une tournure
+    # après deux minutes et demie de compilation serait une punition gratuite.
+    notes = lire_et_verifier_notes(options)
+
+    version = get_version_number(xcodeproj: "ArboreUi/ArboreUi.xcodeproj")
+    latest = latest_testflight_build_number(api_key_path: AUTH_KEY, version: version)
+    increment_build_number(
+      xcodeproj: "ArboreUi/ArboreUi.xcodeproj",
+      build_number: latest + 1
+    )
+
+    build_app(
+      workspace: WORKSPACE,
+      scheme: SCHEME,
+      export_method: "app-store",
+      clean: true,
+      output_directory: "./fastlane/builds",
+      output_name: "Arbore.ipa",
+      include_symbols: true,
+      include_bitcode: false,
+      xcargs: "-allowProvisioningUpdates"
+    )
+
+    # Même ordre que `beta`, et pour la même raison : les symboles avant le
+    # binaire. Elle compte davantage ici, puisque les plantages viendront de
+    # gens qui ne peuvent pas nous décrire ce qu'ils faisaient.
+    begin
+      upload_dsyms_to_sentry(
+        version: version,
+        build: latest + 1,
+        dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH]
+      )
+    rescue => e
+      UI.important("⚠️ Upload dSYM Sentry échoué : #{e.message}")
+      UI.important("   Le build partira SANS symboles vers des testeurs externes.")
+    end
+
+    # `distribute_external: true` déclenche la Beta App Review. Apple la traite
+    # en général en quelques heures, et la build n'atteint le groupe qu'une fois
+    # approuvée : elle n'est donc PAS visible immédiatement, contrairement au
+    # groupe interne.
+    #
+    # Pas de `rescue` sur le changelog ici, à l'inverse de `beta` : les notes
+    # sont l'objet de cette lane. Les perdre silencieusement rendrait à dix
+    # testeurs externes un texte vide ou celui de la build précédente.
+    upload_to_testflight(
+      api_key_path: AUTH_KEY,
+      ipa: "./fastlane/builds/Arbore.ipa",
+      distribute_external: true,
+      groups: [EXTERNAL_GROUP],
+      submit_beta_review: true,
+      skip_waiting_for_build_processing: false,
+      localized_build_info: notes
+    )
+
+    UI.success("✅ Build #{latest + 1} soumise à la Beta App Review → groupe #{EXTERNAL_GROUP}")
+    UI.important("   Elle n'atteindra les testeurs qu'une fois approuvée par Apple.")
+  end
+
+  desc "Republie les notes de version sur une build DÉJÀ en ligne, sans rien reconstruire."
+  desc "Usage : fastlane notes build:33 fr:… en:… es:… de:…"
+  lane :notes do |options|
+    numero = options[:build]
+    unless numero
+      UI.user_error!("Préciser la build.\n\n" + usage_notes("notes build:33"))
+    end
+    infos = lire_et_verifier_notes(options)
+
+    version = get_version_number(xcodeproj: "ArboreUi/ArboreUi.xcodeproj")
+    # `distribute_only` dit à pilot de travailler sur une build DÉJÀ en ligne.
+    # Sans lui, l'action réclame une IPA et échoue sur « No ipa or pkg file
+    # given » : elle croit qu'on lui demande de livrer, pas de corriger un texte.
+    upload_to_testflight(
+      api_key_path: AUTH_KEY,
+      # Sans IPA, pilot ne peut déduire ni l'app ni la plateforme : il les
+      # demande en invite, ce qui fait planter toute exécution non interactive.
+      app_identifier: APP_IDENTIFIER,
+      app_platform: "ios",
+      app_version: version,
+      build_number: numero.to_s,
+      distribute_only: true,
+      distribute_external: false,
+      skip_submission: true,
+      skip_waiting_for_build_processing: true,
+      localized_build_info: infos
+    )
+
+    UI.success("✅ Notes republiées sur la build #{numero} dans #{BETA_LOCALES.size} langues.")
   end
 
   desc "Pousse les TEXTES du listing App Store (fastlane/metadata) vers ASC."

--- a/fastlane/changelogs/de-DE.txt
+++ b/fastlane/changelogs/de-DE.txt
@@ -1,0 +1,11 @@
+Der Katalog hängt nicht mehr, wenn du schnell scrollst. Die Bilder werden vor der Anzeige aufbereitet.
+
+Die Pflanzenseiten sind auf Spanisch und Deutsch vollständig. Bisher fielen drei Viertel des Katalogs auf Englisch zurück.
+
+Der Filter nach Schwierigkeit funktioniert. Vorher lieferte er keine Ergebnisse.
+
+Außenpflanzen (Ahorn, Olive, Lavendel) erscheinen in Augmented Reality in hoher Auflösung.
+
+Ein Eintrag, der keine Pflanze war, wurde aus dem Katalog entfernt.
+
+Zuerst testen: Scrolle den Katalog ganz nach unten und wechsle dann die App-Sprache in den iOS-Einstellungen.

--- a/fastlane/changelogs/en-US.txt
+++ b/fastlane/changelogs/en-US.txt
@@ -1,0 +1,11 @@
+The catalog no longer freezes when you scroll quickly. Images are prepared before they are shown.
+
+Plant pages are complete in Spanish and German. Until now, three quarters of the catalog fell back to English.
+
+The difficulty filter works. It returned no results before.
+
+Outdoor plants (maple, olive, lavender) show in high definition in augmented reality.
+
+One entry that was not a plant has been removed from the catalog.
+
+Worth testing first: scroll the catalog all the way down, then change the app language in iOS settings.

--- a/fastlane/changelogs/es-ES.txt
+++ b/fastlane/changelogs/es-ES.txt
@@ -1,0 +1,11 @@
+El catálogo ya no se congela al desplazarte rápido. Las imágenes se preparan antes de mostrarse.
+
+Las fichas están completas en español y en alemán. Hasta ahora, tres cuartas partes del catálogo pasaban al inglés.
+
+El filtro por dificultad funciona. Antes no devolvía ningún resultado.
+
+Las plantas de exterior (arce, olivo, lavanda) se muestran en alta definición en realidad aumentada.
+
+Se ha retirado del catálogo una ficha que no era una planta.
+
+Para probar primero: desplaza el catálogo hasta el final y luego cambia el idioma de la app en los ajustes de iOS.

--- a/fastlane/changelogs/fr-FR.txt
+++ b/fastlane/changelogs/fr-FR.txt
@@ -1,0 +1,11 @@
+Le catalogue ne se fige plus quand on le fait défiler vite. Les images sont préparées avant d'être affichées.
+
+Les fiches sont complètes en espagnol et en allemand. Jusqu'ici, les trois quarts du catalogue basculaient en anglais.
+
+Le filtre par difficulté fonctionne. Il ne renvoyait aucun résultat avant.
+
+Les plantes d'extérieur (érable, olivier, lavande) s'affichent en haute définition en réalité augmentée.
+
+Une fiche qui n'était pas une plante a été retirée du catalogue.
+
+À tester en premier : faites défiler le catalogue jusqu'en bas, puis changez la langue de l'app dans les réglages iOS.


### PR DESCRIPTION
Promotion de `dev` vers `main`. Une PR, aucun code embarqué dans l'app : `Fastfile`, notes de version et documentation.

**Aucun build ne suit cette promotion.** Un binaire construit sur ce commit serait identique au build 33 déjà chez les testeurs, et le refaire coûterait une Beta App Review pour du Ruby et du Markdown.

## Le défaut qui a déclenché le travail

Le groupe externe « Bêta privée » (10 testeurs, lien public TestFlight) n'était atteignable qu'à la main. Le build 33, promu manuellement, présentait donc à ces dix personnes, dans les quatre langues :

> Build interne automatique (lane: beta).

C'est le texte que la lane interne pose faute d'en avoir un autre. Les vraies notes ont depuis été publiées via la nouvelle lane `notes`.

## Trois lanes

| lane | rôle |
|---|---|
| `public_beta` | archive, dSYM, distribution au groupe externe avec `submit_beta_review: true` |
| `verifier_notes` | contrôle les textes sans rien livrer |
| `notes build:N` | republie les notes sur une build déjà en ligne, sans reconstruire |

La différence entre interne et externe n'est pas cosmétique :

| | `beta` | `public_beta` |
|---|---|---|
| groupe | Internal QA (3) | Bêta privée (10, lien public) |
| revue Apple | aucune | Beta App Review |
| délai avant réception | après le processing | après approbation, heures à un jour |

## Les quatre langues se nomment à la main

```bash
bundle exec fastlane public_beta \
  fr:fastlane/changelogs/fr-FR.txt \
  en:fastlane/changelogs/en-US.txt \
  es:fastlane/changelogs/es-ES.txt \
  de:fastlane/changelogs/de-DE.txt
```

`fastlane/changelogs/` est une convention, **pas un défaut** : aucune lane ne lit ce dossier toute seule. Une lane qui irait y chercher les fichiers publierait les notes de la version précédente le jour d'un oubli, sans rien signaler.

Un chemin qui ne désigne aucun fichier est une **faute**, jamais un texte littéral : accepter les deux ferait publier `notes/33-de.txt` à la moindre faute de frappe.

## Le contrôle refuse plutôt que de laisser passer

Une langue non fournie, un chemin mort, un fichier vide, plus de 4 000 caractères, un **tiret long** (`—` ou `–`), ou une tournure bannie par langue (« nous sommes ravis », « we're excited », « sumérgete », « wir freuen uns »…).

Le contrôle tourne avant l'archive : échouer sur une tournure après deux minutes et demie de compilation serait une punition gratuite.

Sept épreuves, sept comportements justes. Un garde-fou qu'on n'a pas vu refuser n'est pas un garde-fou.

## Une affirmation documentaire qui contredisait le code

`observability.md` annonçait, en FR comme en EN, que la lane envoie les dSYM « après l'upload TestFlight ». C'est l'inverse depuis #511, la PR qui avait justement inversé l'ordre : la mise à jour documentaire d'alors avait manqué cette phrase.

Corrigée, avec le pourquoi plutôt que le seul quoi : sur le build 31, une coupure SSL a arrêté la lane 36 minutes après un upload réussi, donc avant l'envoi des symboles.

## Trois pièges de pilot, consignés dans le code

1. fastlane fait `chdir` dans `fastlane/` : un chemin relatif tapé depuis la racine cherchait `fastlane/fastlane/…`. Même piège que celui déjà documenté pour `AuthKey.json`, rencontré à l'épreuve et non anticipé.
2. Sans IPA, `upload_to_testflight` exige `distribute_only`.
3. Il faut lui nommer `app_identifier` et `app_platform`, sinon il pose une invite et plante en mode non interactif.

## Vérifications

Contrôle de dérive documentaire : 526 références de code vérifiées dans `docs/`, aucune dérive. FR et EN à parité.