### PR TITLE
docs: l'audit documentaire du 31 août à aujourd'hui — promotion vers main

### DIFF
--- a/docs/en/3d-lod-architecture.md
+++ b/docs/en/3d-lod-architecture.md
@@ -17,6 +17,25 @@ Result: the catalog is instant (PNG), AR placement is fast (light), and the user
 ## Runtime behavior
 
 - **Catalog**: `ArboreUi/ArboreUi/Views/PlantCard.swift` loads the PNG thumbnail through `GET /models/thumbnails/{id}.png?v={designVersion}` and stores it in `PlantThumbnailCache`. The version parameter invalidates both the iOS disk cache and the former Cloudflare response when a new design replaces a file under the same identifier. Every render also carries a version signature hidden inside the card's clipped corners; any server PNG without that signature is rejected. If a PNG is unavailable or outdated, the catalog photo is used as a lightweight fallback: the customer-facing catalog never builds 3D thumbnails locally. `PlantThumbnailGenerator` remains limited to the debug/admin screen used before upload. Those renders fit the model's complete projected volume with a shared margin, a continuous gray backdrop, and a short contact shadow.
+
+  **Decoding** those PNGs matters as much as downloading them, and is less
+  obvious. `UIImage(contentsOfFile:)` and `UIImage(data:)` are lazy: they
+  decompress nothing, and decoding happens on first draw, inside the Core
+  Animation commit, on the main thread. Loading the file in a `Task.detached`
+  moves the read off the main thread, not the decode. With 720 × 900 px
+  thumbnails and a grid showing five of them, fast scrolling froze the app for
+  two seconds, measured in production on build 32 (`ARBORE-FRONTEND-A`).
+
+  Since #518, `PlantThumbnailCache` decodes and downsamples in one pass through
+  `CGImageSourceCreateThumbnailAtIndex` with `kCGImageSourceShouldCacheImmediately`,
+  the flag without which ImageIO stays lazy. Two memory caches go with it:
+  decoded images (40 MiB cap) and the version-signature verdicts, whose four
+  pixel scans used to run again on every card appearance.
+
+  The signature check runs on the **original** image, never on the downsampled
+  one: its heuristics sample pixels and **delete the file** when they conclude it
+  is outdated. Judging them on a resampled image would shift their thresholds,
+  and legitimate thumbnails would be removed.
 - **3D model**: `ArboreUi/ArboreUi/Services/ModelCacheManager.swift` downloads the USDZ (disk cache keyed by file name), used in AR and for thumbnail generation.
 - **Backend**: `GET /models/:filename` (protected) serves the USDZ from `./models/`; the `?lod=heavy` parameter switches the read to `./models/heavy/`. `GET /models/thumbnails/:filename` (public) serves the PNGs.
 

--- a/docs/en/architecture/04-data-model.md
+++ b/docs/en/architecture/04-data-model.md
@@ -172,9 +172,51 @@ LanguageData {
   soilAndPot: {substrate, drainage, potSize, repotFrequency, repotSigns},
   health: {commonProblems, symptomsAndCauses, pests, treatments, prevention},
   lifeCycle: {growth, flowering, dormancy, fertilizer, pruning},
-  care: {weekly, monthly, yearly, extraTips}
+  care: {difficulty, weekly, monthly, yearly, extraTips}
 }
 ```
+
+All 123 records carry the **four languages** since #513 and #514. Before that,
+97 of them had only `fr` and `en`, and a Spanish or German reader saw English
+through the `language → en → any` fallback.
+
+##### `care.difficulty` is not prose
+
+This field is read **by keyword**, not displayed as-is: `Plant.careDifficulty(locale:)`
+matches it against a fixed list, and the catalogue's difficulty filter depends on
+it. The binary shipped to testers carries its own copy of that list, so widening
+it in code does not help installations already deployed.
+
+The only recognised labels, to be written exactly:
+
+| level | `fr` | `en` | `es` | `de` |
+|---|---|---|---|---|
+| easy | Facile | Easy | Fácil | Einfach |
+| moderate | Intermédiaire | Moderate | Intermedio | Mittel |
+| hard | Exigeant | Hard | Difícil | Anspruchsvoll |
+
+⚠️ "Difficult" and "Demanding" are **not** recognised, hence "Hard" in English.
+The writing scripts therefore reimpose these values from English rather than
+leaving them to the translator, human or machine (#485, #512).
+
+##### A partial translation makes the plant disappear
+
+`description` and `plantType` are **non-optional** on the app side. Writing a
+language without those two fields does not degrade the display: the record
+becomes undecodable and the plant vanishes from the catalogue, **in every
+language**, including the ones that were fine.
+
+Two protections, at two levels:
+
+- the writing scripts (`scripts/translate-plant-catalog.py`,
+  `scripts/apply-translation-memory.py`) check each record for completeness
+  before writing, and never overwrite an existing language;
+- since #515, `Plant.init(from:)` decodes `translations` **language by
+  language**: an unreadable language costs only that language, and the reader
+  falls back to `en`.
+
+The model-level guard exists because the scripts' discipline protects nothing the
+moment a `$set` is typed by hand in `mongosh`.
 
 #### `PlantBotanicalProfile` sub-document
 

--- a/docs/en/operations/asset-storage.md
+++ b/docs/en/operations/asset-storage.md
@@ -1,7 +1,7 @@
 # 3D asset storage
 
-Where the catalogue's 372 files live — 124 light models, 124 high-definition,
-124 thumbnails — and how to move them without interrupting service.
+Where the catalogue's 369 files live: 123 light models, 123 high-definition,
+123 thumbnails, and how to move them without interrupting service.
 
 ## Why this document exists
 

--- a/docs/en/operations/observability.md
+++ b/docs/en/operations/observability.md
@@ -312,6 +312,30 @@ At the observed rate (~500 KB/day for the backend), 30 MB is roughly **two month
 | Deployed commit | `curl localhost:8080/health` → `commit` field ([#341](https://github.com/ArboreTeam/Arbore/issues/341)) |
 | Full IP for an incident | Cloudflare logs |
 
+## What real events found
+
+Sentry did not merely confirm the instrumentation worked. Every defect listed
+here was found by a real event, not by a code review.
+
+| Sentry issue | build | what it found |
+|---|---|---|
+| `ARBORE-FRONTEND-1` | 29 | `device_app_hash`, a stable install identifier, was still shipping despite the anonymous regime (#496) |
+| `ARBORE-FRONTEND-5` | 31 | fake "App Hanging" events emitted by the test suite, the XCTest harness going undetected (#506) |
+| `ARBORE-FRONTEND-6` to `-9` | 31 | manual controls proving no scrubbing rule can reach `user.geo` (#498) |
+| `ARBORE-FRONTEND-A` | 32 | 2 s freeze while browsing the catalogue: PNG decoding on the main thread (#518) |
+
+Two lessons that reach beyond these cases.
+
+**A review does not see what is outside the field it is looking at.**
+`device_app_hash` does not live in `user` but in the `app` context: nobody
+spotted it while reviewing the anonymisation code, and the public privacy policy
+claimed the opposite for a day.
+
+**A stack with no application frame is not a useless stack.** The one in
+`ARBORE-FRONTEND-A` stopped inside the SwiftUI graph, without a single line of
+our code. It still pointed at the exact place: the main thread was blocked in
+rendering, so the culprit was work done at draw time rather than at call time.
+
 ## Notes / follow-ups
 
 - The breadcrumbs bridge from the iOS app's `AppLog` (nav / AR session / garden save) is a nice-to-have, not wired up yet.

--- a/docs/en/screens/_index.md
+++ b/docs/en/screens/_index.md
@@ -32,7 +32,14 @@ The following screens are borderline but are not yet documented. They will be pr
 - `LiDARScanWizardView` — single screen but RoomPlan + transition to `GardenARPlacementView`. Tracked by issue #139.
 - `ARViewContainerMeasure` — single screen, mainly for non-LiDAR perimeter tracing.
 - `SignUpView` — critical flow (#137) but the details are already in [`../flows/auth-signup.md`](../flows/auth-signup.md).
-- `CatalogueView` — listing with filters but without complex logic (`PlantCatalogView` is now documented above).
+- `CatalogueView` — the Catalogue tab, not to be confused with `PlantCatalogView`
+  documented above, which is the AR flow's plant picker. Two screens, two distinct
+  filter mechanisms: `PlantCatalogContext` dimensions on one side, `PlantFilters`
+  (light, watering, difficulty) on the other.
+  Still borderline, but no longer a "listing without logic": it carries the grid of
+  123 records, the thumbnail pipeline in `PlantCard` and `PlantThumbnailCache`
+  (decoding, downsampling, two memory caches), and it produced the first 2 s freeze
+  seen in production (#518). To be promoted if a third defect concentrates there.
 
 ## Structure of a per-screen spec
 

--- a/docs/en/testing/p1-physical-devices.md
+++ b/docs/en/testing/p1-physical-devices.md
@@ -58,7 +58,9 @@ closure is understandable, and edits reach the 2D plan.
 ### 4. Catalogue and network
 
 1. Clear thumbnail cache, then open the catalogue on Wi-Fi and cellular data.
-2. Scroll through all 124 plants, search, and combine several filters.
+2. Scroll through all 123 plants **with a fast flick all the way down**, search,
+   and combine several filters. Fast scrolling is what revealed the 2 s freeze
+   fixed by #518; a slow pass would not have triggered it.
 3. Open ten plants and place at least five AR models.
 
 Pass: cards download server PNGs without local USDZ reconstruction, simple

--- a/docs/fr/3d-lod-architecture.md
+++ b/docs/fr/3d-lod-architecture.md
@@ -17,6 +17,26 @@ Résultat : le catalogue est instantané (PNG), le placement AR est rapide (lég
 ## Comportement runtime
 
 - **Catalogue** : `ArboreUi/ArboreUi/Views/PlantCard.swift` charge le thumbnail PNG via `GET /models/thumbnails/{id}.png?v={designVersion}` et le conserve dans `PlantThumbnailCache`. Le paramètre de version invalide simultanément le cache disque iOS et l'ancienne réponse Cloudflare lorsqu'un nouveau design remplace un fichier sous le même identifiant. Chaque rendu porte aussi une signature masquée dans les coins rognés de la carte ; tout PNG serveur sans cette signature est rejeté. En cas de PNG indisponible ou ancien, la photo catalogue sert de fallback léger : le catalogue utilisateur ne construit jamais de miniature 3D localement. `PlantThumbnailGenerator` reste réservé à l'écran debug/admin avant l'upload. Le cadrage de ces rendus ajuste la caméra au volume projeté complet du modèle, avec une marge commune, un fond gris continu et une ombre de contact courte.
+
+  Le **décodage** de ces PNG est aussi important que leur téléchargement, et c'est
+  moins évident. `UIImage(contentsOfFile:)` et `UIImage(data:)` sont paresseux :
+  ils ne décompressent rien, et le décodage a lieu au premier dessin, donc dans le
+  commit Core Animation, sur le thread principal. Charger le fichier dans un
+  `Task.detached` déporte la lecture, pas le décodage. Avec des vignettes de
+  720 × 900 px et une grille qui en montre cinq, un défilement rapide gelait l'app
+  deux secondes — mesuré en production sur le build 32 (`ARBORE-FRONTEND-A`).
+
+  Depuis #518, `PlantThumbnailCache` décode et réduit en une passe via
+  `CGImageSourceCreateThumbnailAtIndex` avec `kCGImageSourceShouldCacheImmediately`,
+  le drapeau sans lequel ImageIO reste paresseux. Deux caches mémoire s'y
+  ajoutent : les images décodées (plafond 40 Mio) et les verdicts de la signature
+  de version, dont les quatre balayages de pixels étaient rejoués à chaque
+  apparition de carte.
+
+  Le contrôle de signature porte sur l'image **d'origine**, jamais sur la version
+  réduite : ses heuristiques échantillonnent des pixels et **effacent le fichier**
+  quand elles concluent au périmé. Les juger sur une image rééchantillonnée ferait
+  basculer leurs seuils, et des vignettes légitimes seraient supprimées.
 - **Modèle 3D** : `ArboreUi/ArboreUi/Services/ModelCacheManager.swift` télécharge le USDZ (cache disque par nom de fichier), utilisé en AR et pour la génération de thumbnail.
 - **Backend** : `GET /models/:filename` (protégé) sert le USDZ depuis `./models/` ; le paramètre `?lod=heavy` bascule la lecture vers `./models/heavy/`. `GET /models/thumbnails/:filename` (public) sert les PNG.
 

--- a/docs/fr/architecture/04-data-model.md
+++ b/docs/fr/architecture/04-data-model.md
@@ -172,9 +172,51 @@ LanguageData {
   soilAndPot: {substrate, drainage, potSize, repotFrequency, repotSigns},
   health: {commonProblems, symptomsAndCauses, pests, treatments, prevention},
   lifeCycle: {growth, flowering, dormancy, fertilizer, pruning},
-  care: {weekly, monthly, yearly, extraTips}
+  care: {difficulty, weekly, monthly, yearly, extraTips}
 }
 ```
+
+Les 123 fiches portent les **quatre langues** depuis #513 et #514. Avant cela,
+97 d'entre elles n'avaient que `fr` et `en`, et un lecteur hispanophone ou
+germanophone voyait de l'anglais par le repli
+`langue → en → n'importe laquelle`.
+
+##### `care.difficulty` n'est pas de la prose
+
+Ce champ est lu **par mots-clés**, pas affiché tel quel : `Plant.careDifficulty(locale:)`
+le compare à une liste figée, et c'est de lui que dépend le filtre par difficulté
+du catalogue. Le binaire livré aux testeurs porte sa propre copie de cette liste,
+donc l'élargir côté code n'aide pas les installations déjà déployées.
+
+Les seuls libellés reconnus, à écrire tels quels :
+
+| niveau | `fr` | `en` | `es` | `de` |
+|---|---|---|---|---|
+| facile | Facile | Easy | Fácil | Einfach |
+| intermédiaire | Intermédiaire | Moderate | Intermedio | Mittel |
+| exigeant | Exigeant | Hard | Difícil | Anspruchsvoll |
+
+⚠️ « Difficult » et « Demanding » ne sont **pas** reconnus, d'où « Hard » en
+anglais. Les scripts d'écriture réimposent donc ces valeurs depuis l'anglais au
+lieu de les confier au traducteur, humain ou machine (#485, #512).
+
+##### Une traduction partielle fait disparaître la plante
+
+`description` et `plantType` sont **non optionnels** côté app. Écrire une langue
+sans ces deux champs ne dégrade pas l'affichage : la fiche devient indécodable et
+la plante disparaît du catalogue, **dans toutes les langues**, y compris celles
+qui allaient bien.
+
+Deux protections, à deux niveaux :
+
+- les scripts d'écriture (`scripts/translate-plant-catalog.py`,
+  `scripts/apply-translation-memory.py`) vérifient la complétude de chaque fiche
+  avant d'écrire, et n'écrasent jamais une langue existante ;
+- depuis #515, `Plant.init(from:)` décode `translations` **langue par langue** :
+  une langue illisible ne coûte que cette langue, le lecteur retombe sur `en`.
+
+Le garde-fou du modèle existe parce que la discipline des scripts ne protège de
+rien dès qu'un `$set` est tapé à la main dans `mongosh`.
 
 #### Sous-document `PlantBotanicalProfile`
 

--- a/docs/fr/operations/observability.md
+++ b/docs/fr/operations/observability.md
@@ -316,6 +316,31 @@ Au débit observé (~500 Ko/jour côté backend), 30 Mo représentent environ **
 | Commit déployé | `curl localhost:8080/health` → champ `commit` ([#341](https://github.com/ArboreTeam/Arbore/issues/341)) |
 | IP complète d'un incident | journaux Cloudflare |
 
+## Ce que les événements réels ont trouvé
+
+Sentry n'a pas servi qu'à confirmer que l'instrumentation marchait. Chaque
+défaut listé ici a été découvert par un événement réel, pas par une relecture.
+
+| issue Sentry | build | découverte |
+|---|---|---|
+| `ARBORE-FRONTEND-1` | 29 | `device_app_hash`, un identifiant d'installation stable, passait malgré le régime anonyme (#496) |
+| `ARBORE-FRONTEND-5` | 31 | faux « App Hanging » émis par la suite de tests, le harnais XCTest n'étant pas détecté (#506) |
+| `ARBORE-FRONTEND-6` à `-9` | 31 | contrôles manuels prouvant qu'aucune règle de scrubbing n'atteint `user.geo` (#498) |
+| `ARBORE-FRONTEND-A` | 32 | gel de 2 s en parcourant le catalogue : décodage PNG sur le thread principal (#518) |
+
+Deux enseignements qui valent au-delà de ces cas.
+
+**Une relecture ne voit pas ce qui n'est pas dans le champ.** `device_app_hash`
+ne vit pas dans `user` mais dans le contexte `app` : personne ne l'a vu en
+relisant le code d'anonymisation, et la politique de confidentialité publique a
+affirmé le contraire pendant une journée.
+
+**Une pile sans frame applicative n'est pas une pile inutile.** Celle de
+`ARBORE-FRONTEND-A` s'arrêtait dans le graphe SwiftUI, sans une seule ligne de
+notre code. Elle désignait pourtant l'endroit exact : le thread principal était
+bloqué dans le rendu, donc le coupable était un travail fait au dessin et non à
+l'appel.
+
 ## Notes / suites
 
 - Le pont breadcrumbs depuis l'`AppLog` de l'app iOS (nav / session AR / sauvegarde jardin) est un nice-to-have pas encore câblé.

--- a/docs/fr/operations/stockage-assets.md
+++ b/docs/fr/operations/stockage-assets.md
@@ -1,7 +1,7 @@
 # Stockage des assets 3D
 
-Où vivent les 372 fichiers du catalogue — 124 modèles légers, 124 haute
-définition, 124 vignettes — et comment en changer sans interrompre le service.
+Où vivent les 369 fichiers du catalogue : 123 modèles légers, 123 haute
+définition, 123 vignettes, et comment en changer sans interrompre le service.
 
 ## Pourquoi ce document existe
 

--- a/docs/fr/screens/_index.md
+++ b/docs/fr/screens/_index.md
@@ -32,7 +32,15 @@ Les écrans suivants sont en limite mais ne sont pas encore documentés. Ils ser
 - `LiDARScanWizardView` — single screen mais RoomPlan + transition vers `GardenARPlacementView`. Suivi par l'issue #139.
 - `ARViewContainerMeasure` — single screen, principalement pour le tracé périmètre non-LiDAR.
 - `SignUpView` — flow critique (#137) mais le détail est déjà dans [`../flows/auth-signup.md`](../flows/auth-signup.md).
-- `CatalogueView` — listing avec filtres mais sans logique complexe (`PlantCatalogView` est désormais documenté ci-dessus).
+- `CatalogueView` — l'onglet Catalogue, à ne pas confondre avec `PlantCatalogView`
+  documenté ci-dessus, qui est le sélecteur de plantes du parcours AR. Deux écrans,
+  deux mécanismes de filtre distincts : dimensions `PlantCatalogContext` d'un côté,
+  `PlantFilters` (lumière, arrosage, difficulté) de l'autre.
+  Toujours en limite, mais il ne tient plus de « listing sans logique » : il porte
+  la grille de 123 fiches, le pipeline de vignettes de `PlantCard` et
+  `PlantThumbnailCache` (décodage, réduction, deux caches mémoire), et il a produit
+  le premier gel de 2 s relevé en production (#518). À promouvoir si un troisième
+  défaut s'y concentre.
 
 ## Structure d'une per-screen spec
 

--- a/docs/fr/testing/p1-appareils-physiques.md
+++ b/docs/fr/testing/p1-appareils-physiques.md
@@ -62,7 +62,9 @@ compréhensible et modification reflétée dans le plan 2D.
 ### 4. Catalogue et réseau
 
 1. Vider le cache de vignettes, lancer le catalogue en Wi-Fi puis en 4G/5G.
-2. Faire défiler les 124 plantes, rechercher et appliquer plusieurs filtres.
+2. Faire défiler les 123 plantes **d'un balayage franc jusqu'en bas**, rechercher
+   et appliquer plusieurs filtres. Le défilement rapide est ce qui a révélé le
+   gel de 2 s corrigé par #518 : un parcours posé ne l'aurait pas déclenché.
 3. Ouvrir dix plantes et placer au moins cinq modèles AR.
 
 Critère : les cartes téléchargent des PNG serveur sans reconstruction USDZ locale,


### PR DESCRIPTION
Promotion de `dev` vers `main`. Documentation seule, aucun code.

**Aucun build ne suit.** Rien de ce commit n'atteint le binaire.

## Audit des références documentaires depuis le 31 août

207 commits, 109 PR passés en revue.

Le socle ops et infra est bien couvert : Terraform, SOPS/age, ghcr, R2, MinIO, nginx, rôles et entitlements, Sentry backend ont tous leur page. Cinq écarts subsistaient, dont deux contredisaient le code.

## Un champ absent du modèle documenté

`04-data-model.md` décrivait `care: {weekly, monthly, yearly, extraTips}`. `difficulty` manquait, alors que le filtre du catalogue en dépend et que son vocabulaire est contraint : `careDifficulty(locale:)` le lit par mots-clés, et le binaire livré porte une liste figée.

Les douze libellés reconnus sont consignés, avec l'avertissement : « Difficult » et « Demanding » ne sont **pas** reconnus, d'où « Hard » en anglais.

Le piège des traductions partielles est documenté au même endroit : `description` et `plantType` non optionnels, une langue à moitié écrite rend la fiche entière indécodable et la plante disparaît dans toutes les langues. Les deux protections sont décrites — celle des scripts, et celle du modèle depuis #515.

## Le décodage des vignettes manquait au pipeline

`3d-lod-architecture.md` décrivait le téléchargement des PNG, pas leur décodage. C'est pourtant là que se jouait le gel de 2 s.

La contrainte qui encadre le correctif est consignée avec lui : le contrôle de signature porte sur l'image d'origine, jamais sur la version réduite, parce qu'il efface le fichier quand il conclut au périmé.

## Deux catalogues, un seul documenté

`PlantCatalogView` (sélecteur AR) et `CatalogueView` (onglet Catalogue) sont deux écrans distincts, avec deux mécanismes de filtre différents. L'index n'en décrivait qu'un et qualifiait l'autre de « listing sans logique complexe » — ce que le gel a démenti.

## Chiffres périmés

| fichier | avant | après |
|---|---|---|
| `stockage-assets.md` | 372 fichiers, 124 × 3 | 369 fichiers, 123 × 3 |
| protocoles de test P1 | 124 plantes | 123, et balayer franchement |

## Ce que les événements réels ont trouvé

Nouvelle section dans `observability.md`, FR et EN : les quatre défauts trouvés par Sentry depuis le build 29, et ce qu'ils apprennent — qu'une relecture ne voit pas ce qui n'est pas dans son champ, et qu'une pile sans frame applicative désigne quand même l'endroit exact.

## Un fichier volontairement non touché

`botanical-data-audit.md` porte encore « 124 plantes ». La PR #494 le réécrit déjà en conservant ce chiffre : signalé là-bas plutôt que corrigé ici, pour ne pas créer un conflit sur une PR ouverte.

## Vérifications

530 références de code vérifiées dans `docs/`, aucune dérive. FR et EN à parité.