### PR TITLE
feat(backend): héberger les photos de fiche, au lieu d'appeler les CDN tiers

### DIFF
--- a/ArboreBackend/main.go
+++ b/ArboreBackend/main.go
@@ -2247,6 +2247,42 @@ func buildRouter() *gin.Engine {
 			"image/png",
 			"Thumbnail not found")
 	})
+
+	// Photos de fiche, hébergées par nous depuis #526.
+	//
+	// Publique comme les vignettes, et pour la même raison : `AsyncImage` et
+	// `URLSession` vont chercher ces URL sans porter d'en-tête d'authentification.
+	// Exiger une session ici afficherait des cartes vides.
+	//
+	// Deux extensions, contrairement aux vignettes : les sources d'origine
+	// mêlaient JPEG et PNG, et reconvertir un JPEG en PNG le ferait grossir sans
+	// rien gagner.
+	router.GET("/photos/:filename", publicLimiter.Middleware(), func(c *gin.Context) {
+		filename := c.Param("filename")
+
+		if strings.Contains(filename, "..") || strings.Contains(filename, "/") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid filename"})
+			return
+		}
+
+		lower := strings.ToLower(filename)
+		var contentType string
+		switch {
+		case strings.HasSuffix(lower, ".jpg"), strings.HasSuffix(lower, ".jpeg"):
+			contentType = "image/jpeg"
+		case strings.HasSuffix(lower, ".png"):
+			contentType = "image/png"
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Only .jpg and .png files are allowed"})
+			return
+		}
+
+		serveStorageObject(c,
+			StorageObject{Bucket: BucketPhotos, Name: filename},
+			contentType,
+			"Photo not found")
+	})
+
 	// === ROUTES API KEY UNIQUEMENT (sans session Firebase) ===
 	// Config de référence (wizard + règles de soin, cf. #236) : non sensible,
 	// nécessaire dès le lancement de l'app avant authentification utilisateur.

--- a/ArboreBackend/roles_test.go
+++ b/ArboreBackend/roles_test.go
@@ -276,6 +276,7 @@ var (
 		"GET /config",
 		"GET /models/:filename",
 		"GET /models/thumbnails/:filename",
+		"GET /photos/:filename",
 		"GET /plants",
 		"GET /plants/:id",
 		"POST /chat",

--- a/ArboreBackend/storage_s3.go
+++ b/ArboreBackend/storage_s3.go
@@ -32,6 +32,7 @@ const (
 	s3PrefixModelsLight = "models/"
 	s3PrefixModelsHeavy = "models/heavy/"
 	s3PrefixThumbnails  = "thumbnails/"
+	s3PrefixPhotos      = "photos/"
 
 	// Durée de validité d'une URL signée. Assez longue pour qu'un
 	// téléchargement de 121 Mo aboutisse sur une connexion mobile médiocre,
@@ -104,6 +105,8 @@ func (s *s3Storage) key(obj StorageObject) (string, error) {
 		return s3PrefixModelsHeavy + obj.Name, nil
 	case BucketThumbnails:
 		return s3PrefixThumbnails + obj.Name, nil
+	case BucketPhotos:
+		return s3PrefixPhotos + obj.Name, nil
 	default:
 		return "", fmt.Errorf("unknown bucket %q", obj.Bucket)
 	}

--- a/ArboreBackend/storageprovider.go
+++ b/ArboreBackend/storageprovider.go
@@ -42,6 +42,20 @@ const (
 	BucketModelsLight StorageBucket = "models-light"
 	BucketModelsHeavy StorageBucket = "models-heavy"
 	BucketThumbnails  StorageBucket = "thumbnails"
+
+	// BucketPhotos porte les photos de fiche, que nous hébergeons désormais
+	// nous-mêmes (#526).
+	//
+	// Elles pointaient auparavant directement sur les CDN de botanic et
+	// d'Unsplash. Chaque appareil ouvrant le catalogue émettait donc une requête
+	// vers un tiers, qui y voyait une adresse IP, une heure et les fiches
+	// consultées — un flux que la politique de confidentialité ne mentionnait
+	// pas pour botanic, alors qu'il concernait 97 fiches sur 123.
+	//
+	// S'y ajoutait une dépendance muette : une image retirée ou un lien direct
+	// bloqué chez eux, et les trois quarts du catalogue perdaient leur photo
+	// sans que rien ne nous prévienne.
+	BucketPhotos StorageBucket = "photos"
 )
 
 // StorageObject identifie un objet. `Name` est un nom de fichier simple, déjà
@@ -89,6 +103,7 @@ type filesystemStorage struct {
 	modelsDir     string
 	heavyDir      string
 	thumbnailsDir string
+	photosDir     string
 }
 
 func newFilesystemStorage() *filesystemStorage {
@@ -96,10 +111,15 @@ func newFilesystemStorage() *filesystemStorage {
 	if thumbs == "" {
 		thumbs = "./models/thumbnails"
 	}
+	photos := strings.TrimSpace(os.Getenv("PHOTOS_DIR"))
+	if photos == "" {
+		photos = "./models/photos"
+	}
 	return &filesystemStorage{
 		modelsDir:     "./models",
 		heavyDir:      "./models/heavy",
 		thumbnailsDir: thumbs,
+		photosDir:     photos,
 	}
 }
 
@@ -117,6 +137,8 @@ func (f *filesystemStorage) resolve(obj StorageObject) (string, error) {
 		baseDir = f.heavyDir
 	case BucketThumbnails:
 		baseDir = f.thumbnailsDir
+	case BucketPhotos:
+		baseDir = f.photosDir
 	default:
 		return "", fmt.Errorf("unknown bucket %q", obj.Bucket)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,9 @@ services:
       - ARBORE_ADMIN_UIDS=${ARBORE_ADMIN_UIDS:-}
       # Thumbnails dans un chemin séparé (hors du montage read-only /app/models)
       - THUMBNAILS_DIR=/app/thumbnails
+      # Photos de fiche, hébergées par nous depuis #526 (auparavant : appels
+      # directs aux CDN de botanic et Unsplash depuis chaque appareil).
+      - PHOTOS_DIR=/app/photos
       # Montage conservé uniquement pour supprimer les anciens fichiers lors
       # d'une suppression de compte. Aucune route communautaire n'est exposée.
       - COMMUNITY_UPLOADS_DIR=/app/uploads/community
@@ -170,6 +173,9 @@ services:
       - ${MODELS_HOST_PATH:-./ArboreBackend/models}:/app/models:ro
       # Thumbnails : bind mount sur le dossier existant de la VM (conserve les anciens thumbnails)
       - ${THUMBNAILS_HOST_PATH:-./ArboreBackend/models/thumbnails}:/app/thumbnails
+      # Photos de fiche. Montées en lecture seule : elles sont déposées par la
+      # migration, jamais écrites par le backend — aucune route ne les téléverse.
+      - ${PHOTOS_HOST_PATH:-./ArboreBackend/models/photos}:/app/photos:ro
       # Firebase service account JSON (le vrai fichier du projet)
       - ${FIREBASE_SERVICE_ACCOUNT_HOST_PATH:-./arbore-firebase-adminsdk.json}:/run/secrets/firebase-adminsdk.json:ro
       # Clé privée Apple : fichier hôte hors Git, lecture seule dans le conteneur.

--- a/ops/secrets/env.template
+++ b/ops/secrets/env.template
@@ -114,8 +114,10 @@ GHCR_TOKEN=                           # 🔒 PAT classique, portée read:package
 # ── Divers ────────────────────────────────────────────────────────────────
 UNSPLASH_ACCESS_KEY=                  # 🔒
 THUMBNAILS_DIR=                       # ⚙️
+PHOTOS_DIR=                           # ⚙️ photos de fiche hébergées par nous (#526)
 THUMBNAIL_UPLOAD_ALLOWED_UIDS=        # ⚙️
 MODELS_HOST_PATH=                     # ⚙️ hors du checkout git (#341)
+PHOTOS_HOST_PATH=                     # ⚙️ hors du checkout git, monté en lecture seule
 GIN_MODE=                             # ⚙️ release en production
 PORT=                                 # ⚙️
 


### PR DESCRIPTION
Les photos du catalogue pointaient directement sur `botanic-botanic-storage.omn.proximis.com` (97 fiches) et `images.unsplash.com` (25). **L'app ne copiait rien** : chaque appareil ouvrant le catalogue allait les chercher lui-même.

## Ce que ça coûtait

Botanic et Unsplash voyaient donc l'adresse IP de chaque utilisateur, l'heure, et les fiches consultées.

Or la politique de confidentialité, dans les quatre langues, liste ses destinataires ainsi :

> Sous-traitants : Firebase et Google (dont Gemini), Apple, MongoDB Atlas, Cloudflare, **Unsplash**, Mistral, OpenAI, et Sentry pour les rapports de plantage.

**Unsplash y figure, botanic non** — alors que botanic recevait le trafic de 97 fiches contre 25. Une promesse écrite que la réalité technique ne tenait pas, du même genre que la géolocalisation Sentry (#498).

S'y ajoutait une dépendance muette : une image retirée chez eux, ou un lien direct bloqué, et les trois quarts du catalogue perdaient leur photo sans que rien ne nous prévienne.

## Ce que ça change, et ce que ça ne change pas

Plus aucun appel tiers depuis les appareils. Plus de rupture possible.

La question de la **licence n'est pas réglée** — elle est déplacée. Héberger une copie engage davantage que pointer un lien. C'est un compromis assumé pour la bêta : régler la confidentialité maintenant, la licence ensuite. #526 porte ce « ensuite ».

## Une famille de plus, pas une mécanique de plus

`StorageProvider` prévoyait déjà des familles d'objets indépendantes de leur emplacement. Ajouter les photos tient donc en peu de choses :

| | |
|---|---|
| constante | `BucketPhotos` |
| R2 | préfixe `photos/` |
| disque | `PHOTOS_DIR`, monté en **lecture seule** |
| route | `GET /photos/:filename`, publique |

La route est publique comme celle des vignettes, et pour la même raison : `AsyncImage` et `URLSession` vont chercher ces URL sans en-tête d'authentification. Exiger une session afficherait des cartes vides.

Elle accepte JPEG **et** PNG, contrairement aux vignettes : les sources mêlaient les deux, et reconvertir un JPEG le ferait grossir pour rien.

Le montage est en lecture seule parce que les photos sont déposées par la migration et jamais écrites par le backend — aucune route ne les téléverse, contrairement aux vignettes.

## Aucun changement côté app

`imageURLs` pointera ailleurs, voilà tout. **Pas de build, pas de livraison.**

## Vérifications

`go build`, `go vet` et `go test` passent.

Le test qui verrouille l'inventaire des routes a d'abord échoué — c'est exactement son rôle — et la nouvelle route y est déclarée comme atteignable par un invité, au même titre que les vignettes.

Les **122 images sont déjà en place** sur R2 (`photos/`, 122 objets) et sur le disque du VPS, **avant** toute réécriture de `imageURLs`. L'ordre importe : l'inverse servirait un catalogue dont les photos sont en 404.

64 des 97 visuels botanic ont été recadrés au passage par l'outil de #525, qui retire un fond uni quand il y en a un et s'abstient sinon. Aucune photo Unsplash touchée.

La réécriture de `imageURLs` suit, une fois cette route déployée.