### PR TITLE
docs(données): consigner pourquoi les photos de fiche sont les nôtres

### DIFF
--- a/docs/en/architecture/04-data-model.md
+++ b/docs/en/architecture/04-data-model.md
@@ -150,7 +150,7 @@ Plant catalog document. Each plant embeds its multilingual translations so that 
 | `_id` | ObjectID | Primary key. Referenced by `PlacedPlant.plantId`. |
 | `name` | string | Canonical name. |
 | `type` | string | Plant family / type. |
-| `imageURLs` | array<string> | Photos (Unsplash) via `fetchUnsplashImageURLs`. |
+| `imageURLs` | array<string> | Since #527, **our own studio renders**: `https://api.arbore.app/models/thumbnails/<id>.png?v=<version>`. One entry per record. |
 | `description` | string | Description in French (served by default). |
 | `modelURL` | string | USDZ file name served by `GET /models/:filename`. |
 | `translations` | map<lang, LanguageData> | Sub-document per language (`fr`, `en`, `es`, `de`). |
@@ -161,6 +161,27 @@ Plant catalog document. Each plant embeds its multilingual translations so that 
 | `botanicalProfile` | `PlantBotanicalProfile` (optional) | Canonical horticultural constraints, structured and sourced per field. When absent, the verdict can only be “Probably compatible” or “Not suitable,” never “Suitable.” |
 | `source` | string (optional) | Optional provenance label (curated catalog vs legacy/beta entries). |
 | `sourceUrl` | string (optional) | Optional origin URL, kept for later updates. |
+
+##### Why the photos are ours
+
+The 123 records used to carry direct links to the botanic (97) and Unsplash (25)
+CDNs. The app copied nothing: every device fetched them itself, and those third
+parties saw the user's IP address, the time, and which records were viewed — a
+flow the privacy policy did not mention for botanic.
+
+Botanic's terms also explicitly forbid reproduction (articles L.122-4 and
+L.335-3 of the French intellectual property code), and some of their visuals come
+from stock agencies that license them to botanic, not to us. Hosting a copy was
+therefore out.
+
+Our studio renders settle all three points at once: no third-party call, no one
+else's rights, and the user sees exactly what they will place in augmented
+reality. They are the same files served to the catalogue cards, so one cache
+entry per plant.
+
+> ⚠️ **The generation path did not follow.** `generateAndInsertPlant` still calls
+> `fetchUnsplashImageURLs`: a plant created through AI generation therefore comes
+> back with third-party URLs. Tracked in #526.
 
 The `translations[lang]` sub-document (type `LanguageData`) groups:
 

--- a/docs/fr/architecture/04-data-model.md
+++ b/docs/fr/architecture/04-data-model.md
@@ -150,7 +150,7 @@ Document du catalogue de plantes. Chaque plante embarque ses traductions multili
 | `_id` | ObjectID | Clé primaire. Référencée par `PlacedPlant.plantId`. |
 | `name` | string | Nom canonique. |
 | `type` | string | Famille / type botanique. |
-| `imageURLs` | array<string> | Photos (Unsplash) via `fetchUnsplashImageURLs`. |
+| `imageURLs` | array<string> | Depuis #527, **nos propres rendus studio** : `https://api.arbore.app/models/thumbnails/<id>.png?v=<version>`. Une seule entrée par fiche. |
 | `description` | string | Description en français (servie par défaut). |
 | `modelURL` | string | Nom de fichier USDZ servi par `GET /models/:filename`. |
 | `translations` | map<lang, LanguageData> | Sous-document par langue (`fr`, `en`, `es`, `de`). |
@@ -161,6 +161,28 @@ Document du catalogue de plantes. Chaque plante embarque ses traductions multili
 | `botanicalProfile` | `PlantBotanicalProfile` (optionnel) | Contraintes horticoles canoniques, structurées et sourcées champ par champ. Son absence force le verdict « Probablement compatible » ou « Non adaptée », jamais « Adaptée ». |
 | `source` | string (optionnel) | Libellé de provenance optionnel (catalogue curé vs entrées legacy/beta). |
 | `sourceUrl` | string (optionnel) | URL d'origine optionnelle, conservée pour mise à jour ultérieure. |
+
+##### Pourquoi les photos sont les nôtres
+
+Les 123 fiches portaient auparavant des liens directs vers les CDN de botanic
+(97) et d'Unsplash (25). L'app ne copiait rien : chaque appareil allait les
+chercher lui-même, et ces tiers voyaient l'adresse IP de l'utilisateur, l'heure
+et les fiches consultées — un flux que la politique de confidentialité ne
+mentionnait pas pour botanic.
+
+Les CGU de botanic interdisent par ailleurs explicitement la reproduction
+(articles L.122-4 et L.335-3 du Code de la propriété intellectuelle), et une
+partie de leurs visuels vient de banques d'images qui les leur licencient.
+Héberger une copie était donc exclu.
+
+Nos rendus studio règlent les trois points d'un coup : aucun appel tiers, aucun
+droit d'autrui, et l'utilisateur voit exactement ce qu'il placera en réalité
+augmentée. Ce sont les mêmes fichiers que ceux servis aux cartes du catalogue,
+donc une seule entrée de cache par plante.
+
+> ⚠️ **Le chemin de génération n'a pas suivi.** `generateAndInsertPlant` appelle
+> toujours `fetchUnsplashImageURLs` : une plante créée par la génération IA
+> repart donc avec des URL tierces. Suivi dans #526.
 
 Le sous-document `translations[lang]` (type `LanguageData`) regroupe :
 


### PR DESCRIPTION
`04-data-model.md` décrivait `imageURLs` comme des « photos (Unsplash) via `fetchUnsplashImageURLs` ». Les 123 fiches portent désormais nos rendus studio.

## Ce que la note ajoute au simple constat

Le raisonnement, parce qu'il se reperdrait sinon.

Les fiches pointaient vers les CDN de botanic (97) et d'Unsplash (25). L'app ne copiait rien : chaque appareil allait les chercher lui-même, et ces tiers voyaient l'adresse IP de l'utilisateur, l'heure et les fiches consultées. La politique de confidentialité listait **Unsplash** et **pas botanic**, qui recevait pourtant quatre fois plus de trafic.

Héberger une copie a été envisagé puis abandonné : les CGU de botanic interdisent explicitement la reproduction (articles L.122-4 et L.335-3), et une partie de leurs visuels vient de banques d'images qui les leur licencient — pas à nous.

Nos rendus règlent les trois points d'un coup : aucun appel tiers, aucun droit d'autrui, et l'utilisateur voit exactement ce qu'il placera en AR. Ce sont les mêmes fichiers que ceux servis aux cartes, donc une seule entrée de cache par plante.

## Un avertissement plutôt qu'un silence

`generateAndInsertPlant` appelle toujours `fetchUnsplashImageURLs` : une plante créée par la génération IA repart avec des URL tierces. La note le dit là où quelqu'un le lira, et #530 le suit.

## Vérifications

530 références de code vérifiées dans `docs/`, aucune dérive. FR et EN à parité.