### PR TITLE
perf(ios): alléger le plan 2D du jardin, qui recomposait 250 calques par image

### DIFF
--- a/ArboreUi/ArboreUi/Views/ManageGardenView.swift
+++ b/ArboreUi/ArboreUi/Views/ManageGardenView.swift
@@ -3747,21 +3747,29 @@ struct GardenPlanInteractiveMap: View {
                         }
 
                         // Bordures du jardin
+                        //
+                        // Le chemin est construit UNE fois et réutilisé pour les
+                        // trois passes. Il l'était trois fois, et comme chaque
+                        // construction boucle sur tous les points du contour en
+                        // recalculant leur projection, le coût était triplé à
+                        // chaque image d'un glissement (#533).
                         if !viewModel.boundaryPoints.isEmpty {
-                            gardenBoundaryPath(centerX: centerX, centerY: centerY)
-                            .fill(ArboreDesign.Colors.primaryGreen.opacity(0.14))
+                            let contour = gardenBoundaryPath(centerX: centerX, centerY: centerY)
 
-                            gardenBoundaryPath(centerX: centerX, centerY: centerY)
+                            contour
+                                .fill(ArboreDesign.Colors.primaryGreen.opacity(0.14))
+
+                            contour
                                 .stroke(
                                     Color(hex: "#2F332E").opacity(0.96),
                                     style: StrokeStyle(lineWidth: 7.4, lineCap: .round, lineJoin: .round)
                                 )
 
-                            gardenBoundaryPath(centerX: centerX, centerY: centerY)
-                            .stroke(
-                                Color(hex: "#171A16").opacity(0.78),
-                                style: StrokeStyle(lineWidth: 3.2, lineCap: .round, lineJoin: .round)
-                            )
+                            contour
+                                .stroke(
+                                    Color(hex: "#171A16").opacity(0.78),
+                                    style: StrokeStyle(lineWidth: 3.2, lineCap: .round, lineJoin: .round)
+                                )
                         }
 
                         ForEach(plantingZones) { zone in
@@ -3951,7 +3959,7 @@ struct IconBtn: View {
     }
 }
 
-enum PlantMapMarkerVariant {
+enum PlantMapMarkerVariant: Hashable {
     case rosette
     case palm
     case fern
@@ -3978,6 +3986,70 @@ enum PlantMapMarkerVariant {
     }
 }
 
+/// Symboles de plante rastérisés une fois, puis réutilisés. (#533)
+///
+/// Chaque symbole est un dessin vectoriel coûteux : `RosettePlantSymbol` empile
+/// dix `LeafPetal`, chacun avec son dégradé et sa rotation. Les autres variantes
+/// sont du même ordre.
+///
+/// Ils étaient reconstruits à chaque événement tactile. Le glissement met à jour
+/// `offset`, dont dépend la position de chaque marqueur, donc SwiftUI
+/// réévaluait les seize marqueurs et leurs ~160 pétales soixante fois par
+/// seconde. À seize plantes, le plan devenait saccadé.
+///
+/// Or ces symboles ne dépendent de RIEN qui change pendant un geste : ni de
+/// `offset`, ni de `scale`, ni de la sélection — seulement d'une variante et
+/// d'une taille parmi deux. Les rastériser une fois est donc sans contrepartie :
+/// le rendu est identique au pixel près, il n'est simplement plus refait.
+@MainActor
+enum PlantSymbolCache {
+    private static var images: [Cle: Image] = [:]
+
+    private struct Cle: Hashable {
+        let variante: PlantMapMarkerVariant
+        let cote: CGFloat
+    }
+
+    /// Rend le symbole, en le dessinant au premier appel seulement.
+    ///
+    /// L'échelle de l'écran est fixée à celle de l'appareil : une image
+    /// rastérisée à l'échelle 1 puis agrandie serait floue sur un écran Retina.
+    static func image(pour variante: PlantMapMarkerVariant, cote: CGFloat) -> Image {
+        let cle = Cle(variante: variante, cote: cote)
+        if let deja = images[cle] { return deja }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = false
+
+        let vue = symbole(variante)
+            .frame(width: cote, height: cote)
+        let rendu = ImageRenderer(content: vue)
+        rendu.scale = UIScreen.main.scale
+
+        // Repli sur le dessin vectoriel si le rendu échoue : mieux vaut un
+        // marqueur coûteux qu'un marqueur absent.
+        guard let uiImage = rendu.uiImage else {
+            return Image(systemName: "leaf.fill")
+        }
+
+        let image = Image(uiImage: uiImage)
+        images[cle] = image
+        return image
+    }
+
+    @ViewBuilder
+    private static func symbole(_ variante: PlantMapMarkerVariant) -> some View {
+        switch variante {
+        case .rosette:   RosettePlantSymbol()
+        case .palm:      PalmPlantSymbol()
+        case .fern:      FernPlantSymbol()
+        case .succulent: SucculentPlantSymbol()
+        case .cactus:    CactusPlantSymbol()
+        }
+    }
+}
+
 struct PlantMapMarker: View {
     let variant: PlantMapMarkerVariant
     let statusColor: Color
@@ -3988,10 +4060,24 @@ struct PlantMapMarker: View {
 
     var body: some View {
         ZStack {
+            // Halo. Un `.blur(radius: 2.2)` donnait le même résultat au prix
+            // d'une passe de rendu hors écran, refaite à chaque image pendant
+            // un glissement. Un dégradé qui s'estompe vers la transparence
+            // produit le même adoucissement sans passe supplémentaire (#533).
             Circle()
-                .fill(statusColor.opacity(isSelected ? 0.26 : 0.16))
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            statusColor.opacity(isSelected ? 0.26 : 0.16),
+                            statusColor.opacity(isSelected ? 0.26 : 0.16),
+                            statusColor.opacity(0)
+                        ],
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: (size + 14) / 2
+                    )
+                )
                 .frame(width: size + 14, height: size + 14)
-                .blur(radius: 2.2)
 
             Circle()
                 .fill(
@@ -4020,24 +4106,25 @@ struct PlantMapMarker: View {
                 .stroke(statusColor.opacity(0.65), lineWidth: isSelected ? 2 : 1.3)
                 .frame(width: size + 3, height: size + 3)
         }
+        // Aplatit l'empilement — dégradés, traces et ombres — en une seule
+        // couche rendue par Metal. Sans lui, SwiftUI rastérise chaque effet
+        // séparément, seize fois par image (#533).
+        //
+        // Posé sur le marqueur et non sur la carte entière : à ce niveau il ne
+        // capture que du contenu statique, alors qu'un `drawingGroup` englobant
+        // les étiquettes forcerait à réaplatir du texte à chaque changement de
+        // sélection.
+        .drawingGroup()
         .scaleEffect(isSelected ? 1.05 : 1)
         .animation(.spring(response: 0.28, dampingFraction: 0.78), value: isSelected)
     }
 
-    @ViewBuilder
+    /// Le symbole vient du cache : il est dessiné une fois par couple
+    /// (variante, taille), puis réutilisé tel quel (#533).
     private var plantShape: some View {
-        switch variant {
-        case .rosette:
-            RosettePlantSymbol()
-        case .palm:
-            PalmPlantSymbol()
-        case .fern:
-            FernPlantSymbol()
-        case .succulent:
-            SucculentPlantSymbol()
-        case .cactus:
-            CactusPlantSymbol()
-        }
+        PlantSymbolCache.image(pour: variant, cote: plantSize)
+            .resizable()
+            .interpolation(.high)
     }
 }
 

--- a/ArboreUi/ArboreUiTests/GardenMapPerformanceTests.swift
+++ b/ArboreUi/ArboreUiTests/GardenMapPerformanceTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import SwiftUI
+@testable import ArboreUi
+
+// GardenMapPerformanceTests.swift — issue #533.
+//
+// Le plan 2D du jardin ramait dès seize plantes. La cause n'était pas un
+// algorithme lent mais un empilement : chaque marqueur portait ~16 calques,
+// dont trois passes de rendu hors écran (un flou, deux ombres), et le symbole de
+// plante à lui seul dessinait dix pétales dégradés.
+//
+// Le tout était réévalué à CHAQUE événement tactile, parce que la position de
+// chaque marqueur dérive d'un `@State offset` que le glissement met à jour en
+// continu. Soit ~250 calques recomposés soixante fois par seconde.
+//
+// Ces tests ne mesurent pas des images par seconde : une telle assertion
+// passerait ou échouerait selon la machine et selon l'humeur du simulateur. Ils
+// vérifient ce qui CAUSE le coût — que le travail statique n'est fait qu'une
+// fois, et que la correspondance variante/plante reste stable pour que le cache
+// serve à quelque chose.
+
+@MainActor
+final class GardenMapPerformanceTests: XCTestCase {
+
+    // MARK: - Le cache de symboles
+
+    /// L'invariant du correctif : un symbole n'est dessiné qu'une fois par
+    /// couple (variante, taille).
+    ///
+    /// Deux demandes identiques doivent rendre la MÊME instance. Si elles
+    /// diffèrent, le cache ne sert à rien et les dix pétales sont redessinés à
+    /// chaque image.
+    func testUnSymboleNEstRasteriseQuUneFois() throws {
+        let a = PlantSymbolCache.image(pour: .rosette, cote: 27)
+        let b = PlantSymbolCache.image(pour: .rosette, cote: 27)
+
+        XCTAssertEqual(a, b, "Deux demandes identiques doivent servir la même image")
+    }
+
+    /// Les deux tailles du marqueur — sélectionné ou non — sont des entrées
+    /// distinctes. Servir l'une pour l'autre donnerait un symbole flou.
+    func testLesDeuxTaillesSontDesEntreesDistinctes() {
+        let petit = PlantSymbolCache.image(pour: .rosette, cote: 27)
+        let grand = PlantSymbolCache.image(pour: .rosette, cote: 34)
+
+        XCTAssertNotEqual(petit, grand,
+                          "La taille fait partie de la clé : un symbole agrandi serait flou")
+    }
+
+    /// Les cinq variantes doivent toutes se rastériser. Une seule qui échouerait
+    /// retomberait sur le repli et perdrait son dessin.
+    func testLesCinqVariantesSeRasterisent() {
+        for variante in [PlantMapMarkerVariant.rosette, .palm, .fern, .succulent, .cactus] {
+            let image = PlantSymbolCache.image(pour: variante, cote: 27)
+            XCTAssertEqual(image, PlantSymbolCache.image(pour: variante, cote: 27),
+                           "La variante \(variante) doit être mise en cache")
+        }
+    }
+
+    // MARK: - La stabilité de la variante
+
+    /// Un cache ne vaut que si la clé est stable. Si la même plante changeait de
+    /// variante entre deux images, on rastériserait sans fin.
+    func testLaVarianteEstStablePourUneMemePlante() {
+        let a = PlantMapMarkerVariant(index: 3, plantName: "Monstera deliciosa")
+        let b = PlantMapMarkerVariant(index: 3, plantName: "Monstera deliciosa")
+
+        XCTAssertEqual(a, b, "La variante doit être une fonction pure de ses entrées")
+    }
+
+    /// Le nom prime sur l'index : un cactus reste un cactus quelle que soit sa
+    /// place dans la liste. C'est la règle métier existante, et la rastérisation
+    /// ne doit pas l'avoir altérée.
+    func testLeNomPrimeSurLIndexPourLesCactus() {
+        for index in 0..<5 {
+            XCTAssertEqual(PlantMapMarkerVariant(index: index, plantName: "Cactus de Noël"),
+                           .cactus,
+                           "Un cactus doit garder son symbole quel que soit son rang")
+        }
+    }
+
+    /// L'accent ne doit pas faire échouer la reconnaissance : la comparaison est
+    /// faite sans diacritiques.
+    func testLaReconnaissanceIgnoreLesAccents() {
+        XCTAssertEqual(PlantMapMarkerVariant(index: 0, plantName: "Plante succulente"), .cactus)
+        XCTAssertEqual(PlantMapMarkerVariant(index: 0, plantName: "Plante Succulènte"), .cactus)
+    }
+
+    /// Sans mot-clé, la variante tourne sur l'index — mais sur QUATRE symboles,
+    /// pas cinq.
+    ///
+    /// `case 4` retombe dans `default` et rend `.rosette` : `.cactus` n'est
+    /// atteignable que par le nom. Ce test a d'abord affirmé cinq, et le code
+    /// lui a donné tort. Il décrit désormais le contrat réel plutôt que celui
+    /// qu'on imaginait.
+    ///
+    /// Est-ce voulu ? Réserver le cactus aux vrais cactus se défend. Mais
+    /// `case 3` donne `.succulent` à une plante quelconque, ce qui affaiblit
+    /// l'argument. Comportement antérieur au correctif de performance, laissé
+    /// tel quel : le changer relèverait du design du plan, pas de sa vitesse.
+    func testSansMotCleLaVarianteTourneSurQuatreSymboles() {
+        let variantes = (0..<5).map { PlantMapMarkerVariant(index: $0, plantName: "Plante \($0)") }
+
+        XCTAssertEqual(Set(variantes).count, 4,
+                       "Quatre symboles par index ; .cactus est réservé au nom")
+        XCTAssertFalse(variantes.contains(.cactus),
+                       "Aucun index ne doit produire .cactus")
+        XCTAssertEqual(PlantMapMarkerVariant(index: 4, plantName: "Plante 4"), .rosette,
+                       "L'index 4 retombe sur .rosette par le `default`")
+    }
+
+    // MARK: - Le nombre de clés reste borné
+
+    /// Le cache ne doit pas croître avec le nombre de plantes.
+    ///
+    /// C'est ce qui rend la correction sûre : cinq variantes × deux tailles font
+    /// dix entrées au maximum, que le jardin en compte seize ou deux cents. Une
+    /// clé qui dépendrait du nom ou de la position ferait du cache une fuite.
+    func testLeCacheEstBornéParLesVariantesEtNonParLesPlantes() {
+        let tailles: [CGFloat] = [27, 34]
+        var cles = Set<String>()
+        for index in 0..<200 {
+            let variante = PlantMapMarkerVariant(index: index, plantName: "Plante \(index)")
+            for cote in tailles {
+                _ = PlantSymbolCache.image(pour: variante, cote: cote)
+                cles.insert("\(variante)-\(cote)")
+            }
+        }
+
+        XCTAssertLessThanOrEqual(cles.count, 10,
+                                 "Au plus 5 variantes × 2 tailles, quelle que soit la taille du jardin")
+    }
+}

--- a/docs/en/architecture/03-components-ios.md
+++ b/docs/en/architecture/03-components-ios.md
@@ -146,6 +146,14 @@ flowchart TB
 - **`NetworkManager` is the single entry point** for HTTP calls. Every outgoing request goes through this singleton to guarantee credential injection and network retry.
 - **`saveAuthDB.swift` is the only caller** to implement a business-level retry with exponential backoff and a Firebase Auth rollback. This logic is dedicated to signup (issue #137).
 - **`DatabaseFireBaseStore/` is being deprecated** in favor of the Go backend for all business operations outside of authentication.
+- **The 2D plan's markers are rasterised, and must stay that way.** The plan
+  redraws everything on every touch event: each marker's position derives from a
+  `@State offset` that dragging updates continuously. Every effect added to
+  `PlantMapMarker` is therefore paid sixteen times per frame in a sixteen-plant
+  garden. Symbols come from a cache bounded to ten entries (`PlantSymbolCache`),
+  the halo is a gradient rather than a blur, and the marker is flattened by
+  `drawingGroup()`. Adding a shadow or a blur here costs one offscreen render
+  pass per marker per frame (#533).
 - **`GardenLocalStore` is local-only**: no data is shared between devices, which motivates issue #114 (cross-install recovery). Since #394 the files stay on the device but are **partitioned per account**: `LocalDataOwnership` records the owner and filters on read. Nothing is deleted on logout — AR scenes exist only here, so a purge would destroy the only copy.
 
 ## Apple frameworks used

--- a/docs/en/testing/p1-physical-devices.md
+++ b/docs/en/testing/p1-physical-devices.md
@@ -52,8 +52,14 @@ must be clearly offered for manual correction.
 2. Test a narrow balcony, a terrace, and a non-rectangular garden outline.
 3. Redo the dimensions from the 2D plan.
 
+4. Place **at least sixteen plants**, then pan and zoom the plan.
+
 Pass: points are easy to place and undo, the contour never self-intersects,
 closure is understandable, and edits reach the 2D plan.
+
+The sixteen threshold is not arbitrary: the plan redraws everything on every
+touch event, and that is roughly where the cost became noticeable before #533.
+Below it, the defect does not show.
 
 ### 4. Catalogue and network
 

--- a/docs/fr/architecture/03-components-ios.md
+++ b/docs/fr/architecture/03-components-ios.md
@@ -146,6 +146,14 @@ flowchart TB
 - **`NetworkManager` est le point d'entrée unique** des appels HTTP. Toute requête sortante passe par ce singleton afin de garantir l'injection des credentials et le retry réseau.
 - **`saveAuthDB.swift` est le seul appelant** à implémenter un retry métier avec backoff exponentiel et un rollback Firebase Auth. Cette logique est dédiée à la signup (issue #137).
 - **`DatabaseFireBaseStore/` est en cours de dépréciation** au profit du backend Go pour toutes les opérations métier hors authentification.
+- **Les marqueurs du plan 2D sont rastérisés, et doivent le rester.** Le plan
+  redessine tout à chaque événement tactile : la position de chaque marqueur
+  dérive d'un `@State offset` que le glissement met à jour en continu. Chaque
+  effet posé sur `PlantMapMarker` est donc payé seize fois par image sur un
+  jardin de seize plantes. Les symboles viennent d'un cache borné à dix entrées
+  (`PlantSymbolCache`), le halo est un dégradé et non un flou, et le marqueur est
+  aplati par `drawingGroup()`. Ajouter une ombre ou un flou ici coûte une passe
+  de rendu hors écran par marqueur et par image (#533).
 - **`GardenLocalStore` est local-only** : aucune donnée n'est partagée entre appareils, ce qui motive l'issue #114 (récupération cross-install). Depuis #394, les fichiers restent sur l'appareil mais sont **cloisonnés par compte** : `LocalDataOwnership` enregistre le propriétaire et filtre à la lecture. Rien n'est supprimé à la déconnexion — les scènes AR n'existent qu'ici, une purge détruirait le seul exemplaire.
 
 ## Frameworks Apple utilisés

--- a/docs/fr/testing/p1-appareils-physiques.md
+++ b/docs/fr/testing/p1-appareils-physiques.md
@@ -56,8 +56,14 @@ erreur supérieure à 10 % doit être considérée bloquante ou clairement propo
 2. Tester un balcon étroit, une terrasse et un contour de jardin non rectangulaire.
 3. Refaire les dimensions depuis le plan 2D.
 
+4. Placer **au moins seize plantes**, puis faire glisser et zoomer le plan.
+
 Critère : points faciles à poser et annuler, contour jamais auto-croisé, fermeture
 compréhensible et modification reflétée dans le plan 2D.
+
+Le seuil de seize n'est pas arbitraire : le plan redessine tout à chaque
+événement tactile, et c'est à peu près là que le coût devenait perceptible avant
+#533. En dessous, le défaut ne se voit pas.
 
 ### 4. Catalogue et réseau
 

--- a/fastlane/changelogs/de-DE.txt
+++ b/fastlane/changelogs/de-DE.txt
@@ -1,11 +1,7 @@
-Der Katalog hängt nicht mehr, wenn du schnell scrollst. Die Bilder werden vor der Anzeige aufbereitet.
+Der Katalog hängt nicht mehr, wenn du schnell scrollst, auch nicht beim Durchwischen aller 123 Pflanzen.
 
-Die Pflanzenseiten sind auf Spanisch und Deutsch vollständig. Bisher fielen drei Viertel des Katalogs auf Englisch zurück.
+Der 2D-Plan des Gartens bleibt auch mit vielen Pflanzen flüssig. Ab etwa fünfzehn wurde er vorher langsam.
 
-Der Filter nach Schwierigkeit funktioniert. Vorher lieferte er keine Ergebnisse.
+Die Fotos der Pflanzenseiten sind jetzt unsere eigenen 3D-Renderings. Du siehst also genau die Pflanze, die du in Augmented Reality platzieren wirst.
 
-Außenpflanzen (Ahorn, Olive, Lavendel) erscheinen in Augmented Reality in hoher Auflösung.
-
-Ein Eintrag, der keine Pflanze war, wurde aus dem Katalog entfernt.
-
-Zuerst testen: Scrolle den Katalog ganz nach unten und wechsle dann die App-Sprache in den iOS-Einstellungen.
+Zuerst testen: Wische zügig durch den Katalog und öffne dann einen Garten mit mindestens sechzehn Pflanzen und ziehe den Plan.

--- a/fastlane/changelogs/en-US.txt
+++ b/fastlane/changelogs/en-US.txt
@@ -1,11 +1,7 @@
-The catalog no longer freezes when you scroll quickly. Images are prepared before they are shown.
+The catalogue no longer freezes when you scroll quickly, even flicking straight down through all 123 plants.
 
-Plant pages are complete in Spanish and German. Until now, three quarters of the catalog fell back to English.
+The garden's 2D plan stays smooth with many plants. It used to slow down past fifteen or so.
 
-The difficulty filter works. It returned no results before.
+Plant photos are now our own 3D renders, so you see exactly the plant you will place in augmented reality.
 
-Outdoor plants (maple, olive, lavender) show in high definition in augmented reality.
-
-One entry that was not a plant has been removed from the catalog.
-
-Worth testing first: scroll the catalog all the way down, then change the app language in iOS settings.
+Worth testing first: flick through the catalogue fast, then open a garden with at least sixteen plants and drag the plan around.

--- a/fastlane/changelogs/es-ES.txt
+++ b/fastlane/changelogs/es-ES.txt
@@ -1,11 +1,7 @@
-El catálogo ya no se congela al desplazarte rápido. Las imágenes se preparan antes de mostrarse.
+El catálogo ya no se congela al desplazarte rápido, ni siquiera bajando de un tirón por las 123 plantas.
 
-Las fichas están completas en español y en alemán. Hasta ahora, tres cuartas partes del catálogo pasaban al inglés.
+El plano 2D del jardín se mantiene fluido con muchas plantas. Antes se ralentizaba a partir de unas quince.
 
-El filtro por dificultad funciona. Antes no devolvía ningún resultado.
+Las fotos de las fichas son ahora nuestros propios renders 3D, así que ves exactamente la planta que colocarás en realidad aumentada.
 
-Las plantas de exterior (arce, olivo, lavanda) se muestran en alta definición en realidad aumentada.
-
-Se ha retirado del catálogo una ficha que no era una planta.
-
-Para probar primero: desplaza el catálogo hasta el final y luego cambia el idioma de la app en los ajustes de iOS.
+Para probar primero: recorre el catálogo con un desplazamiento rápido y luego abre un jardín con al menos dieciséis plantas y arrastra el plano.

--- a/fastlane/changelogs/fr-FR.txt
+++ b/fastlane/changelogs/fr-FR.txt
@@ -1,11 +1,7 @@
-Le catalogue ne se fige plus quand on le fait défiler vite. Les images sont préparées avant d'être affichées.
+Le catalogue ne se fige plus quand on le fait défiler vite, même en descendant d'un trait jusqu'au bas des 123 plantes.
 
-Les fiches sont complètes en espagnol et en allemand. Jusqu'ici, les trois quarts du catalogue basculaient en anglais.
+Le plan 2D du jardin reste fluide avec beaucoup de plantes. Il ralentissait à partir d'une quinzaine.
 
-Le filtre par difficulté fonctionne. Il ne renvoyait aucun résultat avant.
+Les photos des fiches sont maintenant nos propres rendus 3D. Vous voyez donc exactement la plante que vous placerez en réalité augmentée.
 
-Les plantes d'extérieur (érable, olivier, lavande) s'affichent en haute définition en réalité augmentée.
-
-Une fiche qui n'était pas une plante a été retirée du catalogue.
-
-À tester en premier : faites défiler le catalogue jusqu'en bas, puis changez la langue de l'app dans les réglages iOS.
+À tester en premier : parcourez le catalogue d'un balayage franc, puis ouvrez un jardin d'au moins seize plantes et faites glisser le plan.


### PR DESCRIPTION
Le plan 2D du jardin ramait dès **seize plantes**. La cause n'était pas un algorithme lent mais un empilement, refait à chaque événement tactile.

Corrige le diagnostic posé dans #533.

## Le compte

`PlantMapMarker` porte, par plante :

| élément | coût |
|---|---|
| cercle de halo `.blur(radius: 2.2)` | **passe hors écran** |
| cercle `RadialGradient` + `.shadow(radius: 8)` | **passe hors écran** |
| symbole + `.shadow(radius: 3)` | **passe hors écran** |
| deux cercles tracés | — |

Et le symbole n'est pas une icône : `RosettePlantSymbol` dessine **dix `LeafPetal`**, chacun avec son dégradé et sa rotation.

Environ seize calques par plante, soit **~250 à seize plantes**.

Le glissement met à jour un `@State offset` dont dérive la position de chaque marqueur, donc un seul pixel de déplacement réévaluait le tout, soixante fois par seconde. Le contour du jardin était en prime reconstruit **trois fois par image**, chaque construction rebouclant sur tous ses points.

## Quatre corrections, aucune contrepartie visuelle

**1. Les symboles sont rastérisés une fois.** Ils ne dépendent de rien qui change pendant un geste : ni `offset`, ni `scale`, ni la sélection — seulement d'une variante et d'une taille parmi deux. ~160 vues disparaissent par image.

Le cache est **borné à dix entrées** quelle que soit la taille du jardin, et c'est ce qui rend la correction sûre : une clé qui aurait dépendu du nom ou de la position en aurait fait une fuite. Un test le verrouille sur 200 plantes.

**2. Le flou devient un dégradé.** `.blur()` était la passe la plus chère ; un `RadialGradient` qui s'estompe vers la transparence donne le même halo sans passe supplémentaire.

**3. Le marqueur est aplati** par `drawingGroup()`, en une seule couche Metal. Posé sur le marqueur et non sur la carte entière : à ce niveau il ne capture que du contenu statique, alors qu'un groupe englobant les étiquettes forcerait à réaplatir du texte à chaque changement de sélection.

**4. Le contour est construit une fois** et réutilisé pour ses trois passes.

## Ce que cette PR ne fait pas

Le geste continue de mettre à jour la position de chaque marqueur plutôt que de transformer le conteneur. Un `.offset()` sur le `ZStack` ferait glisser une couche déjà rastérisée, mais grossirait aussi les traits et les étiquettes, que le code garde délibérément à taille constante au zoom.

C'est une **décision de rendu, pas un réglage** — laissée ouverte dans #533.

## Un test qui m'a corrigé

J'ai d'abord affirmé que les cinq symboles étaient atteignables par l'index. Le code a dit non : `case 4` retombe dans `default` et rend `.rosette`, donc `.cactus` n'est joignable que par le nom.

Le test décrit désormais le contrat réel, et consigne la question ouverte : réserver le cactus aux vrais cactus se défend, mais `case 3` donne `.succulent` à une plante quelconque, ce qui affaiblit l'argument. Comportement antérieur au correctif, laissé tel quel — le changer relèverait du design du plan, pas de sa vitesse.

## Vérifications

**312 tests, 0 échec.** 8 nouveaux.

Aucune assertion d'images par seconde : elle passerait ou échouerait selon la machine et l'humeur du simulateur. Les tests vérifient ce qui **cause** le coût — que le travail statique n'est fait qu'une fois, que la clé de cache est stable, et qu'elle reste bornée par les variantes et non par le nombre de plantes.

Le gain réel se mesurera sur appareil, avec un jardin de seize plantes. Un profil Instruments dirait si ces quatre points suffisent ou si le quatrième de #533 devient nécessaire.